### PR TITLE
options: add auto and dontAsk permission modes

### DIFF
--- a/client.go
+++ b/client.go
@@ -977,6 +977,8 @@ func validateOptions(opts *Options) error {
 		PermissionModePlan:        true,
 		PermissionModeAcceptEdits: true,
 		PermissionModeBypassAll:   true,
+		PermissionModeAuto:        true,
+		PermissionModeDontAsk:     true,
 	}
 	if opts.PermissionMode != "" && !validModes[opts.PermissionMode] {
 		return &ErrInvalidConfiguration{

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,29 @@
+package claudeagent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientAcceptsPermissionModeConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		mode PermissionMode
+	}{
+		{name: "default", mode: PermissionModeDefault},
+		{name: "plan", mode: PermissionModePlan},
+		{name: "accept edits", mode: PermissionModeAcceptEdits},
+		{name: "bypass all", mode: PermissionModeBypassAll},
+		{name: "auto", mode: PermissionModeAuto},
+		{name: "dont ask", mode: PermissionModeDontAsk},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewClient(WithPermissionMode(tt.mode))
+			require.NoError(t, err)
+			require.Equal(t, tt.mode, client.options.PermissionMode)
+		})
+	}
+}

--- a/options.go
+++ b/options.go
@@ -549,6 +549,12 @@ const (
 
 	// PermissionModeBypassAll skips all permission checks.
 	PermissionModeBypassAll PermissionMode = "bypassPermissions"
+
+	// PermissionModeAuto lets Claude automatically decide permission handling.
+	PermissionModeAuto PermissionMode = "auto"
+
+	// PermissionModeDontAsk runs without asking for permission prompts.
+	PermissionModeDontAsk PermissionMode = "dontAsk"
 )
 
 // CanUseToolFunc is a callback invoked before tool execution.

--- a/transport_test.go
+++ b/transport_test.go
@@ -1310,3 +1310,49 @@ func TestSubprocessTransportStderrCallbackWiring(t *testing.T) {
 	assert.Contains(t, joined, "debug: loading config")
 	assert.Contains(t, joined, "warn: deprecated option")
 }
+
+func TestPermissionModeStringValues(t *testing.T) {
+	assert.Equal(t, "auto", string(PermissionModeAuto))
+	assert.Equal(t, "dontAsk", string(PermissionModeDontAsk))
+}
+
+func TestSubprocessTransportPermissionModeArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		mode PermissionMode
+		want string
+	}{
+		{name: "default", mode: PermissionModeDefault, want: "default"},
+		{name: "plan", mode: PermissionModePlan, want: "plan"},
+		{name: "accept edits", mode: PermissionModeAcceptEdits, want: "acceptEdits"},
+		{name: "bypass all", mode: PermissionModeBypassAll, want: "bypassPermissions"},
+		{name: "dont ask", mode: PermissionModeDontAsk, want: "dontAsk"},
+		{name: "auto", mode: PermissionModeAuto, want: "auto"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+			opts := &Options{
+				PermissionMode: tt.mode,
+			}
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+
+			ctx := context.Background()
+			err := transport.Connect(ctx)
+			require.NoError(t, err)
+			defer transport.Close()
+
+			found := false
+			for i, arg := range runner.StartArgs {
+				if arg == "--permission-mode" && i+1 < len(runner.StartArgs) {
+					assert.Equal(t, tt.want, runner.StartArgs[i+1])
+					found = true
+					break
+				}
+			}
+			assert.True(t, found, "expected --permission-mode %s in args: %v", tt.want, runner.StartArgs)
+		})
+	}
+}


### PR DESCRIPTION
See memory/catchup-v0.2.119/PLAN.md §"PR 2".

- Added `PermissionModeAuto` and `PermissionModeDontAsk` constants matching TS SDK v0.2.119 `PermissionMode` literals at `sdk.d.ts` line 1757.
- Kept transport behavior unchanged; existing `--permission-mode <value>` argv wiring passes these values through unchanged.
- Added string-value coverage for the new constants.
- Added table-driven transport argv coverage for every `PermissionMode` constant, including `auto` and `dontAsk`.
- Validation: `gofmt -l .`, `/home/node/.local/go/bin/go vet ./...`, `/home/node/.local/go/bin/go test ./...`.