### PR TITLE
hooks: add 12 v0.2.119 shape-compatible events

### DIFF
--- a/options.go
+++ b/options.go
@@ -697,6 +697,12 @@ func (PermissionDeny) IsAllow() bool { return false }
 type HookType string
 
 const (
+	// HookTypeConfigChange fires when configuration changes.
+	HookTypeConfigChange HookType = "ConfigChange"
+
+	// HookTypeInstructionsLoaded fires when instruction files are loaded.
+	HookTypeInstructionsLoaded HookType = "InstructionsLoaded"
+
 	// HookTypePreToolUse fires before tool execution.
 	HookTypePreToolUse HookType = "PreToolUse"
 
@@ -730,8 +736,38 @@ const (
 	// HookTypePreCompact fires before context compaction.
 	HookTypePreCompact HookType = "PreCompact"
 
+	// HookTypePostCompact fires after context compaction.
+	HookTypePostCompact HookType = "PostCompact"
+
+	// HookTypePostToolBatch fires after a batch of tool calls completes.
+	HookTypePostToolBatch HookType = "PostToolBatch"
+
 	// HookTypePermissionRequest fires when permission check requested.
 	HookTypePermissionRequest HookType = "PermissionRequest"
+
+	// HookTypeSetup fires during setup.
+	HookTypeSetup HookType = "Setup"
+
+	// HookTypeStopFailure fires when a stop attempt fails.
+	HookTypeStopFailure HookType = "StopFailure"
+
+	// HookTypeTaskCompleted fires when a task completes.
+	HookTypeTaskCompleted HookType = "TaskCompleted"
+
+	// HookTypeTaskCreated fires when a task is created.
+	HookTypeTaskCreated HookType = "TaskCreated"
+
+	// HookTypeTeammateIdle fires when a teammate becomes idle.
+	HookTypeTeammateIdle HookType = "TeammateIdle"
+
+	// HookTypeUserPromptExpansion fires when a prompt expansion occurs.
+	HookTypeUserPromptExpansion HookType = "UserPromptExpansion"
+
+	// HookTypeWorktreeCreate fires when a worktree is created.
+	HookTypeWorktreeCreate HookType = "WorktreeCreate"
+
+	// HookTypeWorktreeRemove fires when a worktree is removed.
+	HookTypeWorktreeRemove HookType = "WorktreeRemove"
 )
 
 // HookConfig defines a lifecycle callback.
@@ -761,6 +797,36 @@ type BaseHookInput struct {
 	AgentID        string `json:"agent_id,omitempty"`
 	AgentType      string `json:"agent_type,omitempty"`
 }
+
+// ConfigChangeInput contains data for ConfigChange hooks.
+type ConfigChangeInput struct {
+	BaseHookInput
+	Source   string `json:"source"`
+	FilePath string `json:"file_path,omitempty"`
+}
+
+// HookType implements HookInput.
+func (ConfigChangeInput) HookType() HookType { return HookTypeConfigChange }
+
+// Base implements HookInput.
+func (i ConfigChangeInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// InstructionsLoadedInput contains data for InstructionsLoaded hooks.
+type InstructionsLoadedInput struct {
+	BaseHookInput
+	FilePath        string   `json:"file_path"`
+	MemoryType      string   `json:"memory_type"`
+	LoadReason      string   `json:"load_reason"`
+	Globs           []string `json:"globs,omitempty"`
+	TriggerFilePath string   `json:"trigger_file_path,omitempty"`
+	ParentFilePath  string   `json:"parent_file_path,omitempty"`
+}
+
+// HookType implements HookInput.
+func (InstructionsLoadedInput) HookType() HookType { return HookTypeInstructionsLoaded }
+
+// Base implements HookInput.
+func (i InstructionsLoadedInput) Base() BaseHookInput { return i.BaseHookInput }
 
 // PreToolUseInput contains data for PreToolUse hooks.
 type PreToolUseInput struct {
@@ -848,6 +914,39 @@ func (PreCompactInput) HookType() HookType { return HookTypePreCompact }
 // Base implements HookInput.
 func (i PreCompactInput) Base() BaseHookInput { return i.BaseHookInput }
 
+// PostCompactInput contains data for PostCompact hooks.
+type PostCompactInput struct {
+	BaseHookInput
+	Trigger        string `json:"trigger"`
+	CompactSummary string `json:"compact_summary"`
+}
+
+// HookType implements HookInput.
+func (PostCompactInput) HookType() HookType { return HookTypePostCompact }
+
+// Base implements HookInput.
+func (i PostCompactInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// PostToolBatchInput contains data for PostToolBatch hooks.
+type PostToolBatchInput struct {
+	BaseHookInput
+	ToolCalls []PostToolBatchToolCall `json:"tool_calls"`
+}
+
+// PostToolBatchToolCall contains one tool call result from a PostToolBatch hook.
+type PostToolBatchToolCall struct {
+	ToolName     string          `json:"tool_name"`
+	ToolInput    json.RawMessage `json:"tool_input"`
+	ToolUseID    string          `json:"tool_use_id"`
+	ToolResponse json.RawMessage `json:"tool_response,omitempty"`
+}
+
+// HookType implements HookInput.
+func (PostToolBatchInput) HookType() HookType { return HookTypePostToolBatch }
+
+// Base implements HookInput.
+func (i PostToolBatchInput) Base() BaseHookInput { return i.BaseHookInput }
+
 // PostToolUseFailureInput contains data for PostToolUseFailure hooks.
 type PostToolUseFailureInput struct {
 	BaseHookInput
@@ -926,6 +1025,130 @@ func (PermissionRequestInput) HookType() HookType { return HookTypePermissionReq
 
 // Base implements HookInput.
 func (i PermissionRequestInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// SetupInput contains data for Setup hooks.
+type SetupInput struct {
+	BaseHookInput
+	Trigger string `json:"trigger"`
+}
+
+// HookType implements HookInput.
+func (SetupInput) HookType() HookType { return HookTypeSetup }
+
+// Base implements HookInput.
+func (i SetupInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// AssistantMessageError identifies an assistant message error code.
+type AssistantMessageError string
+
+const (
+	AssistantMessageErrorAuthenticationFailed AssistantMessageError = "authentication_failed"
+	AssistantMessageErrorBillingError         AssistantMessageError = "billing_error"
+	AssistantMessageErrorRateLimit            AssistantMessageError = "rate_limit"
+	AssistantMessageErrorInvalidRequest       AssistantMessageError = "invalid_request"
+	AssistantMessageErrorServerError          AssistantMessageError = "server_error"
+	AssistantMessageErrorUnknown              AssistantMessageError = "unknown"
+	AssistantMessageErrorMaxOutputTokens      AssistantMessageError = "max_output_tokens"
+)
+
+// StopFailureInput contains data for StopFailure hooks.
+type StopFailureInput struct {
+	BaseHookInput
+	Error                AssistantMessageError `json:"error"`
+	ErrorDetails         string                `json:"error_details,omitempty"`
+	LastAssistantMessage string                `json:"last_assistant_message,omitempty"`
+}
+
+// HookType implements HookInput.
+func (StopFailureInput) HookType() HookType { return HookTypeStopFailure }
+
+// Base implements HookInput.
+func (i StopFailureInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// TaskCompletedInput contains data for TaskCompleted hooks.
+type TaskCompletedInput struct {
+	BaseHookInput
+	TaskID          string `json:"task_id"`
+	TaskSubject     string `json:"task_subject"`
+	TaskDescription string `json:"task_description,omitempty"`
+	TeammateName    string `json:"teammate_name,omitempty"`
+	TeamName        string `json:"team_name,omitempty"`
+}
+
+// HookType implements HookInput.
+func (TaskCompletedInput) HookType() HookType { return HookTypeTaskCompleted }
+
+// Base implements HookInput.
+func (i TaskCompletedInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// TaskCreatedInput contains data for TaskCreated hooks.
+type TaskCreatedInput struct {
+	BaseHookInput
+	TaskID          string `json:"task_id"`
+	TaskSubject     string `json:"task_subject"`
+	TaskDescription string `json:"task_description,omitempty"`
+	TeammateName    string `json:"teammate_name,omitempty"`
+	TeamName        string `json:"team_name,omitempty"`
+}
+
+// HookType implements HookInput.
+func (TaskCreatedInput) HookType() HookType { return HookTypeTaskCreated }
+
+// Base implements HookInput.
+func (i TaskCreatedInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// TeammateIdleInput contains data for TeammateIdle hooks.
+type TeammateIdleInput struct {
+	BaseHookInput
+	TeammateName string `json:"teammate_name"`
+	TeamName     string `json:"team_name"`
+}
+
+// HookType implements HookInput.
+func (TeammateIdleInput) HookType() HookType { return HookTypeTeammateIdle }
+
+// Base implements HookInput.
+func (i TeammateIdleInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// UserPromptExpansionInput contains data for UserPromptExpansion hooks.
+type UserPromptExpansionInput struct {
+	BaseHookInput
+	ExpansionType string `json:"expansion_type"`
+	CommandName   string `json:"command_name"`
+	CommandArgs   string `json:"command_args"`
+	CommandSource string `json:"command_source,omitempty"`
+	Prompt        string `json:"prompt"`
+}
+
+// HookType implements HookInput.
+func (UserPromptExpansionInput) HookType() HookType { return HookTypeUserPromptExpansion }
+
+// Base implements HookInput.
+func (i UserPromptExpansionInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// WorktreeCreateInput contains data for WorktreeCreate hooks.
+type WorktreeCreateInput struct {
+	BaseHookInput
+	Name string `json:"name"`
+}
+
+// HookType implements HookInput.
+func (WorktreeCreateInput) HookType() HookType { return HookTypeWorktreeCreate }
+
+// Base implements HookInput.
+func (i WorktreeCreateInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// WorktreeRemoveInput contains data for WorktreeRemove hooks.
+type WorktreeRemoveInput struct {
+	BaseHookInput
+	WorktreePath string `json:"worktree_path"`
+}
+
+// HookType implements HookInput.
+func (WorktreeRemoveInput) HookType() HookType { return HookTypeWorktreeRemove }
+
+// Base implements HookInput.
+func (i WorktreeRemoveInput) Base() BaseHookInput { return i.BaseHookInput }
 
 // HookJSONOutput is the output format for hook callbacks.
 // This is what hooks can return to control behavior.

--- a/protocol.go
+++ b/protocol.go
@@ -272,6 +272,22 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 	// Build hook input based on type.
 	var input HookInput
 	switch HookType(hookType) {
+	case HookTypeConfigChange:
+		input = ConfigChangeInput{
+			BaseHookInput: base,
+			Source:        getString(inputData, "source"),
+			FilePath:      getString(inputData, "file_path"),
+		}
+	case HookTypeInstructionsLoaded:
+		input = InstructionsLoadedInput{
+			BaseHookInput:   base,
+			FilePath:        getString(inputData, "file_path"),
+			MemoryType:      getString(inputData, "memory_type"),
+			LoadReason:      getString(inputData, "load_reason"),
+			Globs:           getStringSlice(inputData, "globs"),
+			TriggerFilePath: getString(inputData, "trigger_file_path"),
+			ParentFilePath:  getString(inputData, "parent_file_path"),
+		}
 	case HookTypePreToolUse:
 		input = PreToolUseInput{
 			BaseHookInput: base,
@@ -312,6 +328,17 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 			Trigger:       getString(inputData, "trigger"),
 			MessageCount:  getInt(inputData, "message_count"),
 		}
+	case HookTypePostCompact:
+		input = PostCompactInput{
+			BaseHookInput:  base,
+			Trigger:        getString(inputData, "trigger"),
+			CompactSummary: getString(inputData, "compact_summary"),
+		}
+	case HookTypePostToolBatch:
+		input = PostToolBatchInput{
+			BaseHookInput: base,
+			ToolCalls:     getPostToolBatchToolCalls(inputData),
+		}
 	case HookTypePostToolUseFailure:
 		input = PostToolUseFailureInput{
 			BaseHookInput: base,
@@ -347,6 +374,61 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 			BaseHookInput: base,
 			ToolName:      getString(inputData, "tool_name"),
 			ToolInput:     marshalJSON(inputData["tool_input"]),
+		}
+	case HookTypeSetup:
+		input = SetupInput{
+			BaseHookInput: base,
+			Trigger:       getString(inputData, "trigger"),
+		}
+	case HookTypeStopFailure:
+		input = StopFailureInput{
+			BaseHookInput:        base,
+			Error:                AssistantMessageError(getString(inputData, "error")),
+			ErrorDetails:         getString(inputData, "error_details"),
+			LastAssistantMessage: getString(inputData, "last_assistant_message"),
+		}
+	case HookTypeTaskCompleted:
+		input = TaskCompletedInput{
+			BaseHookInput:   base,
+			TaskID:          getString(inputData, "task_id"),
+			TaskSubject:     getString(inputData, "task_subject"),
+			TaskDescription: getString(inputData, "task_description"),
+			TeammateName:    getString(inputData, "teammate_name"),
+			TeamName:        getString(inputData, "team_name"),
+		}
+	case HookTypeTaskCreated:
+		input = TaskCreatedInput{
+			BaseHookInput:   base,
+			TaskID:          getString(inputData, "task_id"),
+			TaskSubject:     getString(inputData, "task_subject"),
+			TaskDescription: getString(inputData, "task_description"),
+			TeammateName:    getString(inputData, "teammate_name"),
+			TeamName:        getString(inputData, "team_name"),
+		}
+	case HookTypeTeammateIdle:
+		input = TeammateIdleInput{
+			BaseHookInput: base,
+			TeammateName:  getString(inputData, "teammate_name"),
+			TeamName:      getString(inputData, "team_name"),
+		}
+	case HookTypeUserPromptExpansion:
+		input = UserPromptExpansionInput{
+			BaseHookInput: base,
+			ExpansionType: getString(inputData, "expansion_type"),
+			CommandName:   getString(inputData, "command_name"),
+			CommandArgs:   getString(inputData, "command_args"),
+			CommandSource: getString(inputData, "command_source"),
+			Prompt:        getString(inputData, "prompt"),
+		}
+	case HookTypeWorktreeCreate:
+		input = WorktreeCreateInput{
+			BaseHookInput: base,
+			Name:          getString(inputData, "name"),
+		}
+	case HookTypeWorktreeRemove:
+		input = WorktreeRemoveInput{
+			BaseHookInput: base,
+			WorktreePath:  getString(inputData, "worktree_path"),
 		}
 	default:
 		return SDKControlResponse{
@@ -635,6 +717,22 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 	var input HookInput
 
 	switch hookEventName {
+	case "ConfigChange":
+		input = ConfigChangeInput{
+			BaseHookInput: base,
+			Source:        getString(hookInput, "source"),
+			FilePath:      getString(hookInput, "file_path"),
+		}
+	case "InstructionsLoaded":
+		input = InstructionsLoadedInput{
+			BaseHookInput:   base,
+			FilePath:        getString(hookInput, "file_path"),
+			MemoryType:      getString(hookInput, "memory_type"),
+			LoadReason:      getString(hookInput, "load_reason"),
+			Globs:           getStringSlice(hookInput, "globs"),
+			TriggerFilePath: getString(hookInput, "trigger_file_path"),
+			ParentFilePath:  getString(hookInput, "parent_file_path"),
+		}
 	case "PreToolUse":
 		input = PreToolUseInput{
 			BaseHookInput: base,
@@ -675,6 +773,17 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 			Trigger:       getString(hookInput, "trigger"),
 			MessageCount:  getInt(hookInput, "message_count"),
 		}
+	case "PostCompact":
+		input = PostCompactInput{
+			BaseHookInput:  base,
+			Trigger:        getString(hookInput, "trigger"),
+			CompactSummary: getString(hookInput, "compact_summary"),
+		}
+	case "PostToolBatch":
+		input = PostToolBatchInput{
+			BaseHookInput: base,
+			ToolCalls:     getPostToolBatchToolCalls(hookInput),
+		}
 	case "PostToolUseFailure":
 		input = PostToolUseFailureInput{
 			BaseHookInput: base,
@@ -710,6 +819,61 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 			BaseHookInput: base,
 			ToolName:      getString(hookInput, "tool_name"),
 			ToolInput:     marshalJSON(hookInput["tool_input"]),
+		}
+	case "Setup":
+		input = SetupInput{
+			BaseHookInput: base,
+			Trigger:       getString(hookInput, "trigger"),
+		}
+	case "StopFailure":
+		input = StopFailureInput{
+			BaseHookInput:        base,
+			Error:                AssistantMessageError(getString(hookInput, "error")),
+			ErrorDetails:         getString(hookInput, "error_details"),
+			LastAssistantMessage: getString(hookInput, "last_assistant_message"),
+		}
+	case "TaskCompleted":
+		input = TaskCompletedInput{
+			BaseHookInput:   base,
+			TaskID:          getString(hookInput, "task_id"),
+			TaskSubject:     getString(hookInput, "task_subject"),
+			TaskDescription: getString(hookInput, "task_description"),
+			TeammateName:    getString(hookInput, "teammate_name"),
+			TeamName:        getString(hookInput, "team_name"),
+		}
+	case "TaskCreated":
+		input = TaskCreatedInput{
+			BaseHookInput:   base,
+			TaskID:          getString(hookInput, "task_id"),
+			TaskSubject:     getString(hookInput, "task_subject"),
+			TaskDescription: getString(hookInput, "task_description"),
+			TeammateName:    getString(hookInput, "teammate_name"),
+			TeamName:        getString(hookInput, "team_name"),
+		}
+	case "TeammateIdle":
+		input = TeammateIdleInput{
+			BaseHookInput: base,
+			TeammateName:  getString(hookInput, "teammate_name"),
+			TeamName:      getString(hookInput, "team_name"),
+		}
+	case "UserPromptExpansion":
+		input = UserPromptExpansionInput{
+			BaseHookInput: base,
+			ExpansionType: getString(hookInput, "expansion_type"),
+			CommandName:   getString(hookInput, "command_name"),
+			CommandArgs:   getString(hookInput, "command_args"),
+			CommandSource: getString(hookInput, "command_source"),
+			Prompt:        getString(hookInput, "prompt"),
+		}
+	case "WorktreeCreate":
+		input = WorktreeCreateInput{
+			BaseHookInput: base,
+			Name:          getString(hookInput, "name"),
+		}
+	case "WorktreeRemove":
+		input = WorktreeRemoveInput{
+			BaseHookInput: base,
+			WorktreePath:  getString(hookInput, "worktree_path"),
 		}
 	default:
 		return SDKControlResponse{
@@ -1022,6 +1186,44 @@ func marshalJSON(v interface{}) []byte {
 	}
 	data, _ := json.Marshal(v)
 	return data
+}
+
+func getStringSlice(m map[string]interface{}, key string) []string {
+	raw, ok := m[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func getPostToolBatchToolCalls(m map[string]interface{}) []PostToolBatchToolCall {
+	raw, ok := m["tool_calls"].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]PostToolBatchToolCall, 0, len(raw))
+	for _, v := range raw {
+		entry, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		call := PostToolBatchToolCall{
+			ToolName:  getString(entry, "tool_name"),
+			ToolInput: marshalJSON(entry["tool_input"]),
+			ToolUseID: getString(entry, "tool_use_id"),
+		}
+		if resp, ok := entry["tool_response"]; ok && resp != nil {
+			call.ToolResponse = marshalJSON(resp)
+		}
+		out = append(out, call)
+	}
+	return out
 }
 
 // buildHookResponse constructs the response data map for hook callbacks.

--- a/protocol.go
+++ b/protocol.go
@@ -1218,7 +1218,10 @@ func getPostToolBatchToolCalls(m map[string]interface{}) []PostToolBatchToolCall
 			ToolInput: marshalJSON(entry["tool_input"]),
 			ToolUseID: getString(entry, "tool_use_id"),
 		}
-		if resp, ok := entry["tool_response"]; ok && resp != nil {
+		// Preserve the absent-vs-null distinction: TS `tool_response?: unknown`
+		// allows an explicit null payload, which must round-trip as "null" rather
+		// than be conflated with the key being missing.
+		if resp, ok := entry["tool_response"]; ok {
 			call.ToolResponse = marshalJSON(resp)
 		}
 		out = append(out, call)

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1886,13 +1886,19 @@ func TestHandleHookCallback_ShapeCompatibleEvents(t *testing.T) {
 		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
 			ev, ok := input.(PostToolBatchInput)
 			require.True(t, ok)
-			require.Len(t, ev.ToolCalls, 2)
+			require.Len(t, ev.ToolCalls, 3)
 			assert.Equal(t, "Read", ev.ToolCalls[0].ToolName)
 			assert.Equal(t, "tu_1", ev.ToolCalls[0].ToolUseID)
 			assert.JSONEq(t, `{"file_path":"a.go"}`, string(ev.ToolCalls[0].ToolInput))
 			assert.JSONEq(t, `"contents"`, string(ev.ToolCalls[0].ToolResponse))
+
+			// Absent tool_response → empty.
 			assert.Equal(t, "Grep", ev.ToolCalls[1].ToolName)
 			assert.Empty(t, ev.ToolCalls[1].ToolResponse)
+
+			// Explicit JSON null → preserved as "null", not conflated with absent.
+			assert.Equal(t, "Bash", ev.ToolCalls[2].ToolName)
+			assert.Equal(t, "null", string(ev.ToolCalls[2].ToolResponse))
 			return HookResult{Continue: true}, nil
 		}
 		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
@@ -1913,6 +1919,12 @@ func TestHandleHookCallback_ShapeCompatibleEvents(t *testing.T) {
 							"tool_name":   "Grep",
 							"tool_input":  map[string]interface{}{"pattern": "foo"},
 							"tool_use_id": "tu_2",
+						},
+						map[string]interface{}{
+							"tool_name":     "Bash",
+							"tool_input":    map[string]interface{}{"command": "true"},
+							"tool_use_id":   "tu_3",
+							"tool_response": nil,
 						},
 					},
 				},

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1789,3 +1789,347 @@ func TestBuildHookResponse_PreToolUseUpdatedInput(t *testing.T) {
 		assert.False(t, hasModify)
 	})
 }
+
+// TestHandleHookCallback_ShapeCompatibleEvents covers the 12 v0.2.119 events
+// added in PR 8b. Each subtest exercises one event end-to-end through one of
+// the two dispatch paths and asserts every event-specific field on the parsed
+// input.
+func TestHandleHookCallback_ShapeCompatibleEvents(t *testing.T) {
+	t.Run("ConfigChange via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(ConfigChangeInput)
+			require.True(t, ok)
+			assert.Equal(t, "user_settings", ev.Source)
+			assert.Equal(t, "/home/u/.claude/settings.json", ev.FilePath)
+			assert.Equal(t, "agent-x", ev.Base().AgentID)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event": "ConfigChange",
+					"source":     "user_settings",
+					"file_path":  "/home/u/.claude/settings.json",
+					"agent_id":   "agent-x",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("InstructionsLoaded via SDK path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(InstructionsLoadedInput)
+			require.True(t, ok)
+			assert.Equal(t, "/proj/CLAUDE.md", ev.FilePath)
+			assert.Equal(t, "Project", ev.MemoryType)
+			assert.Equal(t, "session_start", ev.LoadReason)
+			assert.Equal(t, []string{"**/*.md"}, ev.Globs)
+			assert.Equal(t, "/proj/parent.md", ev.ParentFilePath)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+			RequestID: "r",
+			Request: SDKControlRequestBody{
+				Subtype:    "hook_callback",
+				CallbackID: "h",
+				Input: map[string]interface{}{
+					"hook_event_name":  "InstructionsLoaded",
+					"file_path":        "/proj/CLAUDE.md",
+					"memory_type":      "Project",
+					"load_reason":      "session_start",
+					"globs":            []interface{}{"**/*.md"},
+					"parent_file_path": "/proj/parent.md",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("PostCompact via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(PostCompactInput)
+			require.True(t, ok)
+			assert.Equal(t, "auto", ev.Trigger)
+			assert.Equal(t, "summary text", ev.CompactSummary)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event":      "PostCompact",
+					"trigger":         "auto",
+					"compact_summary": "summary text",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("PostToolBatch via SDK path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(PostToolBatchInput)
+			require.True(t, ok)
+			require.Len(t, ev.ToolCalls, 2)
+			assert.Equal(t, "Read", ev.ToolCalls[0].ToolName)
+			assert.Equal(t, "tu_1", ev.ToolCalls[0].ToolUseID)
+			assert.JSONEq(t, `{"file_path":"a.go"}`, string(ev.ToolCalls[0].ToolInput))
+			assert.JSONEq(t, `"contents"`, string(ev.ToolCalls[0].ToolResponse))
+			assert.Equal(t, "Grep", ev.ToolCalls[1].ToolName)
+			assert.Empty(t, ev.ToolCalls[1].ToolResponse)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+			RequestID: "r",
+			Request: SDKControlRequestBody{
+				Subtype:    "hook_callback",
+				CallbackID: "h",
+				Input: map[string]interface{}{
+					"hook_event_name": "PostToolBatch",
+					"tool_calls": []interface{}{
+						map[string]interface{}{
+							"tool_name":     "Read",
+							"tool_input":    map[string]interface{}{"file_path": "a.go"},
+							"tool_use_id":   "tu_1",
+							"tool_response": "contents",
+						},
+						map[string]interface{}{
+							"tool_name":   "Grep",
+							"tool_input":  map[string]interface{}{"pattern": "foo"},
+							"tool_use_id": "tu_2",
+						},
+					},
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("Setup via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(SetupInput)
+			require.True(t, ok)
+			assert.Equal(t, "init", ev.Trigger)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event": "Setup",
+					"trigger":    "init",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("StopFailure via SDK path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(StopFailureInput)
+			require.True(t, ok)
+			assert.Equal(t, AssistantMessageErrorRateLimit, ev.Error)
+			assert.Equal(t, "rate limited by upstream", ev.ErrorDetails)
+			assert.Equal(t, "partial answer", ev.LastAssistantMessage)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+			RequestID: "r",
+			Request: SDKControlRequestBody{
+				Subtype:    "hook_callback",
+				CallbackID: "h",
+				Input: map[string]interface{}{
+					"hook_event_name":        "StopFailure",
+					"error":                  "rate_limit",
+					"error_details":          "rate limited by upstream",
+					"last_assistant_message": "partial answer",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("TaskCompleted via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(TaskCompletedInput)
+			require.True(t, ok)
+			assert.Equal(t, "task_42", ev.TaskID)
+			assert.Equal(t, "ship the thing", ev.TaskSubject)
+			assert.Equal(t, "longer description", ev.TaskDescription)
+			assert.Equal(t, "alice", ev.TeammateName)
+			assert.Equal(t, "platform", ev.TeamName)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event":       "TaskCompleted",
+					"task_id":          "task_42",
+					"task_subject":     "ship the thing",
+					"task_description": "longer description",
+					"teammate_name":    "alice",
+					"team_name":        "platform",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("TaskCreated via SDK path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(TaskCreatedInput)
+			require.True(t, ok)
+			assert.Equal(t, "task_99", ev.TaskID)
+			assert.Equal(t, "draft proposal", ev.TaskSubject)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+			RequestID: "r",
+			Request: SDKControlRequestBody{
+				Subtype:    "hook_callback",
+				CallbackID: "h",
+				Input: map[string]interface{}{
+					"hook_event_name": "TaskCreated",
+					"task_id":         "task_99",
+					"task_subject":    "draft proposal",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("TeammateIdle via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(TeammateIdleInput)
+			require.True(t, ok)
+			assert.Equal(t, "bob", ev.TeammateName)
+			assert.Equal(t, "platform", ev.TeamName)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event":    "TeammateIdle",
+					"teammate_name": "bob",
+					"team_name":     "platform",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("UserPromptExpansion via SDK path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(UserPromptExpansionInput)
+			require.True(t, ok)
+			assert.Equal(t, "slash_command", ev.ExpansionType)
+			assert.Equal(t, "review", ev.CommandName)
+			assert.Equal(t, "PR-30", ev.CommandArgs)
+			assert.Equal(t, "user", ev.CommandSource)
+			assert.Equal(t, "expanded prompt body", ev.Prompt)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+			RequestID: "r",
+			Request: SDKControlRequestBody{
+				Subtype:    "hook_callback",
+				CallbackID: "h",
+				Input: map[string]interface{}{
+					"hook_event_name": "UserPromptExpansion",
+					"expansion_type":  "slash_command",
+					"command_name":    "review",
+					"command_args":    "PR-30",
+					"command_source":  "user",
+					"prompt":          "expanded prompt body",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("WorktreeCreate via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(WorktreeCreateInput)
+			require.True(t, ok)
+			assert.Equal(t, "feature-x", ev.Name)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event": "WorktreeCreate",
+					"name":       "feature-x",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("WorktreeRemove via SDK path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(WorktreeRemoveInput)
+			require.True(t, ok)
+			assert.Equal(t, "/repo/worktrees/feature-x", ev.WorktreePath)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+			RequestID: "r",
+			Request: SDKControlRequestBody{
+				Subtype:    "hook_callback",
+				CallbackID: "h",
+				Input: map[string]interface{}{
+					"hook_event_name": "WorktreeRemove",
+					"worktree_path":   "/repo/worktrees/feature-x",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+}


### PR DESCRIPTION
## Summary
Adds the 12 hook events from `sdk.d.ts` v0.2.119 that have no retry/watchPaths semantics. The remaining 5 land in PR 8c.

New events with their TS sdk.d.ts line refs:
- `ConfigChange` (L190-L194)
- `InstructionsLoaded` (L826-L834)
- `PostCompact` (L1829-L1836)
- `PostToolBatch` (L1841-L1856) plus `PostToolBatchToolCall`
- `Setup` (L5045-L5048)
- `StopFailure` (L5149-L5154) plus the `AssistantMessageError` typed string and seven constants
- `TaskCompleted` (L5221-L5228)
- `TaskCreated` (L5230-L5237)
- `TeammateIdle` (L5239-L5243)
- `UserPromptExpansion` (L5370-L5377)
- `WorktreeCreate` (L5415-L5418)
- `WorktreeRemove` (L5428-L5431)

For each event: a `HookType` constant, an input struct embedding `BaseHookInput`, `HookType()`/`Base()` methods, and dispatch arms in both `handleHookCallback` (legacy path) and `handleSDKHookCallback` (SDK-format path). Adds two helpers: `getStringSlice` and `getPostToolBatchToolCalls`.

## Out of scope
- 5 retry/watchPaths events (`PermissionDenied`, `CwdChanged`, `FileChanged`, `Elicitation`, `ElicitationResult`) — PR 8c.
- `watchPaths` semantics on hook outputs — PR 9.
- Hook matcher / `once` / `asyncRewake` — PR 10.

## Test plan
- [x] `go test ./...`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `protocol_test.go` `TestHandleHookCallback_ShapeCompatibleEvents` — one focused subtest per event, split across both dispatch paths, asserting every event-specific field. `PostToolBatch` covers both `tool_response` present and absent.

Tracks v0.2.119 catchup PLAN.md PR #8 (split: this is PR 8b).