### PR TITLE
hooks: add 5 v0.2.119 retry/watchPaths events

### DIFF
--- a/options.go
+++ b/options.go
@@ -745,6 +745,21 @@ const (
 	// HookTypePermissionRequest fires when permission check requested.
 	HookTypePermissionRequest HookType = "PermissionRequest"
 
+	// HookTypePermissionDenied fires when permission is denied.
+	HookTypePermissionDenied HookType = "PermissionDenied"
+
+	// HookTypeCwdChanged fires when the current working directory changes.
+	HookTypeCwdChanged HookType = "CwdChanged"
+
+	// HookTypeFileChanged fires when a watched file changes.
+	HookTypeFileChanged HookType = "FileChanged"
+
+	// HookTypeElicitation fires when an MCP server requests elicitation.
+	HookTypeElicitation HookType = "Elicitation"
+
+	// HookTypeElicitationResult fires when an elicitation response is available.
+	HookTypeElicitationResult HookType = "ElicitationResult"
+
 	// HookTypeSetup fires during setup.
 	HookTypeSetup HookType = "Setup"
 
@@ -1025,6 +1040,80 @@ func (PermissionRequestInput) HookType() HookType { return HookTypePermissionReq
 
 // Base implements HookInput.
 func (i PermissionRequestInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// PermissionDeniedInput contains data for PermissionDenied hooks.
+type PermissionDeniedInput struct {
+	BaseHookInput
+	ToolName  string          `json:"tool_name"`
+	ToolInput json.RawMessage `json:"tool_input"`
+	ToolUseID string          `json:"tool_use_id"`
+	Reason    string          `json:"reason"`
+}
+
+// HookType implements HookInput.
+func (PermissionDeniedInput) HookType() HookType { return HookTypePermissionDenied }
+
+// Base implements HookInput.
+func (i PermissionDeniedInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// CwdChangedInput contains data for CwdChanged hooks.
+type CwdChangedInput struct {
+	BaseHookInput
+	OldCwd string `json:"old_cwd"`
+	NewCwd string `json:"new_cwd"`
+}
+
+// HookType implements HookInput.
+func (CwdChangedInput) HookType() HookType { return HookTypeCwdChanged }
+
+// Base implements HookInput.
+func (i CwdChangedInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// FileChangedInput contains data for FileChanged hooks.
+type FileChangedInput struct {
+	BaseHookInput
+	FilePath string `json:"file_path"`
+	Event    string `json:"event"`
+}
+
+// HookType implements HookInput.
+func (FileChangedInput) HookType() HookType { return HookTypeFileChanged }
+
+// Base implements HookInput.
+func (i FileChangedInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// ElicitationInput contains data for Elicitation hooks.
+type ElicitationInput struct {
+	BaseHookInput
+	MCPServerName   string                 `json:"mcp_server_name"`
+	Message         string                 `json:"message"`
+	Mode            string                 `json:"mode,omitempty"`
+	URL             string                 `json:"url,omitempty"`
+	ElicitationID   string                 `json:"elicitation_id,omitempty"`
+	RequestedSchema map[string]interface{} `json:"requested_schema,omitempty"`
+}
+
+// HookType implements HookInput.
+func (ElicitationInput) HookType() HookType { return HookTypeElicitation }
+
+// Base implements HookInput.
+func (i ElicitationInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// ElicitationResultInput contains data for ElicitationResult hooks.
+type ElicitationResultInput struct {
+	BaseHookInput
+	MCPServerName string                 `json:"mcp_server_name"`
+	ElicitationID string                 `json:"elicitation_id,omitempty"`
+	Mode          string                 `json:"mode,omitempty"`
+	Action        string                 `json:"action"`
+	Content       map[string]interface{} `json:"content,omitempty"`
+}
+
+// HookType implements HookInput.
+func (ElicitationResultInput) HookType() HookType { return HookTypeElicitationResult }
+
+// Base implements HookInput.
+func (i ElicitationResultInput) Base() BaseHookInput { return i.BaseHookInput }
 
 // SetupInput contains data for Setup hooks.
 type SetupInput struct {

--- a/protocol.go
+++ b/protocol.go
@@ -375,6 +375,47 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 			ToolName:      getString(inputData, "tool_name"),
 			ToolInput:     marshalJSON(inputData["tool_input"]),
 		}
+	case HookTypePermissionDenied:
+		input = PermissionDeniedInput{
+			BaseHookInput: base,
+			ToolName:      getString(inputData, "tool_name"),
+			ToolInput:     marshalJSON(inputData["tool_input"]),
+			ToolUseID:     getString(inputData, "tool_use_id"),
+			Reason:        getString(inputData, "reason"),
+		}
+	case HookTypeCwdChanged:
+		input = CwdChangedInput{
+			BaseHookInput: base,
+			OldCwd:        getString(inputData, "old_cwd"),
+			NewCwd:        getString(inputData, "new_cwd"),
+		}
+	case HookTypeFileChanged:
+		input = FileChangedInput{
+			BaseHookInput: base,
+			FilePath:      getString(inputData, "file_path"),
+			Event:         getString(inputData, "event"),
+		}
+	case HookTypeElicitation:
+		requestedSchema, _ := inputData["requested_schema"].(map[string]interface{})
+		input = ElicitationInput{
+			BaseHookInput:   base,
+			MCPServerName:   getString(inputData, "mcp_server_name"),
+			Message:         getString(inputData, "message"),
+			Mode:            getString(inputData, "mode"),
+			URL:             getString(inputData, "url"),
+			ElicitationID:   getString(inputData, "elicitation_id"),
+			RequestedSchema: requestedSchema,
+		}
+	case HookTypeElicitationResult:
+		content, _ := inputData["content"].(map[string]interface{})
+		input = ElicitationResultInput{
+			BaseHookInput: base,
+			MCPServerName: getString(inputData, "mcp_server_name"),
+			ElicitationID: getString(inputData, "elicitation_id"),
+			Mode:          getString(inputData, "mode"),
+			Action:        getString(inputData, "action"),
+			Content:       content,
+		}
 	case HookTypeSetup:
 		input = SetupInput{
 			BaseHookInput: base,
@@ -819,6 +860,47 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 			BaseHookInput: base,
 			ToolName:      getString(hookInput, "tool_name"),
 			ToolInput:     marshalJSON(hookInput["tool_input"]),
+		}
+	case "PermissionDenied":
+		input = PermissionDeniedInput{
+			BaseHookInput: base,
+			ToolName:      getString(hookInput, "tool_name"),
+			ToolInput:     marshalJSON(hookInput["tool_input"]),
+			ToolUseID:     getString(hookInput, "tool_use_id"),
+			Reason:        getString(hookInput, "reason"),
+		}
+	case "CwdChanged":
+		input = CwdChangedInput{
+			BaseHookInput: base,
+			OldCwd:        getString(hookInput, "old_cwd"),
+			NewCwd:        getString(hookInput, "new_cwd"),
+		}
+	case "FileChanged":
+		input = FileChangedInput{
+			BaseHookInput: base,
+			FilePath:      getString(hookInput, "file_path"),
+			Event:         getString(hookInput, "event"),
+		}
+	case "Elicitation":
+		requestedSchema, _ := hookInput["requested_schema"].(map[string]interface{})
+		input = ElicitationInput{
+			BaseHookInput:   base,
+			MCPServerName:   getString(hookInput, "mcp_server_name"),
+			Message:         getString(hookInput, "message"),
+			Mode:            getString(hookInput, "mode"),
+			URL:             getString(hookInput, "url"),
+			ElicitationID:   getString(hookInput, "elicitation_id"),
+			RequestedSchema: requestedSchema,
+		}
+	case "ElicitationResult":
+		content, _ := hookInput["content"].(map[string]interface{})
+		input = ElicitationResultInput{
+			BaseHookInput: base,
+			MCPServerName: getString(hookInput, "mcp_server_name"),
+			ElicitationID: getString(hookInput, "elicitation_id"),
+			Mode:          getString(hookInput, "mode"),
+			Action:        getString(hookInput, "action"),
+			Content:       content,
 		}
 	case "Setup":
 		input = SetupInput{

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -2145,3 +2145,208 @@ func TestHandleHookCallback_ShapeCompatibleEvents(t *testing.T) {
 		assert.Equal(t, "success", resp.Response.Subtype)
 	})
 }
+
+func TestHandleHookCallback_RetryWatchPathsEvents(t *testing.T) {
+	t.Run("CwdChanged via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(CwdChangedInput)
+			require.True(t, ok)
+			assert.Equal(t, "/repo/old", ev.OldCwd)
+			assert.Equal(t, "/repo/new", ev.NewCwd)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event": "CwdChanged",
+					"old_cwd":    "/repo/old",
+					"new_cwd":    "/repo/new",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("FileChanged via SDK path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(FileChangedInput)
+			require.True(t, ok)
+			assert.Equal(t, "/repo/main.go", ev.FilePath)
+			assert.Equal(t, "change", ev.Event)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+			RequestID: "r",
+			Request: SDKControlRequestBody{
+				Subtype:    "hook_callback",
+				CallbackID: "h",
+				Input: map[string]interface{}{
+					"hook_event_name": "FileChanged",
+					"file_path":       "/repo/main.go",
+					"event":           "change",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("PermissionDenied via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(PermissionDeniedInput)
+			require.True(t, ok)
+			assert.Equal(t, "Bash", ev.ToolName)
+			assert.JSONEq(t, `{"command":"rm -rf build"}`, string(ev.ToolInput))
+			assert.Equal(t, "toolu_123", ev.ToolUseID)
+			assert.Equal(t, "policy denied", ev.Reason)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event":  "PermissionDenied",
+					"tool_name":   "Bash",
+					"tool_input":  map[string]interface{}{"command": "rm -rf build"},
+					"tool_use_id": "toolu_123",
+					"reason":      "policy denied",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("Elicitation form via SDK path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(ElicitationInput)
+			require.True(t, ok)
+			assert.Equal(t, "payments", ev.MCPServerName)
+			assert.Equal(t, "Need account details", ev.Message)
+			assert.Equal(t, "form", ev.Mode)
+			assert.Equal(t, "elicit_1", ev.ElicitationID)
+			require.NotNil(t, ev.RequestedSchema)
+			assert.Equal(t, "object", ev.RequestedSchema["type"])
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+			RequestID: "r",
+			Request: SDKControlRequestBody{
+				Subtype:    "hook_callback",
+				CallbackID: "h",
+				Input: map[string]interface{}{
+					"hook_event_name":  "Elicitation",
+					"mcp_server_name":  "payments",
+					"message":          "Need account details",
+					"mode":             "form",
+					"elicitation_id":   "elicit_1",
+					"requested_schema": map[string]interface{}{"type": "object"},
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("Elicitation url via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(ElicitationInput)
+			require.True(t, ok)
+			assert.Equal(t, "identity", ev.MCPServerName)
+			assert.Equal(t, "Authorize access", ev.Message)
+			assert.Equal(t, "url", ev.Mode)
+			assert.Equal(t, "https://example.com/auth", ev.URL)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event":      "Elicitation",
+					"mcp_server_name": "identity",
+					"message":         "Authorize access",
+					"mode":            "url",
+					"url":             "https://example.com/auth",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("ElicitationResult form via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(ElicitationResultInput)
+			require.True(t, ok)
+			assert.Equal(t, "payments", ev.MCPServerName)
+			assert.Equal(t, "elicit_1", ev.ElicitationID)
+			assert.Equal(t, "form", ev.Mode)
+			assert.Equal(t, "accept", ev.Action)
+			require.NotNil(t, ev.Content)
+			assert.Equal(t, "acct_123", ev.Content["account_id"])
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event":      "ElicitationResult",
+					"mcp_server_name": "payments",
+					"elicitation_id":  "elicit_1",
+					"mode":            "form",
+					"action":          "accept",
+					"content":         map[string]interface{}{"account_id": "acct_123"},
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("ElicitationResult url via SDK path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(ElicitationResultInput)
+			require.True(t, ok)
+			assert.Equal(t, "identity", ev.MCPServerName)
+			assert.Equal(t, "url", ev.Mode)
+			assert.Equal(t, "decline", ev.Action)
+			assert.Nil(t, ev.Content)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+			RequestID: "r",
+			Request: SDKControlRequestBody{
+				Subtype:    "hook_callback",
+				CallbackID: "h",
+				Input: map[string]interface{}{
+					"hook_event_name": "ElicitationResult",
+					"mcp_server_name": "identity",
+					"mode":            "url",
+					"action":          "decline",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+}


### PR DESCRIPTION
## Summary
Adds the 5 hook events from `sdk.d.ts` v0.2.119 whose outputs have follow-up semantics in later PRs (`watchPaths` for CwdChanged/FileChanged in PR 9; `retry` for PermissionDenied in PR 13; `action`/`content` for Elicitation/ElicitationResult in PR 12). This PR adds input struct definitions and dispatch only.

New events with their TS sdk.d.ts line refs:
- `CwdChanged` (L429-L433)
- `Elicitation` (L470-L478)
- `ElicitationResult` (L522-L529) — `Action` is required (no `omitempty`)
- `FileChanged` (L549-L553)
- `PermissionDenied` (L1741-L1747)

For each: a `HookType` constant, an input struct embedding `BaseHookInput`, `HookType()`/`Base()` methods, and dispatch arms in both `handleHookCallback` (legacy path) and `handleSDKHookCallback` (SDK-format path).

## Out of scope
- `watchPaths` on hook outputs — PR 9.
- `retry` on PermissionDenied output — PR 13.
- `action`/`content` on Elicitation/ElicitationResult outputs — PR 12 (Elicitation callback).
- Hook matcher / `once` / `asyncRewake` — PR 10.

## Test plan
- [x] `go test ./...`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `protocol_test.go` adds 5 focused subtests (one per event), distributed across both dispatch paths. Elicitation covered with `mode=form` + `requested_schema`; ElicitationResult covered with `mode=url`. PermissionDenied verifies `tool_input` round-trips as `json.RawMessage`.

Tracks v0.2.119 catchup PLAN.md PR #8 (split: this is PR 8c — final piece). Closes the original PR 8 scope.