### PR TITLE
options: add extra-args passthrough for cli flags

### DIFF
--- a/options.go
+++ b/options.go
@@ -29,6 +29,10 @@ type Options struct {
 	// If empty, the CLI will be discovered from PATH.
 	CLIPath string
 
+	// ExtraArgs are arbitrary Claude CLI flags appended after SDK-managed flags.
+	// A nil value emits a bare flag.
+	ExtraArgs map[string]*string
+
 	// Cwd is the current working directory for the agent.
 	// Default: process.cwd() equivalent
 	Cwd string
@@ -368,6 +372,13 @@ func WithModel(model string) Option {
 func WithCLIPath(path string) Option {
 	return func(o *Options) {
 		o.CLIPath = path
+	}
+}
+
+// WithExtraArgs sets arbitrary Claude CLI flags appended after SDK-managed flags.
+func WithExtraArgs(args map[string]*string) Option {
+	return func(o *Options) {
+		o.ExtraArgs = args
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"iter"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -259,6 +260,21 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 	// --system-prompt is set.
 	if t.options.ExcludeDynamicSystemPromptSections {
 		args = append(args, "--exclude-dynamic-system-prompt-sections")
+	}
+
+	if len(t.options.ExtraArgs) > 0 {
+		keys := make([]string, 0, len(t.options.ExtraArgs))
+		for key := range t.options.ExtraArgs {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			args = append(args, "--"+key)
+			if value := t.options.ExtraArgs[key]; value != nil {
+				args = append(args, *value)
+			}
+		}
 	}
 
 	// Build environment - start with current process env, then overlay options.

--- a/transport_test.go
+++ b/transport_test.go
@@ -33,6 +33,10 @@ func assertArgAbsent(t *testing.T, args []string, flag string) {
 	assert.NotContains(t, args, flag)
 }
 
+func stringPtr(s string) *string {
+	return &s
+}
+
 // TestSubprocessTransportBasicCommunication tests stdin/stdout communication.
 func TestSubprocessTransportBasicCommunication(t *testing.T) {
 	// Create mock subprocess
@@ -662,6 +666,62 @@ func TestSubprocessTransportConnectArguments(t *testing.T) {
 	assert.True(t, runner.started)
 	assert.Contains(t, runner.StartArgs, "--model")
 	assert.Contains(t, runner.StartArgs, "--verbose")
+}
+
+func TestSubprocessTransportExtraArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		extraArgs map[string]*string
+		wantTail  []string
+	}{
+		{
+			name:      "nil",
+			extraArgs: nil,
+			wantTail:  nil,
+		},
+		{
+			name:      "empty",
+			extraArgs: map[string]*string{},
+			wantTail:  nil,
+		},
+		{
+			name:      "bare flag",
+			extraArgs: map[string]*string{"debug": nil},
+			wantTail:  []string{"--debug"},
+		},
+		{
+			name: "valued flags sorted",
+			extraArgs: map[string]*string{
+				"foo": stringPtr("bar"),
+				"baz": stringPtr("qux"),
+			},
+			wantTail: []string{"--baz", "qux", "--foo", "bar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+			opts := NewOptions()
+			opts.ExtraArgs = tt.extraArgs
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+
+			err := transport.Connect(context.Background())
+			require.NoError(t, err)
+			defer transport.Close()
+
+			if len(tt.wantTail) == 0 {
+				assertArgAbsent(t, runner.StartArgs, "--debug")
+				assertArgAbsent(t, runner.StartArgs, "--baz")
+				assertArgAbsent(t, runner.StartArgs, "--foo")
+				return
+			}
+
+			require.GreaterOrEqual(t, len(runner.StartArgs), len(tt.wantTail))
+			assert.Equal(t, tt.wantTail, runner.StartArgs[len(runner.StartArgs)-len(tt.wantTail):])
+		})
+	}
 }
 
 func TestSubprocessTransportThinkingArguments(t *testing.T) {


### PR DESCRIPTION
Wires up the `extraArgs` option from TS SDK v0.2.119 (`sdk.d.ts` L1224-L1229, `sdk.mjs` argv builder). Plan reference: PR 4 in `memory/catchup-v0.2.119/PLAN.md`.

## What changed

- `Options.ExtraArgs map[string]*string` — nil value means a bare `--flag`, non-nil means `--flag <value>`.
- `WithExtraArgs(map[string]*string) Option` helper.
- `transport.go` appends extra flags last in argv, with keys sorted alphabetically for deterministic output (Go map iteration is unordered; TS uses insertion order which doesn't port).

## Tests

`transport_test.go` covers:
- nil / empty `ExtraArgs` → no extra flags appended
- `{"debug": nil}` → trailing `--debug` (bare)
- `{"foo": ptr("bar"), "baz": ptr("qux")}` → trailing `--baz qux --foo bar` (alphabetical)

## Validation

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)