### PR TITLE
options: add task budget

### DIFF
--- a/options.go
+++ b/options.go
@@ -116,6 +116,9 @@ type Options struct {
 	// MaxBudgetUsd is the maximum budget in USD for the query.
 	MaxBudgetUsd *float64
 
+	// TaskBudget is the maximum task budget for the query.
+	TaskBudget *TaskBudget
+
 	// MaxThinkingTokens is the maximum tokens for thinking process.
 	//
 	// Deprecated: Use Thinking instead.
@@ -249,6 +252,11 @@ type OutputFormat struct {
 	Type string
 	// Schema is the JSON schema for output validation.
 	Schema interface{}
+}
+
+// TaskBudget configures the maximum task budget.
+type TaskBudget struct {
+	Total int `json:"total"`
 }
 
 // ToolsConfig configures available tools.
@@ -1100,6 +1108,13 @@ func WithEffort(effort EffortLevel) Option {
 func WithMaxBudgetUsd(budget float64) Option {
 	return func(o *Options) {
 		o.MaxBudgetUsd = &budget
+	}
+}
+
+// WithTaskBudget sets the maximum task budget for the query.
+func WithTaskBudget(total int) Option {
+	return func(o *Options) {
+		o.TaskBudget = &TaskBudget{Total: total}
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -155,6 +155,10 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		args = append(args, "--effort", string(t.options.Effort))
 	}
 
+	if t.options.TaskBudget != nil {
+		args = append(args, "--task-budget", fmt.Sprintf("%d", t.options.TaskBudget.Total))
+	}
+
 	// Add permission bypass flags if configured.
 	if t.options.AllowDangerouslySkipPermissions {
 		args = append(args, "--dangerously-skip-permissions")

--- a/transport_test.go
+++ b/transport_test.go
@@ -842,6 +842,43 @@ func TestSubprocessTransportEffortEmptyOmitsFlag(t *testing.T) {
 	assertArgAbsent(t, runner.StartArgs, "--effort")
 }
 
+func TestSubprocessTransportTaskBudgetArguments(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	opts.TaskBudget = &TaskBudget{Total: 1000}
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	err := transport.Connect(context.Background())
+	require.NoError(t, err)
+	defer transport.Close()
+
+	assertArgValue(t, runner.StartArgs, "--task-budget", "1000")
+}
+
+func TestWithTaskBudgetSetsFreshBudget(t *testing.T) {
+	opts := NewOptions()
+
+	WithTaskBudget(1000)(opts)
+
+	require.NotNil(t, opts.TaskBudget)
+	assert.Equal(t, 1000, opts.TaskBudget.Total)
+}
+
+func TestSubprocessTransportTaskBudgetNilOmitsFlag(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	opts.TaskBudget = nil
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	err := transport.Connect(context.Background())
+	require.NoError(t, err)
+	defer transport.Close()
+
+	assertArgAbsent(t, runner.StartArgs, "--task-budget")
+}
+
 func TestSubprocessTransportMaxThinkingTokensStillWorks(t *testing.T) {
 	tokens := 2048
 	runner := NewMockSubprocessRunner()


### PR DESCRIPTION
## Summary

Wires up the `taskBudget` option introduced in TS SDK v0.2.119 (`sdk.d.ts` L1382-L1401).

- New `TaskBudget` struct with `Total int` and pointer-typed `Options.TaskBudget` so unset is zero-cost.
- `WithTaskBudget(total int) Option` helper.
- `transport.go` appends `--task-budget <total>` when set, matching the TS argv builder (`sdk.mjs`: `l.push("--task-budget", N.total.toString())`).
- Beta header `task-budgets-2026-03-13` is **not** emitted implicitly per the brief — callers add it via `Betas`.

Plan reference: PR 3 in `memory/catchup-v0.2.119/PLAN.md`.

## Validation

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `git diff --check`

## Test plan

- [ ] argv contains `--task-budget 1000` when `TaskBudget = &TaskBudget{Total: 1000}`
- [ ] argv has no `--task-budget` flag when `TaskBudget` is unset
