### PR TITLE
protocol: add init-time subagent and session options

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -222,24 +222,31 @@ type SDKControlRequest struct {
 // SDKControlRequestBody contains the actual request data.
 // Note: This is a union type - different fields are used for different subtypes.
 type SDKControlRequestBody struct {
-	Subtype            string                              `json:"subtype"`                       // Request subtype
-	Hooks              map[string][]SDKHookCallbackMatcher `json:"hooks,omitempty"`               // For initialize
-	SDKMCPServers      []string                            `json:"sdkMcpServers,omitempty"`       // For initialize
-	JSONSchema         map[string]interface{}              `json:"jsonSchema,omitempty"`          // For initialize
-	SystemPrompt       string                              `json:"systemPrompt,omitempty"`        // For initialize
-	AppendSystemPrompt string                              `json:"appendSystemPrompt,omitempty"`  // For initialize
-	Agents             map[string]interface{}              `json:"agents,omitempty"`              // For initialize
-	ToolName           string                              `json:"tool_name,omitempty"`           // For can_use_tool/hook_callback
-	Input              map[string]interface{}              `json:"input,omitempty"`               // For can_use_tool/hook_callback
-	ToolUseID          string                              `json:"tool_use_id,omitempty"`         // For can_use_tool/hooks
-	AgentID            string                              `json:"agent_id,omitempty"`            // For can_use_tool
-	CallbackID         string                              `json:"callback_id,omitempty"`         // For hook_callback
-	Mode               string                              `json:"mode,omitempty"`                // For set_permission_mode
-	Model              string                              `json:"model,omitempty"`               // For set_model
-	MaxThinkingTokens  *int                                `json:"max_thinking_tokens,omitempty"` // For set_max_thinking_tokens
-	UserMessageID      string                              `json:"user_message_id,omitempty"`     // For rewind_files
-	ServerName         string                              `json:"server_name,omitempty"`         // For mcp_message
-	Message            map[string]interface{}              `json:"message,omitempty"`             // For mcp_message (JSONRPC)
+	Subtype                string                              `json:"subtype"`                          // Request subtype
+	Hooks                  map[string][]SDKHookCallbackMatcher `json:"hooks,omitempty"`                  // For initialize
+	SDKMCPServers          []string                            `json:"sdkMcpServers,omitempty"`          // For initialize
+	JSONSchema             map[string]interface{}              `json:"jsonSchema,omitempty"`             // For initialize
+	SystemPrompt           string                              `json:"systemPrompt,omitempty"`           // For initialize
+	AppendSystemPrompt     string                              `json:"appendSystemPrompt,omitempty"`     // For initialize
+	PlanModeInstructions   string                              `json:"planModeInstructions,omitempty"`   // For initialize
+	ExcludeDynamicSections *bool                               `json:"excludeDynamicSections,omitempty"` // For initialize
+	Agents                 map[string]interface{}              `json:"agents,omitempty"`                 // For initialize
+	Title                  string                              `json:"title,omitempty"`                  // For initialize
+	Skills                 []string                            `json:"skills,omitempty"`                 // For initialize
+	PromptSuggestions      *bool                               `json:"promptSuggestions,omitempty"`      // For initialize
+	AgentProgressSummaries *bool                               `json:"agentProgressSummaries,omitempty"` // For initialize
+	ForwardSubagentText    *bool                               `json:"forwardSubagentText,omitempty"`    // For initialize
+	ToolName               string                              `json:"tool_name,omitempty"`              // For can_use_tool/hook_callback
+	Input                  map[string]interface{}              `json:"input,omitempty"`                  // For can_use_tool/hook_callback
+	ToolUseID              string                              `json:"tool_use_id,omitempty"`            // For can_use_tool/hooks
+	AgentID                string                              `json:"agent_id,omitempty"`               // For can_use_tool
+	CallbackID             string                              `json:"callback_id,omitempty"`            // For hook_callback
+	Mode                   string                              `json:"mode,omitempty"`                   // For set_permission_mode
+	Model                  string                              `json:"model,omitempty"`                  // For set_model
+	MaxThinkingTokens      *int                                `json:"max_thinking_tokens,omitempty"`    // For set_max_thinking_tokens
+	UserMessageID          string                              `json:"user_message_id,omitempty"`        // For rewind_files
+	ServerName             string                              `json:"server_name,omitempty"`            // For mcp_message
+	Message                map[string]interface{}              `json:"message,omitempty"`                // For mcp_message (JSONRPC)
 }
 
 // SDKHookCallbackMatcher defines hook callback matching configuration.

--- a/messages_test.go
+++ b/messages_test.go
@@ -9,6 +9,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSDKControlRequestBodyInitializeOptions(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	body := SDKControlRequestBody{
+		Subtype:                "initialize",
+		PlanModeInstructions:   "plan first",
+		ExcludeDynamicSections: &trueVal,
+		Title:                  "custom title",
+		Skills:                 []string{"go", "review"},
+		PromptSuggestions:      &falseVal,
+		AgentProgressSummaries: &trueVal,
+		ForwardSubagentText:    &falseVal,
+	}
+
+	data, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, "initialize", got["subtype"])
+	assert.Equal(t, "plan first", got["planModeInstructions"])
+	assert.Equal(t, true, got["excludeDynamicSections"])
+	assert.Equal(t, "custom title", got["title"])
+	assert.Equal(t, []interface{}{"go", "review"}, got["skills"])
+	assert.Equal(t, false, got["promptSuggestions"])
+	assert.Equal(t, true, got["agentProgressSummaries"])
+	assert.Equal(t, false, got["forwardSubagentText"])
+}
+
+func TestSDKControlRequestBodyInitializeOptionsOmitUnset(t *testing.T) {
+	data, err := json.Marshal(SDKControlRequestBody{Subtype: "initialize"})
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	for _, key := range []string{
+		"planModeInstructions",
+		"excludeDynamicSections",
+		"title",
+		"skills",
+		"promptSuggestions",
+		"agentProgressSummaries",
+		"forwardSubagentText",
+	} {
+		assert.NotContains(t, got, key)
+	}
+}
+
 // TestParseMessageUserMessage tests parsing user messages.
 func TestParseMessageUserMessage(t *testing.T) {
 	input := `{

--- a/options.go
+++ b/options.go
@@ -65,6 +65,24 @@ type Options struct {
 	// Agents defines specialized subagents for task delegation.
 	Agents map[string]AgentDefinition
 
+	// PlanModeInstructions customizes the plan-mode workflow body.
+	PlanModeInstructions string
+
+	// Title sets a custom session title.
+	Title string
+
+	// Skills limits main-session skills to the named allowlist.
+	Skills []string
+
+	// PromptSuggestions enables next-prompt suggestion events.
+	PromptSuggestions *bool
+
+	// AgentProgressSummaries enables agent progress summary events.
+	AgentProgressSummaries *bool
+
+	// ForwardSubagentText surfaces subagent text in the main stream.
+	ForwardSubagentText *bool
+
 	// SessionOptions configure session behavior (create/resume/fork).
 	SessionOptions SessionOptions
 
@@ -380,6 +398,48 @@ func WithModel(model string) Option {
 func WithMainAgent(name string) Option {
 	return func(o *Options) {
 		o.MainAgent = name
+	}
+}
+
+// WithPlanModeInstructions customizes the plan-mode workflow body.
+func WithPlanModeInstructions(instructions string) Option {
+	return func(o *Options) {
+		o.PlanModeInstructions = instructions
+	}
+}
+
+// WithTitle sets a custom session title.
+func WithTitle(title string) Option {
+	return func(o *Options) {
+		o.Title = title
+	}
+}
+
+// WithSkillsAllowlist limits main-session skills to the named allowlist.
+func WithSkillsAllowlist(skills []string) Option {
+	return func(o *Options) {
+		o.Skills = skills
+	}
+}
+
+// WithPromptSuggestions enables or disables next-prompt suggestion events.
+func WithPromptSuggestions(enable bool) Option {
+	return func(o *Options) {
+		o.PromptSuggestions = &enable
+	}
+}
+
+// WithAgentProgressSummaries enables or disables agent progress summary events.
+func WithAgentProgressSummaries(enable bool) Option {
+	return func(o *Options) {
+		o.AgentProgressSummaries = &enable
+	}
+}
+
+// WithForwardSubagentText enables or disables forwarding subagent text.
+func WithForwardSubagentText(enable bool) Option {
+	return func(o *Options) {
+		o.ForwardSubagentText = &enable
 	}
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -84,16 +84,29 @@ func (p *Protocol) Initialize(ctx context.Context) error {
 		}
 	}
 
+	var excludeDynamicSections *bool
+	if p.options.ExcludeDynamicSystemPromptSections {
+		trueVal := true
+		excludeDynamicSections = &trueVal
+	}
+
 	// Build initialization request in TypeScript SDK format.
 	requestID := p.nextRequestID()
 	req := SDKControlRequest{
 		Type:      "control_request",
 		RequestID: requestID,
 		Request: SDKControlRequestBody{
-			Subtype:       "initialize",
-			Hooks:         hooks,
-			SDKMCPServers: sdkMcpServers,
-			SystemPrompt:  p.options.SystemPrompt,
+			Subtype:                "initialize",
+			Hooks:                  hooks,
+			SDKMCPServers:          sdkMcpServers,
+			SystemPrompt:           p.options.SystemPrompt,
+			PlanModeInstructions:   p.options.PlanModeInstructions,
+			ExcludeDynamicSections: excludeDynamicSections,
+			Title:                  p.options.Title,
+			Skills:                 p.options.Skills,
+			PromptSuggestions:      p.options.PromptSuggestions,
+			AgentProgressSummaries: p.options.AgentProgressSummaries,
+			ForwardSubagentText:    p.options.ForwardSubagentText,
 		},
 	}
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -102,6 +102,117 @@ func TestProtocolInitialize(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestProtocolInitializeOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		configure  func(*Options)
+		expected   map[string]interface{}
+		unexpected []string
+	}{
+		{
+			name: "all options",
+			configure: func(opts *Options) {
+				WithPlanModeInstructions("plan deliberately")(opts)
+				WithTitle("session title")(opts)
+				WithSkillsAllowlist([]string{"go", "review"})(opts)
+				WithPromptSuggestions(false)(opts)
+				WithAgentProgressSummaries(true)(opts)
+				WithForwardSubagentText(false)(opts)
+				WithExcludeDynamicSystemPromptSections(true)(opts)
+			},
+			expected: map[string]interface{}{
+				"planModeInstructions":   "plan deliberately",
+				"title":                  "session title",
+				"skills":                 []interface{}{"go", "review"},
+				"promptSuggestions":      false,
+				"agentProgressSummaries": true,
+				"forwardSubagentText":    false,
+				"excludeDynamicSections": true,
+			},
+		},
+		{
+			name: "exclude dynamic false omitted",
+			configure: func(opts *Options) {
+				WithExcludeDynamicSystemPromptSections(false)(opts)
+			},
+			unexpected: []string{"excludeDynamicSections"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+			opts := NewOptions()
+			tt.configure(opts)
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+			protocol := NewProtocol(transport, opts)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+
+			err := transport.Connect(ctx)
+			require.NoError(t, err)
+			defer transport.Close()
+
+			initReqCh := make(chan SDKControlRequest, 1)
+			go func() {
+				decoder := json.NewDecoder(runner.StdinPipe)
+				var initReq SDKControlRequest
+				if err := decoder.Decode(&initReq); err != nil {
+					return
+				}
+				initReqCh <- initReq
+
+				resp := SDKControlResponse{
+					Type: "control_response",
+					Response: SDKControlResponseBody{
+						Subtype:   "success",
+						RequestID: initReq.RequestID,
+						Response:  map[string]interface{}{"status": "ok"},
+					},
+				}
+				data, _ := json.Marshal(resp)
+				data = append(data, '\n')
+				runner.StdoutPipe.Write(data)
+			}()
+
+			go func() {
+				for msg, err := range transport.ReadMessages(ctx) {
+					if err != nil {
+						continue
+					}
+					if ctrlResp, ok := msg.(SDKControlResponse); ok {
+						protocol.handleSDKControlResponse(ctrlResp)
+					}
+				}
+			}()
+
+			err = protocol.Initialize(ctx)
+			require.NoError(t, err)
+
+			var initReq SDKControlRequest
+			select {
+			case initReq = <-initReqCh:
+			case <-ctx.Done():
+				t.Fatal("timeout waiting for initialize request")
+			}
+
+			data, err := json.Marshal(initReq.Request)
+			require.NoError(t, err)
+			var requestBody map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &requestBody))
+
+			for key, want := range tt.expected {
+				assert.Equal(t, want, requestBody[key])
+			}
+			for _, key := range tt.unexpected {
+				assert.NotContains(t, requestBody, key)
+			}
+		})
+	}
+}
+
 // TestProtocolPermissionRequest tests permission checking.
 func TestProtocolPermissionRequest(t *testing.T) {
 	t.Run("allow", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Wires the seven init-only options from `SDKControlInitializeRequest` (TS `sdk.d.ts` L2500-L2528) through to the control-channel `initialize` body. None of these are CLI argv flags.

- New `Options` fields + helpers: `PlanModeInstructions`, `Title`, `Skills`, `PromptSuggestions *bool`, `AgentProgressSummaries *bool`, `ForwardSubagentText *bool`. Bool fields are pointer-typed so unset omits cleanly from JSON (TS distinguishes false from absent).
- Existing `ExcludeDynamicSystemPromptSections bool` is now forwarded to the init body as `excludeDynamicSections` (only when true; false omits, matching TS truthiness).
- `SDKControlRequestBody` (`messages.go`) gains the seven JSON fields with TS-matching camelCase keys + `omitempty`.
- `Protocol.Initialize` populates them from `Options`.

## Out of scope
- New CLI argv flags. None required.
- `SDKControlInitializeResponse` parsing (lands in PR 18).
- New message types triggered by these options (`SDKPromptSuggestionMessage`, etc — land in PR 14).

## Test plan
- [x] `go test ./...`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `messages_test.go` round-trips the seven fields with correct camelCase keys + omitempty.
- [x] `protocol_test.go` `TestProtocolInitializeOptions` table-driven test: each helper populates the wire body correctly; `ExcludeDynamicSystemPromptSections=false` omits `excludeDynamicSections`.

Tracks v0.2.119 catchup PLAN.md PR #6 follow-up (PR 6b).