### PR TITLE
protocol: fix hook Modify serialization for PreToolUse/PermissionRequest

### DIFF
--- a/options.go
+++ b/options.go
@@ -785,6 +785,10 @@ const (
 // For most hooks, set Continue=true to allow execution to proceed.
 // For Stop hooks, use Decision/Reason/SystemMessage to control whether
 // the session exits or continues with a new prompt (Ralph Wiggum pattern).
+//
+// For PreToolUse hooks, Modify is automatically translated into the
+// hookSpecificOutput.updatedInput format expected by the CLI. Set
+// HookSpecificOutput directly for finer control over the response.
 type HookResult struct {
 	Continue bool                   // Continue execution (false = abort)
 	Modify   map[string]interface{} // Modifications to apply
@@ -801,6 +805,12 @@ type HookResult struct {
 	// SystemMessage is displayed to Claude as context when blocking exit.
 	// Use this to provide iteration counts or other status information.
 	SystemMessage string
+
+	// HookSpecificOutput provides raw hookSpecificOutput for the CLI
+	// response. When set, this takes precedence over auto-translation
+	// of Modify. Use this for finer control over permissionDecision,
+	// additionalContext, or other hook-specific fields.
+	HookSpecificOutput map[string]interface{}
 }
 
 // AgentDefinition defines a specialized subagent.

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -829,7 +829,7 @@ func TestBuildHookResponse_StopHookOmitsContinue(t *testing.T) {
 			SystemMessage: "You have 1 unread message",
 		}
 
-		resp := buildHookResponse(result)
+		resp := buildHookResponse("Stop", result)
 
 		// Must have decision, reason, systemMessage.
 		assert.Equal(t, "block", resp["decision"])
@@ -856,7 +856,7 @@ func TestBuildHookResponse_StopHookOmitsContinue(t *testing.T) {
 			Decision: "approve",
 		}
 
-		resp := buildHookResponse(result)
+		resp := buildHookResponse("Stop", result)
 
 		assert.Equal(t, "approve", resp["decision"])
 
@@ -873,7 +873,7 @@ func TestBuildHookResponse_StopHookOmitsContinue(t *testing.T) {
 			Continue: true,
 		}
 
-		resp := buildHookResponse(result)
+		resp := buildHookResponse("PreToolUse", result)
 
 		assert.Equal(t, true, resp["continue"])
 
@@ -884,7 +884,9 @@ func TestBuildHookResponse_StopHookOmitsContinue(t *testing.T) {
 		)
 	})
 
-	t.Run("block with modify", func(t *testing.T) {
+	t.Run("block with modify uses legacy format", func(t *testing.T) {
+		// Stop hooks with Modify should use the legacy modify
+		// field since Stop is not PreToolUse or PermissionRequest.
 		result := HookResult{
 			Decision: "block",
 			Reason:   "New task",
@@ -893,12 +895,12 @@ func TestBuildHookResponse_StopHookOmitsContinue(t *testing.T) {
 			},
 		}
 
-		resp := buildHookResponse(result)
+		resp := buildHookResponse("Stop", result)
 
 		assert.Equal(t, "block", resp["decision"])
 		assert.Equal(t, "New task", resp["reason"])
 
-		// Modify should still be included.
+		// Modify should still be included as legacy format.
 		modify, ok := resp["modify"]
 		assert.True(t, ok)
 		assert.Equal(t,

--- a/ralph_test.go
+++ b/ralph_test.go
@@ -148,7 +148,7 @@ func TestHookResultStopFields(t *testing.T) {
 func TestBuildHookResponse(t *testing.T) {
 	t.Run("basic continue", func(t *testing.T) {
 		result := HookResult{Continue: true}
-		resp := buildHookResponse(result)
+		resp := buildHookResponse("PostToolUse", result)
 
 		assert.Equal(t, true, resp["continue"])
 		_, hasDecision := resp["decision"]
@@ -160,7 +160,7 @@ func TestBuildHookResponse(t *testing.T) {
 			Continue: true,
 			Modify:   map[string]interface{}{"key": "value"},
 		}
-		resp := buildHookResponse(result)
+		resp := buildHookResponse("PostToolUse", result)
 
 		assert.Equal(t, true, resp["continue"])
 		modify, ok := resp["modify"].(map[string]interface{})
@@ -174,7 +174,7 @@ func TestBuildHookResponse(t *testing.T) {
 			Reason:        "New prompt here",
 			SystemMessage: "Status message",
 		}
-		resp := buildHookResponse(result)
+		resp := buildHookResponse("Stop", result)
 
 		// When Decision is set, continue must be omitted to
 		// match shell hook behavior. Shell hooks only output
@@ -193,7 +193,7 @@ func TestBuildHookResponse(t *testing.T) {
 			Continue: true,
 			Decision: "", // Empty - should not be included.
 		}
-		resp := buildHookResponse(result)
+		resp := buildHookResponse("PostToolUse", result)
 
 		_, hasDecision := resp["decision"]
 		assert.False(t, hasDecision)


### PR DESCRIPTION
When a Go SDK hook callback returns `HookResult.Modify` for a PreToolUse hook,
the SDK was serializing it as a top-level `modify` field in the JSON response.
The CLI silently ignores that field entirely — the only way to actually rewrite
tool inputs is via `hookSpecificOutput.updatedInput`, which is the format that
shell-based hooks produce natively.

This PR threads the `hookType` parameter through `buildHookResponse` so it knows
which hook event is being responded to. For PreToolUse hooks, `Modify` is now
auto-translated into the `hookSpecificOutput` envelope with
`permissionDecision=allow` and an `updatedInput` map containing the caller's
modifications. PermissionRequest hooks get an analogous translation using the
nested `decision.updatedInput` structure that the CLI expects for that event
type. All other hook types continue to use the legacy `modify` field as before.

For callbacks that need finer control over the wire format (e.g., returning
`permissionDecision=deny` with a custom reason), a new `HookSpecificOutput`
field on `HookResult` lets them bypass auto-translation entirely and provide the
raw `hookSpecificOutput` envelope directly.

Test coverage includes unit tests for every `buildHookResponse` translation
branch, plus integration tests that exercise the full
`handleHookCallback`/`handleSDKHookCallback` → `buildHookResponse` → wire path
for both the legacy and SDK control request formats. Edge cases like missing
`hook_event` fields and explicit `HookSpecificOutput` passthrough are covered as
well.