### PR TITLE
options: thinking config and effort level

### DIFF
--- a/options.go
+++ b/options.go
@@ -1098,6 +1098,8 @@ func WithMaxBudgetUsd(budget float64) Option {
 }
 
 // WithMaxThinkingTokens sets the maximum tokens for thinking process.
+//
+// Deprecated: Use WithThinking instead.
 func WithMaxThinkingTokens(tokens int) Option {
 	return func(o *Options) {
 		o.MaxThinkingTokens = &tokens

--- a/options.go
+++ b/options.go
@@ -106,10 +106,19 @@ type Options struct {
 	// Can be a list of tool names or use preset "claude_code".
 	Tools *ToolsConfig
 
+	// Thinking controls Claude's thinking/reasoning behavior.
+	// When set, takes precedence over MaxThinkingTokens.
+	Thinking *ThinkingConfig
+
+	// Effort controls how much effort Claude puts into its response.
+	Effort EffortLevel
+
 	// MaxBudgetUsd is the maximum budget in USD for the query.
 	MaxBudgetUsd *float64
 
 	// MaxThinkingTokens is the maximum tokens for thinking process.
+	//
+	// Deprecated: Use Thinking instead.
 	MaxThinkingTokens *int
 
 	// MaxTurns is the maximum conversation turns.
@@ -251,6 +260,61 @@ type ToolsConfig struct {
 	// Tools is a list of specific tool names.
 	Tools []string
 }
+
+// ThinkingConfig controls Claude's thinking/reasoning behavior.
+//
+// Type is one of "adaptive", "enabled", or "disabled". BudgetTokens applies only
+// when Type is "enabled"; if nil, the CLI is told to use adaptive thinking. Display
+// applies when Type is "adaptive" or "enabled" and is one of "summarized" or "omitted".
+type ThinkingConfig struct {
+	Type         string          `json:"type"`
+	BudgetTokens *int            `json:"budgetTokens,omitempty"`
+	Display      ThinkingDisplay `json:"display,omitempty"`
+}
+
+// ThinkingDisplay controls how thinking blocks are surfaced to the client.
+type ThinkingDisplay string
+
+const (
+	// ThinkingDisplaySummarized emits a short summary in place of raw thinking.
+	ThinkingDisplaySummarized ThinkingDisplay = "summarized"
+	// ThinkingDisplayOmitted suppresses thinking blocks entirely.
+	ThinkingDisplayOmitted ThinkingDisplay = "omitted"
+)
+
+// ThinkingAdaptive lets Claude decide when and how much to think.
+func ThinkingAdaptive() *ThinkingConfig {
+	return &ThinkingConfig{Type: "adaptive"}
+}
+
+// ThinkingEnabled enables thinking with a fixed token budget.
+func ThinkingEnabled(budget int) *ThinkingConfig {
+	return &ThinkingConfig{
+		Type:         "enabled",
+		BudgetTokens: &budget,
+	}
+}
+
+// ThinkingDisabled disables extended thinking.
+func ThinkingDisabled() *ThinkingConfig {
+	return &ThinkingConfig{Type: "disabled"}
+}
+
+// EffortLevel controls how much thinking/reasoning Claude applies.
+type EffortLevel string
+
+const (
+	// EffortLow applies minimal thinking for fastest responses.
+	EffortLow EffortLevel = "low"
+	// EffortMedium applies moderate thinking.
+	EffortMedium EffortLevel = "medium"
+	// EffortHigh applies deep reasoning.
+	EffortHigh EffortLevel = "high"
+	// EffortXHigh applies deeper reasoning than high.
+	EffortXHigh EffortLevel = "xhigh"
+	// EffortMax applies maximum effort.
+	EffortMax EffortLevel = "max"
+)
 
 // NewOptions creates a new Options with sensible defaults.
 //
@@ -1009,6 +1073,20 @@ func WithDisallowedTools(tools []string) Option {
 func WithTools(config *ToolsConfig) Option {
 	return func(o *Options) {
 		o.Tools = config
+	}
+}
+
+// WithThinking controls Claude's thinking/reasoning behavior.
+func WithThinking(thinking *ThinkingConfig) Option {
+	return func(o *Options) {
+		o.Thinking = thinking
+	}
+}
+
+// WithEffort controls how much effort Claude puts into its response.
+func WithEffort(effort EffortLevel) Option {
+	return func(o *Options) {
+		o.Effort = effort
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -125,6 +125,36 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		args = append(args, "--permission-mode", string(t.options.PermissionMode))
 	}
 
+	if t.options.Thinking != nil {
+		switch t.options.Thinking.Type {
+		case "enabled":
+			if t.options.Thinking.BudgetTokens == nil {
+				args = append(args, "--thinking", "adaptive")
+			} else {
+				args = append(args, "--max-thinking-tokens",
+					fmt.Sprintf("%d", *t.options.Thinking.BudgetTokens))
+			}
+		case "disabled":
+			args = append(args, "--thinking", "disabled")
+		case "adaptive":
+			args = append(args, "--thinking", "adaptive")
+		}
+		if t.options.Thinking.Type != "disabled" && t.options.Thinking.Display != "" {
+			args = append(args, "--thinking-display", string(t.options.Thinking.Display))
+		}
+	} else if t.options.MaxThinkingTokens != nil {
+		if *t.options.MaxThinkingTokens == 0 {
+			args = append(args, "--thinking", "disabled")
+		} else {
+			args = append(args, "--max-thinking-tokens",
+				fmt.Sprintf("%d", *t.options.MaxThinkingTokens))
+		}
+	}
+
+	if t.options.Effort != "" {
+		args = append(args, "--effort", string(t.options.Effort))
+	}
+
 	// Add permission bypass flags if configured.
 	if t.options.AllowDangerouslySkipPermissions {
 		args = append(args, "--dangerously-skip-permissions")

--- a/transport_test.go
+++ b/transport_test.go
@@ -13,6 +13,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func assertArgValue(t *testing.T, args []string, flag, value string) {
+	t.Helper()
+
+	for i, arg := range args {
+		if arg == flag {
+			require.Less(t, i+1, len(args), "flag %s missing value", flag)
+			assert.Equal(t, value, args[i+1])
+			return
+		}
+	}
+
+	require.Failf(t, "flag not found", "expected %s %s in args %v", flag, value, args)
+}
+
+func assertArgAbsent(t *testing.T, args []string, flag string) {
+	t.Helper()
+
+	assert.NotContains(t, args, flag)
+}
+
 // TestSubprocessTransportBasicCommunication tests stdin/stdout communication.
 func TestSubprocessTransportBasicCommunication(t *testing.T) {
 	// Create mock subprocess
@@ -642,6 +662,209 @@ func TestSubprocessTransportConnectArguments(t *testing.T) {
 	assert.True(t, runner.started)
 	assert.Contains(t, runner.StartArgs, "--model")
 	assert.Contains(t, runner.StartArgs, "--verbose")
+}
+
+func TestSubprocessTransportThinkingArguments(t *testing.T) {
+	tests := []struct {
+		name       string
+		thinking   *ThinkingConfig
+		wantFlag   string
+		wantValue  string
+		absentFlag string
+	}{
+		{
+			name:       "adaptive",
+			thinking:   ThinkingAdaptive(),
+			wantFlag:   "--thinking",
+			wantValue:  "adaptive",
+			absentFlag: "--max-thinking-tokens",
+		},
+		{
+			name:       "enabled",
+			thinking:   ThinkingEnabled(4096),
+			wantFlag:   "--max-thinking-tokens",
+			wantValue:  "4096",
+			absentFlag: "--thinking",
+		},
+		{
+			name:       "disabled",
+			thinking:   ThinkingDisabled(),
+			wantFlag:   "--thinking",
+			wantValue:  "disabled",
+			absentFlag: "--max-thinking-tokens",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+			opts := NewOptions()
+			opts.Thinking = tt.thinking
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+
+			err := transport.Connect(context.Background())
+			require.NoError(t, err)
+			defer transport.Close()
+
+			assertArgValue(t, runner.StartArgs, tt.wantFlag, tt.wantValue)
+			assertArgAbsent(t, runner.StartArgs, tt.absentFlag)
+		})
+	}
+}
+
+func TestSubprocessTransportThinkingNilOmitsFlags(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	opts.Thinking = nil
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	err := transport.Connect(context.Background())
+	require.NoError(t, err)
+	defer transport.Close()
+
+	assertArgAbsent(t, runner.StartArgs, "--thinking")
+	assertArgAbsent(t, runner.StartArgs, "--max-thinking-tokens")
+}
+
+func TestSubprocessTransportThinkingDisplay(t *testing.T) {
+	tests := []struct {
+		name    string
+		build   func() *ThinkingConfig
+		present bool
+		value   string
+	}{
+		{
+			name: "adaptive with summarized",
+			build: func() *ThinkingConfig {
+				c := ThinkingAdaptive()
+				c.Display = ThinkingDisplaySummarized
+				return c
+			},
+			present: true,
+			value:   "summarized",
+		},
+		{
+			name: "enabled with omitted",
+			build: func() *ThinkingConfig {
+				c := ThinkingEnabled(1024)
+				c.Display = ThinkingDisplayOmitted
+				return c
+			},
+			present: true,
+			value:   "omitted",
+		},
+		{
+			name: "disabled ignores display",
+			build: func() *ThinkingConfig {
+				c := ThinkingDisabled()
+				c.Display = ThinkingDisplaySummarized
+				return c
+			},
+			present: false,
+		},
+		{
+			name:    "adaptive without display omits flag",
+			build:   ThinkingAdaptive,
+			present: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+			opts := NewOptions()
+			opts.Thinking = tt.build()
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+
+			err := transport.Connect(context.Background())
+			require.NoError(t, err)
+			defer transport.Close()
+
+			if tt.present {
+				assertArgValue(t, runner.StartArgs, "--thinking-display", tt.value)
+			} else {
+				assertArgAbsent(t, runner.StartArgs, "--thinking-display")
+			}
+		})
+	}
+}
+
+func TestSubprocessTransportEffortArguments(t *testing.T) {
+	tests := []struct {
+		name   string
+		effort EffortLevel
+	}{
+		{name: "low", effort: EffortLow},
+		{name: "medium", effort: EffortMedium},
+		{name: "high", effort: EffortHigh},
+		{name: "xhigh", effort: EffortXHigh},
+		{name: "max", effort: EffortMax},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+			opts := NewOptions()
+			opts.Effort = tt.effort
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+
+			err := transport.Connect(context.Background())
+			require.NoError(t, err)
+			defer transport.Close()
+
+			assertArgValue(t, runner.StartArgs, "--effort", string(tt.effort))
+		})
+	}
+}
+
+func TestSubprocessTransportEffortEmptyOmitsFlag(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	opts.Effort = ""
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	err := transport.Connect(context.Background())
+	require.NoError(t, err)
+	defer transport.Close()
+
+	assertArgAbsent(t, runner.StartArgs, "--effort")
+}
+
+func TestSubprocessTransportMaxThinkingTokensStillWorks(t *testing.T) {
+	tokens := 2048
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	opts.MaxThinkingTokens = &tokens
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	err := transport.Connect(context.Background())
+	require.NoError(t, err)
+	defer transport.Close()
+
+	assertArgValue(t, runner.StartArgs, "--max-thinking-tokens", "2048")
+	assertArgAbsent(t, runner.StartArgs, "--thinking")
+}
+
+func TestSubprocessTransportMaxThinkingTokensZeroDisablesThinking(t *testing.T) {
+	tokens := 0
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	opts.MaxThinkingTokens = &tokens
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	err := transport.Connect(context.Background())
+	require.NoError(t, err)
+	defer transport.Close()
+
+	assertArgValue(t, runner.StartArgs, "--thinking", "disabled")
+	assertArgAbsent(t, runner.StartArgs, "--max-thinking-tokens")
 }
 
 // TestSubprocessTransportWorkingDirectory tests that Cwd option is passed to runner.

--- a/transport_test.go
+++ b/transport_test.go
@@ -687,6 +687,13 @@ func TestSubprocessTransportThinkingArguments(t *testing.T) {
 			absentFlag: "--thinking",
 		},
 		{
+			name:       "enabled without budget uses adaptive",
+			thinking:   &ThinkingConfig{Type: "enabled"},
+			wantFlag:   "--thinking",
+			wantValue:  "adaptive",
+			absentFlag: "--max-thinking-tokens",
+		},
+		{
 			name:       "disabled",
 			thinking:   ThinkingDisabled(),
 			wantFlag:   "--thinking",
@@ -855,6 +862,23 @@ func TestSubprocessTransportMaxThinkingTokensZeroDisablesThinking(t *testing.T) 
 	tokens := 0
 	runner := NewMockSubprocessRunner()
 	opts := NewOptions()
+	opts.MaxThinkingTokens = &tokens
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	err := transport.Connect(context.Background())
+	require.NoError(t, err)
+	defer transport.Close()
+
+	assertArgValue(t, runner.StartArgs, "--thinking", "disabled")
+	assertArgAbsent(t, runner.StartArgs, "--max-thinking-tokens")
+}
+
+func TestSubprocessTransportThinkingPrecedesMaxThinkingTokens(t *testing.T) {
+	tokens := 2048
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	opts.Thinking = ThinkingDisabled()
 	opts.MaxThinkingTokens = &tokens
 
 	transport := NewSubprocessTransportWithRunner(runner, opts)


### PR DESCRIPTION
Catches the Go SDK up to TS SDK v0.2.119 on the thinking/reasoning options. See `memory/catchup-v0.2.119/PLAN.md` §"PR 1".

## What changed

- `ThinkingConfig` type with `Adaptive` / `Enabled(budget)` / `Disabled` constructors, plus an optional `Display` hint (`summarized` | `omitted`).
- `EffortLevel` string type and constants `EffortLow`, `EffortMedium`, `EffortHigh`, `EffortXHigh`, `EffortMax`.
- `Options.Thinking` and `Options.Effort` fields with `WithThinking` / `WithEffort` functional-option helpers.
- Transport now encodes `--thinking`, `--max-thinking-tokens`, `--thinking-display`, and `--effort` to match the TS SDK's argv builder in `sdk.mjs`.
- `MaxThinkingTokens` left in place with a `Deprecated:` comment; `Thinking` takes precedence when both are set.

## Tests

`transport_test.go` gets table-driven coverage for:
- each `Thinking.Type` variant (adaptive / enabled-with-budget / disabled) emits the right argv;
- nil `Thinking` emits neither `--thinking` nor `--max-thinking-tokens`;
- `Thinking.Display` wires `--thinking-display` (and is omitted when `Type == "disabled"` or unset);
- each of the five `EffortLevel` constants round-trips; empty `Effort` emits nothing;
- `MaxThinkingTokens` deprecation path still works, including the zero-value → `--thinking disabled` edge case.

## References

- `sdk.d.ts` L1347–1381 (`Options.thinking`, `Options.effort`, deprecated `maxThinkingTokens`)
- `sdk.d.ts` L5250–5277 (`ThinkingConfig` union)
- `sdk.mjs` argv builder (switch on `thinking.type` and optional `thinking.display`)