### PR TITLE
mcp: add http + sse transport configs to MCPServerConfig

### DIFF
--- a/options.go
+++ b/options.go
@@ -1499,12 +1499,27 @@ type SessionOptions struct {
 
 // MCPServerConfig configures an MCP server.
 type MCPServerConfig struct {
-	Type    string            `json:"type,omitempty"`    // "stdio" or "socket"
-	Command string            `json:"command,omitempty"` // Command to start server (for stdio)
-	Args    []string          `json:"args,omitempty"`    // Command arguments
-	Env     map[string]string `json:"env,omitempty"`     // Environment variables
-	Address string            `json:"address,omitempty"` // Socket address (for socket type)
+	Type    string                `json:"type,omitempty"`    // "stdio", "sse", "http", or legacy "socket"
+	Command string                `json:"command,omitempty"` // Command to start server (for stdio)
+	Args    []string              `json:"args,omitempty"`    // Command arguments
+	Env     map[string]string     `json:"env,omitempty"`     // Environment variables
+	URL     string                `json:"url,omitempty"`     // Remote server URL (for sse/http)
+	Headers map[string]string     `json:"headers,omitempty"` // Remote server headers (for sse/http)
+	Tools   []MCPServerToolPolicy `json:"tools,omitempty"`   // Remote server tool permission policies
+	Address string                `json:"address,omitempty"` // Socket address (for socket type)
 }
+
+// MCPServerToolPolicy configures a per-tool permission policy for remote MCP servers.
+type MCPServerToolPolicy struct {
+	Name             string `json:"name"`
+	PermissionPolicy string `json:"permission_policy"`
+}
+
+const (
+	MCPToolPolicyAllowAlways = "always_allow"
+	MCPToolPolicyAskAlways   = "always_ask"
+	MCPToolPolicyDenyAlways  = "always_deny"
+)
 
 // SkillsConfig controls how Skills are loaded.
 type SkillsConfig struct {

--- a/transport.go
+++ b/transport.go
@@ -185,14 +185,33 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 	// Add MCP server configurations.
 	// The CLI uses --mcp-config which takes JSON configuration.
 	for name, config := range t.options.MCPServers {
+		serverType := config.Type
+		if serverType == "" {
+			serverType = "stdio"
+		}
+
 		mcpConfig := map[string]interface{}{
-			"command": config.Command,
+			"type": serverType,
 		}
-		if len(config.Args) > 0 {
-			mcpConfig["args"] = config.Args
-		}
-		if len(config.Env) > 0 {
-			mcpConfig["env"] = config.Env
+		switch serverType {
+		case "stdio":
+			mcpConfig["command"] = config.Command
+			if len(config.Args) > 0 {
+				mcpConfig["args"] = config.Args
+			}
+			if len(config.Env) > 0 {
+				mcpConfig["env"] = config.Env
+			}
+		case "http", "sse":
+			mcpConfig["url"] = config.URL
+			if len(config.Headers) > 0 {
+				mcpConfig["headers"] = config.Headers
+			}
+			if len(config.Tools) > 0 {
+				mcpConfig["tools"] = config.Tools
+			}
+		case "socket":
+			mcpConfig["address"] = config.Address
 		}
 
 		// Wrap in outer object with server name as key.

--- a/transport_test.go
+++ b/transport_test.go
@@ -33,6 +33,29 @@ func assertArgAbsent(t *testing.T, args []string, flag string) {
 	assert.NotContains(t, args, flag)
 }
 
+func decodeMCPConfigArgs(t *testing.T, args []string) map[string]map[string]interface{} {
+	t.Helper()
+
+	configs := make(map[string]map[string]interface{})
+	for i, arg := range args {
+		if arg != "--mcp-config" {
+			continue
+		}
+		require.Less(t, i+1, len(args), "flag --mcp-config missing value")
+
+		var wrapper struct {
+			MCPServers map[string]map[string]interface{} `json:"mcpServers"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(args[i+1]), &wrapper))
+		require.Len(t, wrapper.MCPServers, 1)
+		for name, config := range wrapper.MCPServers {
+			configs[name] = config
+		}
+	}
+
+	return configs
+}
+
 func stringPtr(s string) *string {
 	return &s
 }
@@ -904,6 +927,181 @@ func TestSubprocessTransportThinkingDisplay(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubprocessTransportMCPConfigEncoding(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverName string
+		config     MCPServerConfig
+		want       map[string]interface{}
+		absentKeys []string
+	}{
+		{
+			name:       "stdio explicit type",
+			serverName: "local",
+			config: MCPServerConfig{
+				Type:    "stdio",
+				Command: "x",
+				Args:    []string{"y"},
+			},
+			want: map[string]interface{}{
+				"type":    "stdio",
+				"command": "x",
+				"args":    []interface{}{"y"},
+			},
+		},
+		{
+			name:       "stdio implicit type",
+			serverName: "local",
+			config: MCPServerConfig{
+				Command: "x",
+			},
+			want: map[string]interface{}{
+				"type":    "stdio",
+				"command": "x",
+			},
+		},
+		{
+			name:       "http minimal",
+			serverName: "remote",
+			config: MCPServerConfig{
+				Type: "http",
+				URL:  "https://example.com/mcp",
+			},
+			want: map[string]interface{}{
+				"type": "http",
+				"url":  "https://example.com/mcp",
+			},
+			absentKeys: []string{"command", "headers", "tools"},
+		},
+		{
+			name:       "http with headers and tools",
+			serverName: "remote",
+			config: MCPServerConfig{
+				Type: "http",
+				URL:  "https://example.com/mcp",
+				Headers: map[string]string{
+					"Authorization": "Bearer token",
+				},
+				Tools: []MCPServerToolPolicy{
+					{Name: "foo", PermissionPolicy: MCPToolPolicyAllowAlways},
+					{Name: "bar", PermissionPolicy: MCPToolPolicyAskAlways},
+				},
+			},
+			want: map[string]interface{}{
+				"type": "http",
+				"url":  "https://example.com/mcp",
+				"headers": map[string]interface{}{
+					"Authorization": "Bearer token",
+				},
+				"tools": []interface{}{
+					map[string]interface{}{
+						"name":              "foo",
+						"permission_policy": "always_allow",
+					},
+					map[string]interface{}{
+						"name":              "bar",
+						"permission_policy": "always_ask",
+					},
+				},
+			},
+		},
+		{
+			name:       "sse with headers",
+			serverName: "events",
+			config: MCPServerConfig{
+				Type: "sse",
+				URL:  "https://example.com/sse",
+				Headers: map[string]string{
+					"X-API-Key": "secret",
+				},
+			},
+			want: map[string]interface{}{
+				"type": "sse",
+				"url":  "https://example.com/sse",
+				"headers": map[string]interface{}{
+					"X-API-Key": "secret",
+				},
+			},
+		},
+		{
+			name:       "http omits empty headers and tools",
+			serverName: "remote",
+			config: MCPServerConfig{
+				Type:    "http",
+				URL:     "https://example.com/mcp",
+				Headers: map[string]string{},
+				Tools:   []MCPServerToolPolicy{},
+			},
+			want: map[string]interface{}{
+				"type": "http",
+				"url":  "https://example.com/mcp",
+			},
+			absentKeys: []string{"headers", "tools"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+			opts := NewOptions()
+			opts.MCPServers = map[string]MCPServerConfig{
+				tt.serverName: tt.config,
+			}
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+			err := transport.Connect(context.Background())
+			require.NoError(t, err)
+			defer transport.Close()
+
+			configs := decodeMCPConfigArgs(t, runner.StartArgs)
+			require.Len(t, configs, 1)
+			require.Contains(t, configs, tt.serverName)
+			assert.Equal(t, tt.want, configs[tt.serverName])
+			for _, key := range tt.absentKeys {
+				assert.NotContains(t, configs[tt.serverName], key)
+			}
+		})
+	}
+}
+
+func TestSubprocessTransportMCPConfigMultipleServers(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	opts.MCPServers = map[string]MCPServerConfig{
+		"local": {
+			Command: "local-mcp",
+		},
+		"remote": {
+			Type: "http",
+			URL:  "https://example.com/mcp",
+		},
+	}
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+	err := transport.Connect(context.Background())
+	require.NoError(t, err)
+	defer transport.Close()
+
+	configs := decodeMCPConfigArgs(t, runner.StartArgs)
+	require.Len(t, configs, 2)
+	assert.Equal(t, map[string]interface{}{
+		"type":    "stdio",
+		"command": "local-mcp",
+	}, configs["local"])
+	assert.Equal(t, map[string]interface{}{
+		"type": "http",
+		"url":  "https://example.com/mcp",
+	}, configs["remote"])
+
+	var flagCount int
+	for _, arg := range runner.StartArgs {
+		if arg == "--mcp-config" {
+			flagCount++
+		}
+	}
+	assert.Equal(t, 2, flagCount)
 }
 
 func TestSubprocessTransportEffortArguments(t *testing.T) {


### PR DESCRIPTION
Adds the `http` and `sse` MCP transport variants and the per-server `tools` policy to `MCPServerConfig`, matching `McpHttpServerConfig` (sdk.d.ts L926-L931) and `McpSSEServerConfig` (L1027-L1032).

## Changes
- `options.go` — adds `URL`, `Headers map[string]string`, `Tools []MCPServerToolPolicy` to `MCPServerConfig`; new `MCPServerToolPolicy{Name, PermissionPolicy}` struct; `MCPToolPolicy{AllowAlways,AskAlways,DenyAlways}` constants.
- `transport.go` — `--mcp-config` encoding now switches on `Type` and emits the right fields per variant; `type` always reaches the CLI (defaulted to `"stdio"` when unset, matching the TS optional-with-default shape). Legacy Go-only `socket` type left as-is.

## Tests
`TestSubprocessTransportMCPConfigEncoding` table-drives:
- stdio explicit + implicit type
- http minimal (no headers/tools)
- http with headers + tools (verifies tool policy serialization)
- sse with headers
- empty headers/tools maps omit the JSON keys

`TestSubprocessTransportMCPConfigMultipleServers` verifies one `--mcp-config` flag per server and stdio + http coexist.

`go test -count=1 ./...`, `go vet ./...`, `gofmt -l .` clean.

## Out of scope
- `McpSdkServerConfig` (in-process) and `McpClaudeAIProxyServerConfig` (managed proxy).
- Discriminated-union refactor of `MCPServerConfig` — current shape stays usable at this size.
- Settings-file MCP fields.

Part of the v0.2.119 catchup (PR 11/N).