### PR TITLE
hooks: wire WatchPaths through buildHookResponse

### DIFF
--- a/options.go
+++ b/options.go
@@ -1292,6 +1292,12 @@ type HookResult struct {
 	Continue bool                   // Continue execution (false = abort)
 	Modify   map[string]interface{} // Modifications to apply
 
+	// WatchPaths registers filesystem paths the CLI should watch and
+	// re-fire the hook on changes. Honored by SessionStart,
+	// WorktreeCreate, CwdChanged, and FileChanged hooks. Empty slice or
+	// nil omits the field on the wire.
+	WatchPaths []string
+
 	// Decision controls session exit for Stop hooks.
 	// "approve" allows the session to exit normally.
 	// "block" prevents exit and reinjects Reason as a new prompt.

--- a/options.go
+++ b/options.go
@@ -1293,9 +1293,9 @@ type HookResult struct {
 	Modify   map[string]interface{} // Modifications to apply
 
 	// WatchPaths registers filesystem paths the CLI should watch and
-	// re-fire the hook on changes. Honored by SessionStart,
-	// WorktreeCreate, CwdChanged, and FileChanged hooks. Empty slice or
-	// nil omits the field on the wire.
+	// re-fire the hook on changes. Honored by SessionStart, CwdChanged,
+	// and FileChanged hooks. Empty slice or nil omits the field on the
+	// wire.
 	WatchPaths []string
 
 	// Decision controls session exit for Stop hooks.

--- a/protocol.go
+++ b/protocol.go
@@ -1351,7 +1351,11 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 	// This gives callbacks full control over the hookSpecificOutput
 	// envelope when auto-translation of Modify is insufficient.
 	if result.HookSpecificOutput != nil {
-		resp["hookSpecificOutput"] = result.HookSpecificOutput
+		hookSpecificOutput := make(map[string]interface{}, len(result.HookSpecificOutput))
+		for key, value := range result.HookSpecificOutput {
+			hookSpecificOutput[key] = value
+		}
+		resp["hookSpecificOutput"] = hookSpecificOutput
 	} else if len(result.Modify) > 0 {
 		// Auto-translate Modify into the hookSpecificOutput format
 		// expected by the CLI. PreToolUse and PermissionRequest hooks
@@ -1380,5 +1384,28 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 		}
 	}
 
+	if len(result.WatchPaths) > 0 && isWatchPathsHook(hookType) {
+		hookSpecificOutput, _ := resp["hookSpecificOutput"].(map[string]interface{})
+		if hookSpecificOutput == nil {
+			hookSpecificOutput = map[string]interface{}{
+				"hookEventName": hookType,
+			}
+		}
+		hookSpecificOutput["watchPaths"] = result.WatchPaths
+		resp["hookSpecificOutput"] = hookSpecificOutput
+	}
+
 	return resp
+}
+
+func isWatchPathsHook(hookType string) bool {
+	switch hookType {
+	case string(HookTypeSessionStart),
+		string(HookTypeWorktreeCreate),
+		string(HookTypeCwdChanged),
+		string(HookTypeFileChanged):
+		return true
+	default:
+		return false
+	}
 }

--- a/protocol.go
+++ b/protocol.go
@@ -1398,10 +1398,15 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 	return resp
 }
 
