### PR TITLE
options: add debug and debug-file

### DIFF
--- a/options.go
+++ b/options.go
@@ -84,6 +84,13 @@ type Options struct {
 	// list. Example: []string{"context-1m-2025-08-07"}.
 	Betas []string
 
+	// Debug enables debug logging from the CLI.
+	Debug bool
+
+	// DebugFile writes debug logs to the specified file.
+	// When set, the CLI implicitly enables debug logging.
+	DebugFile string
+
 	// ExcludeDynamicSystemPromptSections moves per-machine sections (cwd,
 	// env info, memory paths, git status) from the system prompt into the
 	// first user message. This improves cross-invocation prompt-cache reuse
@@ -1048,6 +1055,20 @@ func WithSandbox(sandbox *SandboxSettings) Option {
 func WithBetas(betas []string) Option {
 	return func(o *Options) {
 		o.Betas = betas
+	}
+}
+
+// WithDebug enables debug logging from the CLI.
+func WithDebug(debug bool) Option {
+	return func(o *Options) {
+		o.Debug = debug
+	}
+}
+
+// WithDebugFile writes debug logs to the specified file.
+func WithDebugFile(path string) Option {
+	return func(o *Options) {
+		o.DebugFile = path
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -254,6 +254,12 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		args = append(args, "--betas", strings.Join(t.options.Betas, ","))
 	}
 
+	if t.options.DebugFile != "" {
+		args = append(args, "--debug-file", t.options.DebugFile)
+	} else if t.options.Debug {
+		args = append(args, "--debug")
+	}
+
 	// Move per-machine system prompt sections (cwd, env, memory, git status)
 	// into the first user message. Stabilizes the system prompt prefix for
 	// cross-invocation prompt-cache reuse. The CLI ignores this flag when

--- a/transport_test.go
+++ b/transport_test.go
@@ -1197,6 +1197,67 @@ func TestSubprocessTransportBetasEmpty(t *testing.T) {
 	}
 }
 
+func TestSubprocessTransportDebugOptions(t *testing.T) {
+	tests := []struct {
+		name               string
+		debug              bool
+		debugFile          string
+		wantDebug          bool
+		wantDebugFile      bool
+		wantDebugFileValue string
+	}{
+		{
+			name: "disabled",
+		},
+		{
+			name:      "debug enabled",
+			debug:     true,
+			wantDebug: true,
+		},
+		{
+			name:               "debug file enables debug",
+			debugFile:          "/tmp/x.log",
+			wantDebugFile:      true,
+			wantDebugFileValue: "/tmp/x.log",
+		},
+		{
+			name:               "debug file wins over debug",
+			debug:              true,
+			debugFile:          "/tmp/x.log",
+			wantDebugFile:      true,
+			wantDebugFileValue: "/tmp/x.log",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+			opts := &Options{
+				Debug:     tt.debug,
+				DebugFile: tt.debugFile,
+			}
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+
+			err := transport.Connect(context.Background())
+			require.NoError(t, err)
+			defer transport.Close()
+
+			if tt.wantDebug {
+				assert.Contains(t, runner.StartArgs, "--debug")
+			} else {
+				assertArgAbsent(t, runner.StartArgs, "--debug")
+			}
+
+			if tt.wantDebugFile {
+				assertArgValue(t, runner.StartArgs, "--debug-file", tt.wantDebugFileValue)
+			} else {
+				assertArgAbsent(t, runner.StartArgs, "--debug-file")
+			}
+		})
+	}
+}
+
 // TestSubprocessTransportExcludeDynamicSystemPromptSections tests the flag is
 // passed when the option is enabled.
 func TestSubprocessTransportExcludeDynamicSystemPromptSections(t *testing.T) {


### PR DESCRIPTION
See `memory/catchup-v0.2.119/PLAN.md` §"PR 5".

- Adds `Options.Debug bool` and `Options.DebugFile string` plus `WithDebug` / `WithDebugFile` helpers.
- Mirrors TS SDK v0.2.119 `sdk.d.ts` L1615-L1627: `debug` enables CLI debug logging and `debugFile` writes debug logs to a file while implicitly enabling debug.
- Updates subprocess argv construction to match the authoritative `sdk.mjs` ordering: `DebugFile` emits `--debug-file <path>` and takes precedence over `Debug` emitting `--debug`.
- Covers all requested argv combinations in table-driven `transport_test.go`, including the no-flag default and DebugFile-over-Debug precedence.
- Validated with `go test ./...`, `gofmt -l .`, and `go vet ./...`.