### PR TITLE
options: extend AgentDefinition and wire agents through initialize

### DIFF
--- a/messages_test.go
+++ b/messages_test.go
@@ -174,6 +174,17 @@ func TestAgentMCPServerSpecJSON(t *testing.T) {
 		assert.Equal(t, "gh", decoded.Inline["github"].Command)
 		assert.Empty(t, decoded.Name)
 	})
+
+	t.Run("leading whitespace", func(t *testing.T) {
+		var named AgentMCPServerSpec
+		require.NoError(t, json.Unmarshal([]byte("  \n\t\"github\""), &named))
+		assert.Equal(t, "github", named.Name)
+
+		var inline AgentMCPServerSpec
+		require.NoError(t, json.Unmarshal([]byte("\n {\"github\":{\"type\":\"stdio\",\"command\":\"gh\"}}"), &inline))
+		require.Contains(t, inline.Inline, "github")
+		assert.Equal(t, "stdio", inline.Inline["github"].Type)
+	})
 }
 
 func TestAgentEffortJSON(t *testing.T) {

--- a/messages_test.go
+++ b/messages_test.go
@@ -60,6 +60,166 @@ func TestSDKControlRequestBodyInitializeOptionsOmitUnset(t *testing.T) {
 	}
 }
 
+func TestAgentDefinitionJSON(t *testing.T) {
+	background := false
+	effortBudget := 30000
+	agent := AgentDefinition{
+		Name:                               "reviewer",
+		Description:                        "Reviews Go changes",
+		Prompt:                             "Review carefully",
+		Tools:                              []string{"Read", "Grep"},
+		Model:                              "claude-opus-4-5-20250929",
+		DisallowedTools:                    []string{"Bash"},
+		MCPServers:                         []AgentMCPServerSpec{{Name: "github"}},
+		CriticalSystemReminderExperimental: "Stay focused",
+		Skills:                             []string{"go"},
+		InitialPrompt:                      "Start here",
+		MaxTurns:                           5,
+		Background:                         &background,
+		Memory:                             AgentMemoryProject,
+		Effort:                             AgentEffort{Numeric: &effortBudget},
+		PermissionMode:                     PermissionModeAcceptEdits,
+	}
+
+	data, err := json.Marshal(agent)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.NotContains(t, got, "Name")
+	assert.NotContains(t, got, "name")
+	assert.Equal(t, "Reviews Go changes", got["description"])
+	assert.Equal(t, "Review carefully", got["prompt"])
+	assert.Equal(t, []interface{}{"Read", "Grep"}, got["tools"])
+	assert.Equal(t, "claude-opus-4-5-20250929", got["model"])
+	assert.Equal(t, []interface{}{"Bash"}, got["disallowedTools"])
+	assert.Equal(t, []interface{}{"github"}, got["mcpServers"])
+	assert.Equal(t, "Stay focused", got["criticalSystemReminder_EXPERIMENTAL"])
+	assert.Equal(t, []interface{}{"go"}, got["skills"])
+	assert.Equal(t, "Start here", got["initialPrompt"])
+	assert.Equal(t, float64(5), got["maxTurns"])
+	assert.Equal(t, false, got["background"])
+	assert.Equal(t, "project", got["memory"])
+	assert.Equal(t, float64(30000), got["effort"])
+	assert.Equal(t, "acceptEdits", got["permissionMode"])
+
+	var decoded AgentDefinition
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, agent.Description, decoded.Description)
+	assert.Equal(t, agent.Prompt, decoded.Prompt)
+	assert.Equal(t, agent.Tools, decoded.Tools)
+	assert.Equal(t, agent.Model, decoded.Model)
+	assert.Equal(t, agent.DisallowedTools, decoded.DisallowedTools)
+	require.Len(t, decoded.MCPServers, 1)
+	assert.Equal(t, "github", decoded.MCPServers[0].Name)
+	assert.Equal(t, agent.CriticalSystemReminderExperimental, decoded.CriticalSystemReminderExperimental)
+	assert.Equal(t, agent.Skills, decoded.Skills)
+	assert.Equal(t, agent.InitialPrompt, decoded.InitialPrompt)
+	assert.Equal(t, agent.MaxTurns, decoded.MaxTurns)
+	require.NotNil(t, decoded.Background)
+	assert.Equal(t, false, *decoded.Background)
+	assert.Equal(t, agent.Memory, decoded.Memory)
+	require.NotNil(t, decoded.Effort.Numeric)
+	assert.Equal(t, effortBudget, *decoded.Effort.Numeric)
+	assert.Equal(t, agent.PermissionMode, decoded.PermissionMode)
+}
+
+func TestAgentDefinitionJSONOmitUnset(t *testing.T) {
+	data, err := json.Marshal(AgentDefinition{
+		Description: "Reviews changes",
+		Prompt:      "Review carefully",
+	})
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, "Reviews changes", got["description"])
+	assert.Equal(t, "Review carefully", got["prompt"])
+	for _, key := range []string{"memory", "effort", "maxTurns", "background"} {
+		assert.NotContains(t, got, key)
+	}
+}
+
+func TestAgentMCPServerSpecJSON(t *testing.T) {
+	t.Run("name", func(t *testing.T) {
+		data, err := json.Marshal(AgentMCPServerSpec{Name: "github"})
+		require.NoError(t, err)
+		assert.JSONEq(t, `"github"`, string(data))
+
+		var decoded AgentMCPServerSpec
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, "github", decoded.Name)
+		assert.Nil(t, decoded.Inline)
+	})
+
+	t.Run("inline", func(t *testing.T) {
+		spec := AgentMCPServerSpec{
+			Inline: map[string]MCPServerConfig{
+				"github": {
+					Type:    "stdio",
+					Command: "gh",
+				},
+			},
+		}
+		data, err := json.Marshal(spec)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"github":{"type":"stdio","command":"gh"}}`, string(data))
+
+		var decoded AgentMCPServerSpec
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.Contains(t, decoded.Inline, "github")
+		assert.Equal(t, "stdio", decoded.Inline["github"].Type)
+		assert.Equal(t, "gh", decoded.Inline["github"].Command)
+		assert.Empty(t, decoded.Name)
+	})
+}
+
+func TestAgentEffortJSON(t *testing.T) {
+	t.Run("level", func(t *testing.T) {
+		data, err := json.Marshal(AgentEffort{Level: EffortHigh})
+		require.NoError(t, err)
+		assert.JSONEq(t, `"high"`, string(data))
+
+		var decoded AgentEffort
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, EffortHigh, decoded.Level)
+		assert.Nil(t, decoded.Numeric)
+	})
+
+	t.Run("numeric", func(t *testing.T) {
+		budget := 30000
+		data, err := json.Marshal(AgentEffort{Numeric: &budget})
+		require.NoError(t, err)
+		assert.JSONEq(t, `30000`, string(data))
+
+		var decoded AgentEffort
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		require.NotNil(t, decoded.Numeric)
+		assert.Equal(t, budget, *decoded.Numeric)
+		assert.Empty(t, decoded.Level)
+	})
+}
+
+func TestAgentMemoryScopeJSON(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		scope AgentMemoryScope
+		want  string
+	}{
+		{"user", AgentMemoryUser, `"user"`},
+		{"project", AgentMemoryProject, `"project"`},
+		{"local", AgentMemoryLocal, `"local"`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.scope)
+			require.NoError(t, err)
+			assert.JSONEq(t, tt.want, string(data))
+		})
+	}
+}
+
 // TestParseMessageUserMessage tests parsing user messages.
 func TestParseMessageUserMessage(t *testing.T) {
 	input := `{

--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package claudeagent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 )
 
 // Options holds configuration for a Claude agent client.
@@ -991,11 +992,166 @@ type HookResult struct {
 
 // AgentDefinition defines a specialized subagent.
 type AgentDefinition struct {
-	Name        string   // Agent identifier
-	Description string   // When to invoke this agent
-	Prompt      string   // System instructions for the subagent
-	Tools       []string // Tool whitelist (nil = inherit all)
-	Model       string   // Optional model override
+	Name                               string               `json:"-"` // Agent identifier
+	Description                        string               `json:"description"`
+	Prompt                             string               `json:"prompt"`
+	Tools                              []string             `json:"tools,omitempty"`
+	Model                              string               `json:"model,omitempty"`
+	DisallowedTools                    []string             `json:"disallowedTools,omitempty"`
+	MCPServers                         []AgentMCPServerSpec `json:"mcpServers,omitempty"`
+	CriticalSystemReminderExperimental string               `json:"criticalSystemReminder_EXPERIMENTAL,omitempty"`
+	Skills                             []string             `json:"skills,omitempty"`
+	InitialPrompt                      string               `json:"initialPrompt,omitempty"`
+	MaxTurns                           int                  `json:"maxTurns,omitempty"`
+	Background                         *bool                `json:"background,omitempty"`
+	Memory                             AgentMemoryScope     `json:"memory,omitempty"`
+	Effort                             AgentEffort          `json:"effort,omitempty"`
+	PermissionMode                     PermissionMode       `json:"permissionMode,omitempty"`
+}
+
+// MarshalJSON emits the TypeScript SDK agent wire shape.
+func (a AgentDefinition) MarshalJSON() ([]byte, error) {
+	type agentDefinitionJSON struct {
+		Description                        string               `json:"description"`
+		Prompt                             string               `json:"prompt"`
+		Tools                              []string             `json:"tools,omitempty"`
+		Model                              string               `json:"model,omitempty"`
+		DisallowedTools                    []string             `json:"disallowedTools,omitempty"`
+		MCPServers                         []AgentMCPServerSpec `json:"mcpServers,omitempty"`
+		CriticalSystemReminderExperimental string               `json:"criticalSystemReminder_EXPERIMENTAL,omitempty"`
+		Skills                             []string             `json:"skills,omitempty"`
+		InitialPrompt                      string               `json:"initialPrompt,omitempty"`
+		MaxTurns                           int                  `json:"maxTurns,omitempty"`
+		Background                         *bool                `json:"background,omitempty"`
+		Memory                             AgentMemoryScope     `json:"memory,omitempty"`
+		Effort                             *AgentEffort         `json:"effort,omitempty"`
+		PermissionMode                     PermissionMode       `json:"permissionMode,omitempty"`
+	}
+
+	out := agentDefinitionJSON{
+		Description:                        a.Description,
+		Prompt:                             a.Prompt,
+		Tools:                              a.Tools,
+		Model:                              a.Model,
+		DisallowedTools:                    a.DisallowedTools,
+		MCPServers:                         a.MCPServers,
+		CriticalSystemReminderExperimental: a.CriticalSystemReminderExperimental,
+		Skills:                             a.Skills,
+		InitialPrompt:                      a.InitialPrompt,
+		MaxTurns:                           a.MaxTurns,
+		Background:                         a.Background,
+		Memory:                             a.Memory,
+		PermissionMode:                     a.PermissionMode,
+	}
+	if !a.Effort.IsZero() {
+		out.Effort = &a.Effort
+	}
+
+	return json.Marshal(out)
+}
+
+// AgentMemoryScope controls which memory scope is available to an agent.
+type AgentMemoryScope string
+
+const (
+	// AgentMemoryUser enables user memory for the agent.
+	AgentMemoryUser AgentMemoryScope = "user"
+	// AgentMemoryProject enables project memory for the agent.
+	AgentMemoryProject AgentMemoryScope = "project"
+	// AgentMemoryLocal enables local memory for the agent.
+	AgentMemoryLocal AgentMemoryScope = "local"
+)
+
+// AgentEffort is the AgentDefinition effort union: EffortLevel or numeric budget.
+type AgentEffort struct {
+	Level   EffortLevel
+	Numeric *int
+}
+
+// IsZero reports whether no effort was configured.
+func (e AgentEffort) IsZero() bool {
+	return e.Level == "" && e.Numeric == nil
+}
+
+// MarshalJSON emits either the numeric or string effort variant.
+func (e AgentEffort) MarshalJSON() ([]byte, error) {
+	if e.Numeric != nil {
+		return json.Marshal(*e.Numeric)
+	}
+	if e.Level != "" {
+		return json.Marshal(e.Level)
+	}
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON decodes either the numeric or string effort variant.
+func (e *AgentEffort) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*e = AgentEffort{}
+		return nil
+	}
+
+	var level EffortLevel
+	if err := json.Unmarshal(data, &level); err == nil {
+		*e = AgentEffort{Level: level}
+		return nil
+	}
+
+	var numeric int
+	if err := json.Unmarshal(data, &numeric); err != nil {
+		return err
+	}
+	*e = AgentEffort{Numeric: &numeric}
+	return nil
+}
+
+// AgentMCPServerSpec references a top-level MCP server or defines inline servers.
+type AgentMCPServerSpec struct {
+	// Name references a server defined in Options.MCPServers by key. Mutually exclusive with Inline.
+	Name string
+	// Inline defines servers locally for this agent. Mutually exclusive with Name.
+	Inline map[string]MCPServerConfig
+}
+
+// MarshalJSON emits the AgentMCPServerSpec discriminated union.
+func (s AgentMCPServerSpec) MarshalJSON() ([]byte, error) {
+	if s.Name != "" {
+		return json.Marshal(s.Name)
+	}
+	if s.Inline != nil {
+		return json.Marshal(s.Inline)
+	}
+	return []byte("null"), nil
+}
+
+// UnmarshalJSON decodes a named or inline AgentMCPServerSpec.
+func (s *AgentMCPServerSpec) UnmarshalJSON(data []byte) error {
+	var raw json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if len(raw) == 0 || string(raw) == "null" {
+		*s = AgentMCPServerSpec{}
+		return nil
+	}
+
+	switch raw[0] {
+	case '"':
+		var name string
+		if err := json.Unmarshal(raw, &name); err != nil {
+			return err
+		}
+		*s = AgentMCPServerSpec{Name: name}
+	case '{':
+		var inline map[string]MCPServerConfig
+		if err := json.Unmarshal(raw, &inline); err != nil {
+			return err
+		}
+		*s = AgentMCPServerSpec{Inline: inline}
+	default:
+		return fmt.Errorf("agent MCP server spec must be string or object")
+	}
+	return nil
 }
 
 // SessionOptions configures session behavior.
@@ -1009,11 +1165,11 @@ type SessionOptions struct {
 
 // MCPServerConfig configures an MCP server.
 type MCPServerConfig struct {
-	Type    string            // "stdio" or "socket"
-	Command string            // Command to start server (for stdio)
-	Args    []string          // Command arguments
-	Env     map[string]string // Environment variables
-	Address string            // Socket address (for socket type)
+	Type    string            `json:"type,omitempty"`    // "stdio" or "socket"
+	Command string            `json:"command,omitempty"` // Command to start server (for stdio)
+	Args    []string          `json:"args,omitempty"`    // Command arguments
+	Env     map[string]string `json:"env,omitempty"`     // Environment variables
+	Address string            `json:"address,omitempty"` // Socket address (for socket type)
 }
 
 // SkillsConfig controls how Skills are loaded.

--- a/options.go
+++ b/options.go
@@ -1130,6 +1130,11 @@ func (s *AgentMCPServerSpec) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
+	// json.RawMessage preserves leading whitespace, so skip it before
+	// dispatching on the first significant byte.
+	for len(raw) > 0 && (raw[0] == ' ' || raw[0] == '\t' || raw[0] == '\n' || raw[0] == '\r') {
+		raw = raw[1:]
+	}
 	if len(raw) == 0 || string(raw) == "null" {
 		*s = AgentMCPServerSpec{}
 		return nil

--- a/protocol.go
+++ b/protocol.go
@@ -90,6 +90,14 @@ func (p *Protocol) Initialize(ctx context.Context) error {
 		excludeDynamicSections = &trueVal
 	}
 
+	var agents map[string]interface{}
+	if len(p.options.Agents) > 0 {
+		agents = make(map[string]interface{}, len(p.options.Agents))
+		for k, v := range p.options.Agents {
+			agents[k] = v
+		}
+	}
+
 	// Build initialization request in TypeScript SDK format.
 	requestID := p.nextRequestID()
 	req := SDKControlRequest{
@@ -102,6 +110,7 @@ func (p *Protocol) Initialize(ctx context.Context) error {
 			SystemPrompt:           p.options.SystemPrompt,
 			PlanModeInstructions:   p.options.PlanModeInstructions,
 			ExcludeDynamicSections: excludeDynamicSections,
+			Agents:                 agents,
 			Title:                  p.options.Title,
 			Skills:                 p.options.Skills,
 			PromptSuggestions:      p.options.PromptSuggestions,

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -137,6 +137,32 @@ func TestProtocolInitializeOptions(t *testing.T) {
 			},
 			unexpected: []string{"excludeDynamicSections"},
 		},
+		{
+			name: "agents wired through",
+			configure: func(opts *Options) {
+				WithAgents(map[string]AgentDefinition{
+					"reviewer": {
+						Description: "Reviews Go changes",
+						Prompt:      "Review carefully",
+						Tools:       []string{"Read", "Grep"},
+					},
+				})(opts)
+			},
+			expected: map[string]interface{}{
+				"agents": map[string]interface{}{
+					"reviewer": map[string]interface{}{
+						"description": "Reviews Go changes",
+						"prompt":      "Review carefully",
+						"tools":       []interface{}{"Read", "Grep"},
+					},
+				},
+			},
+		},
+		{
+			name:       "no agents omits key",
+			configure:  func(opts *Options) {},
+			unexpected: []string{"agents"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Extends `AgentDefinition` with the v0.2.119 fields from `sdk.d.ts` L38-L92: `DisallowedTools`, `MCPServers`, `CriticalSystemReminderExperimental`, `Skills`, `InitialPrompt`, `MaxTurns`, `Background`, `Memory`, `Effort`, `PermissionMode`. Adds JSON tags to existing fields.
- New union types with custom marshalers:
  - `AgentMCPServerSpec` — TS `string | Record<string, McpServerConfigForProcessTransport>`. Either `Name` (named ref) or `Inline` (local definition).
  - `AgentEffort` — TS `EffortLevel | number`. Either `Level` or `Numeric`.
  - `AgentMemoryScope` — `user` / `project` / `local`.
- Wires `Options.Agents` through `Protocol.Initialize` to `SDKControlRequestBody.Agents`. The TS SDK passes agents on the `initialize` control body (`sdk.d.ts` L2516), not argv. Previously the field was a stub — agents never reached the CLI.
- Adds JSON tags to `MCPServerConfig` so inline agent server specs serialize with TS-matching lowercase keys.

## Out of scope
- `AgentInfo` parsing in `SDKControlInitializeResponse` (PR 18).
- New hook events that mention agents (PR 8).
- Refactoring `MCPServerConfig` into per-transport types (PR 11).

## Test plan
- [x] `go test ./...`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `messages_test.go` round-trips `AgentDefinition` with every new field, plus `AgentMCPServerSpec` (name + inline), `AgentEffort` (level + numeric), `AgentMemoryScope` constants.
- [x] `protocol_test.go` `TestProtocolInitializeOptions` adds cases for `Options.Agents` wiring through to the init body and for nil agents omitting the `agents` key.

Tracks v0.2.119 catchup PLAN.md PR #7.