### PR TITLE
transport: wire Betas and ExcludeDynamicSystemPromptSections to CLI

### DIFF
--- a/options.go
+++ b/options.go
@@ -76,8 +76,18 @@ type Options struct {
 	Sandbox *SandboxSettings
 
 	// Betas enables beta features.
-	// Example: []string{"context-1m-2025-08-07"}
+	// Each beta header is passed to the CLI via --betas as a comma-separated
+	// list. Example: []string{"context-1m-2025-08-07"}.
 	Betas []string
+
+	// ExcludeDynamicSystemPromptSections moves per-machine sections (cwd,
+	// env info, memory paths, git status) from the system prompt into the
+	// first user message. This improves cross-invocation prompt-cache reuse
+	// by keeping the system prompt prefix stable across runs.
+	//
+	// The CLI only honors this flag with the default system prompt — it is
+	// ignored when SystemPrompt is set to a custom string.
+	ExcludeDynamicSystemPromptSections bool
 
 	// Plugins loads custom plugins from local paths.
 	Plugins []PluginConfig
@@ -939,9 +949,30 @@ func WithSandbox(sandbox *SandboxSettings) Option {
 }
 
 // WithBetas enables beta features.
+//
+// Each value is an API beta header name. They are joined and passed to the
+// CLI as --betas a,b,c.
+//
+// Example:
+//
+//	WithBetas([]string{"context-1m-2025-08-07"})
 func WithBetas(betas []string) Option {
 	return func(o *Options) {
 		o.Betas = betas
+	}
+}
+
+// WithExcludeDynamicSystemPromptSections moves per-machine sections (cwd,
+// env info, memory paths, git status) out of the system prompt and into the
+// first user message.
+//
+// Enable this when cross-invocation prompt-cache reuse matters more than
+// maximally authoritative environment context in the system prompt. The CLI
+// only honors this flag with the default system prompt; it is ignored if
+// WithSystemPrompt is used to set a custom string.
+func WithExcludeDynamicSystemPromptSections(enable bool) Option {
+	return func(o *Options) {
+		o.ExcludeDynamicSystemPromptSections = enable
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -206,6 +206,21 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		args = append(args, "--include-partial-messages")
 	}
 
+	// Add beta headers. The CLI accepts --betas as a variadic flag; we
+	// pass a single comma-separated value to match the Python SDK and keep
+	// parsing unambiguous when additional flags follow.
+	if len(t.options.Betas) > 0 {
+		args = append(args, "--betas", strings.Join(t.options.Betas, ","))
+	}
+
+	// Move per-machine system prompt sections (cwd, env, memory, git status)
+	// into the first user message. Stabilizes the system prompt prefix for
+	// cross-invocation prompt-cache reuse. The CLI ignores this flag when
+	// --system-prompt is set.
+	if t.options.ExcludeDynamicSystemPromptSections {
+		args = append(args, "--exclude-dynamic-system-prompt-sections")
+	}
+
 	// Build environment - start with current process env, then overlay options.
 	env := os.Environ()
 	for k, v := range t.options.Env {

--- a/transport_test.go
+++ b/transport_test.go
@@ -777,6 +777,98 @@ func TestSubprocessTransportAdditionalDirectories(t *testing.T) {
 	}
 }
 
+// TestSubprocessTransportBetas tests that Betas are passed to the CLI as a
+// single --betas flag with a comma-separated value.
+func TestSubprocessTransportBetas(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	opts := &Options{
+		Betas: []string{"context-1m-2025-08-07", "some-other-beta"},
+	}
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	ctx := context.Background()
+	err := transport.Connect(ctx)
+	require.NoError(t, err)
+	defer transport.Close()
+
+	// Find --betas followed by the comma-joined value.
+	assert.True(t, runner.started)
+	found := false
+	for i, arg := range runner.StartArgs {
+		if arg == "--betas" && i+1 < len(runner.StartArgs) {
+			assert.Equal(t,
+				"context-1m-2025-08-07,some-other-beta",
+				runner.StartArgs[i+1],
+				"betas should be comma-joined",
+			)
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected --betas in args: %v", runner.StartArgs)
+}
+
+// TestSubprocessTransportBetasEmpty verifies no --betas flag is emitted when
+// Betas is empty.
+func TestSubprocessTransportBetasEmpty(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	ctx := context.Background()
+	err := transport.Connect(ctx)
+	require.NoError(t, err)
+	defer transport.Close()
+
+	for _, arg := range runner.StartArgs {
+		assert.NotEqual(t, "--betas", arg,
+			"unexpected --betas in args: %v", runner.StartArgs)
+	}
+}
+
+// TestSubprocessTransportExcludeDynamicSystemPromptSections tests the flag is
+// passed when the option is enabled.
+func TestSubprocessTransportExcludeDynamicSystemPromptSections(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	opts := &Options{
+		ExcludeDynamicSystemPromptSections: true,
+	}
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	ctx := context.Background()
+	err := transport.Connect(ctx)
+	require.NoError(t, err)
+	defer transport.Close()
+
+	assert.True(t, runner.started)
+	assert.Contains(t, runner.StartArgs,
+		"--exclude-dynamic-system-prompt-sections")
+}
+
+// TestSubprocessTransportExcludeDynamicSystemPromptSectionsDefault verifies
+// the flag is absent by default.
+func TestSubprocessTransportExcludeDynamicSystemPromptSectionsDefault(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	ctx := context.Background()
+	err := transport.Connect(ctx)
+	require.NoError(t, err)
+	defer transport.Close()
+
+	for _, arg := range runner.StartArgs {
+		assert.NotEqual(t, "--exclude-dynamic-system-prompt-sections", arg,
+			"unexpected flag in args: %v", runner.StartArgs)
+	}
+}
+
 // TestSubprocessTransportAdditionalDirectoriesEmpty tests that no --add-dir
 // flags are passed when AdditionalDirectories is empty.
 func TestSubprocessTransportAdditionalDirectoriesEmpty(t *testing.T) {


### PR DESCRIPTION
- `Options.Betas` was defined but never passed to the CLI — callers who set beta headers got no effect. Now emitted as `--betas a,b,c`.
- New `Options.ExcludeDynamicSystemPromptSections` field + `WithExcludeDynamicSystemPromptSections` helper. Emits `--exclude-dynamic-system-prompt-sections`, which moves per-machine context (cwd, env info, git status, memory paths) out of the system prompt and into the first user message.