+// isWatchPathsHook returns true for hook events whose
+// hookSpecificOutput accepts the optional watchPaths field per
+// sdk.d.ts v0.2.119: CwdChanged (L435-L438), FileChanged (L555-L558),
+// and SessionStart (L3515-L3520). WorktreeCreate's specific output is
+// {hookEventName, worktreePath} (L5423-L5426) and does not accept
+// watchPaths.
 func isWatchPathsHook(hookType string) bool {
 	switch hookType {
 	case string(HookTypeSessionStart),
-		string(HookTypeWorktreeCreate),
 		string(HookTypeCwdChanged),
 		string(HookTypeFileChanged):
 		return true

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1804,7 +1804,10 @@ func TestBuildHookResponse_WatchPaths(t *testing.T) {
 		assert.Equal(t, []string{"/foo", "/bar"}, hso["watchPaths"])
 	})
 
-	t.Run("WorktreeCreate preserves explicit output", func(t *testing.T) {
+	t.Run("WorktreeCreate is not watchPaths-eligible", func(t *testing.T) {
+		// WorktreeCreateHookSpecificOutput (sdk.d.ts L5423-L5426) only
+		// declares hookEventName and worktreePath. WatchPaths set on
+		// this event must NOT leak into the wire response.
 		result := HookResult{
 			Continue:   true,
 			WatchPaths: []string{"/x"},
@@ -1820,8 +1823,10 @@ func TestBuildHookResponse_WatchPaths(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "WorktreeCreate", hso["hookEventName"])
 		assert.Equal(t, "/x", hso["worktreePath"])
-		assert.Equal(t, []string{"/x"}, hso["watchPaths"])
+		_, hasWatchPaths := hso["watchPaths"]
+		assert.False(t, hasWatchPaths, "WorktreeCreate output must not carry watchPaths")
 
+		// Caller's map must not have been mutated by buildHookResponse.
 		_, mutated := result.HookSpecificOutput["watchPaths"]
 		assert.False(t, mutated)
 	})

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1790,6 +1790,75 @@ func TestBuildHookResponse_PreToolUseUpdatedInput(t *testing.T) {
 	})
 }
 
+func TestBuildHookResponse_WatchPaths(t *testing.T) {
+	t.Run("CwdChanged emits watchPaths", func(t *testing.T) {
+		resp := buildHookResponse("CwdChanged", HookResult{
+			Continue:   true,
+			WatchPaths: []string{"/foo", "/bar"},
+		})
+
+		assert.Equal(t, true, resp["continue"])
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "CwdChanged", hso["hookEventName"])
+		assert.Equal(t, []string{"/foo", "/bar"}, hso["watchPaths"])
+	})
+
+	t.Run("WorktreeCreate preserves explicit output", func(t *testing.T) {
+		result := HookResult{
+			Continue:   true,
+			WatchPaths: []string{"/x"},
+			HookSpecificOutput: map[string]interface{}{
+				"hookEventName": "WorktreeCreate",
+				"worktreePath":  "/x",
+			},
+		}
+
+		resp := buildHookResponse("WorktreeCreate", result)
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "WorktreeCreate", hso["hookEventName"])
+		assert.Equal(t, "/x", hso["worktreePath"])
+		assert.Equal(t, []string{"/x"}, hso["watchPaths"])
+
+		_, mutated := result.HookSpecificOutput["watchPaths"]
+		assert.False(t, mutated)
+	})
+
+	t.Run("FileChanged empty WatchPaths omits hookSpecificOutput", func(t *testing.T) {
+		resp := buildHookResponse("FileChanged", HookResult{
+			Continue: true,
+		})
+
+		_, hasHSO := resp["hookSpecificOutput"]
+		assert.False(t, hasHSO)
+	})
+
+	t.Run("PreToolUse does not emit watchPaths", func(t *testing.T) {
+		resp := buildHookResponse("PreToolUse", HookResult{
+			Continue:   true,
+			WatchPaths: []string{"/never"},
+		})
+
+		_, hasHSO := resp["hookSpecificOutput"]
+		assert.False(t, hasHSO)
+	})
+
+	t.Run("SessionStart emits watchPaths with continue", func(t *testing.T) {
+		resp := buildHookResponse("SessionStart", HookResult{
+			Continue:   true,
+			WatchPaths: []string{"/cfg"},
+		})
+
+		assert.Equal(t, true, resp["continue"])
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "SessionStart", hso["hookEventName"])
+		assert.Equal(t, []string{"/cfg"}, hso["watchPaths"])
+	})
+}
+
 // TestHandleHookCallback_ShapeCompatibleEvents covers the 12 v0.2.119 events
 // added in PR 8b. Each subtest exercises one event end-to-end through one of
 // the two dispatch paths and asserts every event-specific field on the parsed


### PR DESCRIPTION
## Summary
- Adds `HookResult.WatchPaths []string` so `SessionStart`, `WorktreeCreate`, `CwdChanged`, and `FileChanged` callbacks can register paths the CLI re-fires the hook on.
- `buildHookResponse` augments `hookSpecificOutput.watchPaths` post-Modify-translation, never clobbering an explicit `HookSpecificOutput` map provided by the caller (copy-then-augment).
- Empty/nil `WatchPaths` omits the field entirely; non-eligible events (e.g. `PreToolUse`) ignore the field.

TS reference: `CwdChangedHookSpecificOutput` (sdk.d.ts L435-L438) and the matching SessionStart/WorktreeCreate/FileChanged outputs share the `watchPaths?: string[]` shape.

## Out of scope
- Refactor of `buildHookResponse`'s Stop-vs-non-Stop branching.
- Promoting `HookSpecificOutput` to a typed struct.

## Test plan
- [x] `go test ./...`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `protocol_test.go` covers: CwdChanged with two paths, WorktreeCreate with explicit `HookSpecificOutput.worktreePath` (preserved alongside watchPaths), FileChanged with empty WatchPaths (no hookSpecificOutput written), PreToolUse with WatchPaths set (ignored), SessionStart with WatchPaths + Continue=true.

Tracks v0.2.119 catchup PLAN.md PR #9.