### PR TITLE
transport: wire ForkFrom to --resume <id> --fork-session args

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -184,6 +184,12 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		args = append(args, "--resume", t.options.SessionOptions.Resume)
 	}
 
+	// Fork from a parent session: resume the parent then branch to a new ID.
+	if t.options.SessionOptions.ForkFrom != "" {
+		args = append(args, "--resume", t.options.SessionOptions.ForkFrom,
+			"--fork-session")
+	}
+
 	// Add fork-session flag if set (used with --resume or --continue).
 	if t.options.SessionOptions.ForkSession {
 		args = append(args, "--fork-session")

--- a/transport_test.go
+++ b/transport_test.go
@@ -713,6 +713,30 @@ func TestSubprocessTransportSessionOptions(t *testing.T) {
 	assert.Contains(t, runner.StartArgs, "msg-uuid-456")
 }
 
+// TestSubprocessTransportForkFrom verifies that WithForkSession emits
+// --resume <parentID> --fork-session so the CLI branches a new session.
+func TestSubprocessTransportForkFrom(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	opts := &Options{
+		SessionOptions: SessionOptions{
+			ForkFrom: "parent-session-abc",
+		},
+	}
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	ctx := context.Background()
+	err := transport.Connect(ctx)
+	require.NoError(t, err)
+	defer transport.Close()
+
+	assert.True(t, runner.started)
+	assert.Contains(t, runner.StartArgs, "--resume")
+	assert.Contains(t, runner.StartArgs, "parent-session-abc")
+	assert.Contains(t, runner.StartArgs, "--fork-session")
+}
+
 // TestSubprocessTransportCloseTimeout tests forced kill on close timeout.
 func TestSubprocessTransportCloseTimeout(t *testing.T) {
 	runner := NewMockSubprocessRunner()


### PR DESCRIPTION
Also adds a unit test verifying the correct CLI flags are emitted when SessionOptions.ForkFrom is set.