### PR TITLE
options: add main-thread agent flag

### DIFF
--- a/options.go
+++ b/options.go
@@ -22,6 +22,9 @@ type Options struct {
 	// Default: "claude-sonnet-4-5-20250929"
 	Model string
 
+	// MainAgent names the agent to apply to the main thread.
+	MainAgent string
+
 	// FallbackModel is the model to use if primary fails.
 	FallbackModel string
 
@@ -370,6 +373,13 @@ func WithSystemPrompt(prompt string) Option {
 func WithModel(model string) Option {
 	return func(o *Options) {
 		o.Model = model
+	}
+}
+
+// WithMainAgent sets the agent to apply to the main thread.
+func WithMainAgent(name string) Option {
+	return func(o *Options) {
+		o.MainAgent = name
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -118,6 +118,10 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		args = append(args, "--model", t.options.Model)
 	}
 
+	if t.options.MainAgent != "" {
+		args = append(args, "--agent", t.options.MainAgent)
+	}
+
 	if t.options.SystemPrompt != "" {
 		args = append(args, "--system-prompt", t.options.SystemPrompt)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -724,6 +724,53 @@ func TestSubprocessTransportExtraArgs(t *testing.T) {
 	}
 }
 
+func TestSubprocessTransportMainAgentArguments(t *testing.T) {
+	tests := []struct {
+		name      string
+		mainAgent string
+		want      bool
+	}{
+		{
+			name:      "empty",
+			mainAgent: "",
+			want:      false,
+		},
+		{
+			name:      "reviewer",
+			mainAgent: "reviewer",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+			opts := NewOptions()
+			opts.MainAgent = tt.mainAgent
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+
+			err := transport.Connect(context.Background())
+			require.NoError(t, err)
+			defer transport.Close()
+
+			if tt.want {
+				assertArgValue(t, runner.StartArgs, "--agent", tt.mainAgent)
+			} else {
+				assertArgAbsent(t, runner.StartArgs, "--agent")
+			}
+		})
+	}
+}
+
+func TestWithMainAgent(t *testing.T) {
+	opts := NewOptions()
+
+	WithMainAgent("reviewer")(opts)
+
+	assert.Equal(t, "reviewer", opts.MainAgent)
+}
+
 func TestSubprocessTransportThinkingArguments(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary
- Adds `Options.MainAgent string` and `WithMainAgent(name string)` helper.
- Argv builder emits `--agent <name>` when `MainAgent != ""`, placed alongside the other per-request flags (after `--model`), matching `sdk.mjs` ordering.
- `MainAgent` naming avoids collision with the existing `Agents` map and reads as the "main-thread agent" the TS comment describes.

## Out of scope (deferred to PR 6b)
- `promptSuggestions` / `agentProgressSummaries` are not CLI flags — they ride the `initialize` control-channel body. Tracked separately so this PR stays a clean argv change.

## Test plan
- [x] `go test ./...`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `transport_test.go` covers unset and set cases.

Tracks v0.2.119 catchup PLAN.md PR #06.