### PR TITLE
protocol: omit continue field from Stop hook responses

### DIFF
--- a/ralph_test.go
+++ b/ralph_test.go
@@ -170,14 +170,19 @@ func TestBuildHookResponse(t *testing.T) {
 
 	t.Run("with Stop hook fields", func(t *testing.T) {
 		result := HookResult{
-			Continue:      false,
 			Decision:      "block",
 			Reason:        "New prompt here",
 			SystemMessage: "Status message",
 		}
 		resp := buildHookResponse(result)
 
-		assert.Equal(t, false, resp["continue"])
+		// When Decision is set, continue must be omitted to
+		// match shell hook behavior. Shell hooks only output
+		// {"decision":"block","reason":"..."} without continue.
+		_, hasContinue := resp["continue"]
+		assert.False(t, hasContinue,
+			"stop hook must not include continue field",
+		)
 		assert.Equal(t, "block", resp["decision"])
 		assert.Equal(t, "New prompt here", resp["reason"])
 		assert.Equal(t, "Status message", resp["systemMessage"])


### PR DESCRIPTION
## Summary

- Fix `buildHookResponse` to omit the `continue` field when `Decision` is set (Stop/SubagentStop hooks), matching the wire format that shell-based hooks produce
- The CLI treats `continue` and `decision` as independent control paths; including `"continue":false` alongside `"decision":"block"` caused the CLI to short-circuit and terminate the session before honoring the block decision
- Existing tests in `ralph_test.go` updated to assert absence of `continue` rather than checking for `false`

## Root Cause

Shell hooks output `{"decision":"block","reason":"..."}` without a `continue` field. The SDK was emitting `{"continue":false,"decision":"block","reason":"..."}`, which hit the CLI's `continue=false` early-exit path before reaching the decision-handling logic.

## Test Plan

- [x] New `TestBuildHookResponse_StopHookOmitsContinue` covers block, approve, non-stop, and block+modify cases
- [x] Updated existing `TestBuildHookResponse/with_Stop_hook_fields` to verify `continue` is absent
- [x] All unit tests pass (`go test ./...`)
