### PR TITLE
mcp: add OnElicitation callback for elicitation control requests

### DIFF
--- a/options.go
+++ b/options.go
@@ -60,6 +60,9 @@ type Options struct {
 	// Return PermissionAllow to proceed or PermissionDeny to block.
 	CanUseTool CanUseToolFunc
 
+	// OnElicitation handles MCP server requests for user input.
+	OnElicitation OnElicitationFunc
+
 	// Hooks register lifecycle callbacks for events like tool use.
 	Hooks map[HookType][]HookConfig
 
@@ -491,6 +494,15 @@ func WithCanUseTool(fn CanUseToolFunc) Option {
 	}
 }
 
+// WithOnElicitation registers a callback that handles MCP elicitation requests.
+//
+// If unset, the SDK auto-declines all elicitation requests.
+func WithOnElicitation(fn OnElicitationFunc) Option {
+	return func(o *Options) {
+		o.OnElicitation = fn
+	}
+}
+
 // WithHooks registers lifecycle callbacks.
 //
 // Example:
@@ -658,6 +670,39 @@ const (
 //
 // Return PermissionAllow{} to proceed or PermissionDeny{Reason: "..."} to block.
 type CanUseToolFunc func(ctx context.Context, req ToolPermissionRequest) PermissionResult
+
+// OnElicitationFunc is invoked when an MCP server requests user input.
+//
+// Returning a non-nil error converts the response to action="cancel".
+type OnElicitationFunc func(ctx context.Context, req ElicitationRequest) (ElicitationResult, error)
+
+// ElicitationRequest is the input to the OnElicitation callback.
+type ElicitationRequest struct {
+	ServerName      string                 `json:"serverName"`
+	Message         string                 `json:"message"`
+	Mode            string                 `json:"mode,omitempty"`
+	URL             string                 `json:"url,omitempty"`
+	ElicitationID   string                 `json:"elicitationId,omitempty"`
+	RequestedSchema map[string]interface{} `json:"requestedSchema,omitempty"`
+	Title           string                 `json:"title,omitempty"`
+	DisplayName     string                 `json:"displayName,omitempty"`
+	Description     string                 `json:"description,omitempty"`
+}
+
+// ElicitationResult is what OnElicitation returns.
+type ElicitationResult struct {
+	Action  string                 `json:"action"`
+	Content map[string]interface{} `json:"content,omitempty"`
+}
+
+const (
+	// ElicitationActionAccept accepts the elicitation response.
+	ElicitationActionAccept = "accept"
+	// ElicitationActionDecline declines the elicitation response.
+	ElicitationActionDecline = "decline"
+	// ElicitationActionCancel cancels the elicitation response.
+	ElicitationActionCancel = "cancel"
+)
 
 // ToolPermissionRequest contains details about a tool execution request.
 type ToolPermissionRequest struct {

--- a/protocol.go
+++ b/protocol.go
@@ -183,6 +183,10 @@ func (p *Protocol) handleControlRequest(ctx context.Context, req ControlRequest)
 	case "mcp_message":
 		resp = p.handleMCPMessage(ctx, req)
 
+	// MCP elicitation request from CLI (elicitation).
+	case "elicitation":
+		resp = p.handleElicitationRequest(ctx, req)
+
 	default:
 		resp = SDKControlResponse{
 			Type: "control_response",
@@ -228,6 +232,48 @@ func (p *Protocol) handlePermissionRequest(ctx context.Context, req ControlReque
 	}
 	if deny, ok := result.(PermissionDeny); ok && !result.IsAllow() {
 		respData["reason"] = deny.Reason
+	}
+
+	return SDKControlResponse{
+		Type: "control_response",
+		Response: SDKControlResponseBody{
+			Subtype:   "success",
+			RequestID: req.RequestID,
+			Response:  respData,
+		},
+	}
+}
+
+// handleElicitationRequest processes an MCP elicitation request from the CLI.
+func (p *Protocol) handleElicitationRequest(ctx context.Context, req ControlRequest) SDKControlResponse {
+	elReq := ElicitationRequest{}
+	elReq.ServerName, _ = req.Payload["mcp_server_name"].(string)
+	elReq.Message, _ = req.Payload["message"].(string)
+	elReq.Mode, _ = req.Payload["mode"].(string)
+	elReq.URL, _ = req.Payload["url"].(string)
+	elReq.ElicitationID, _ = req.Payload["elicitation_id"].(string)
+	if rs, ok := req.Payload["requested_schema"].(map[string]interface{}); ok {
+		elReq.RequestedSchema = rs
+	}
+	elReq.Title, _ = req.Payload["title"].(string)
+	elReq.DisplayName, _ = req.Payload["display_name"].(string)
+	elReq.Description, _ = req.Payload["description"].(string)
+
+	result := ElicitationResult{Action: ElicitationActionDecline}
+	if p.options.OnElicitation != nil {
+		callbackResult, err := p.options.OnElicitation(ctx, elReq)
+		if err != nil {
+			result = ElicitationResult{Action: ElicitationActionCancel}
+		} else {
+			result = callbackResult
+		}
+	}
+
+	respData := map[string]interface{}{
+		"action": result.Action,
+	}
+	if len(result.Content) > 0 {
+		respData["content"] = result.Content
 	}
 
 	return SDKControlResponse{

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -3,6 +3,7 @@ package claudeagent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -508,6 +509,122 @@ func TestProtocolPermissionRequest(t *testing.T) {
 		case <-time.After(500 * time.Millisecond):
 			t.Fatal("Timeout waiting for response")
 		}
+	})
+}
+
+func TestProtocolHandleElicitationRequest(t *testing.T) {
+	basePayload := map[string]interface{}{
+		"mcp_server_name":  "auth-server",
+		"message":          "Enter credentials",
+		"mode":             "form",
+		"url":              "https://example.com/auth",
+		"elicitation_id":   "elicit_1",
+		"requested_schema": map[string]interface{}{"type": "object"},
+		"title":            "Sign in",
+		"display_name":     "Auth Server",
+		"description":      "Authentication required",
+	}
+
+	tests := []struct {
+		name      string
+		callback  OnElicitationFunc
+		want      map[string]interface{}
+		noContent bool
+	}{
+		{
+			name: "accept with content",
+			callback: func(ctx context.Context, req ElicitationRequest) (ElicitationResult, error) {
+				return ElicitationResult{
+					Action:  ElicitationActionAccept,
+					Content: map[string]interface{}{"name": "alice"},
+				}, nil
+			},
+			want: map[string]interface{}{
+				"action":  "accept",
+				"content": map[string]interface{}{"name": "alice"},
+			},
+		},
+		{
+			name: "decline",
+			callback: func(ctx context.Context, req ElicitationRequest) (ElicitationResult, error) {
+				return ElicitationResult{Action: ElicitationActionDecline}, nil
+			},
+			want:      map[string]interface{}{"action": "decline"},
+			noContent: true,
+		},
+		{
+			name: "cancel",
+			callback: func(ctx context.Context, req ElicitationRequest) (ElicitationResult, error) {
+				return ElicitationResult{Action: ElicitationActionCancel}, nil
+			},
+			want:      map[string]interface{}{"action": "cancel"},
+			noContent: true,
+		},
+		{
+			name: "callback error cancels",
+			callback: func(ctx context.Context, req ElicitationRequest) (ElicitationResult, error) {
+				return ElicitationResult{Action: ElicitationActionAccept}, errors.New("failed")
+			},
+			want:      map[string]interface{}{"action": "cancel"},
+			noContent: true,
+		},
+		{
+			name:      "nil callback declines",
+			want:      map[string]interface{}{"action": "decline"},
+			noContent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := NewOptions()
+			opts.OnElicitation = tt.callback
+			protocol := NewProtocol(nil, opts)
+
+			resp := protocol.handleElicitationRequest(context.Background(), ControlRequest{
+				Type:      "control",
+				Subtype:   "elicitation",
+				RequestID: "req_elicit",
+				Payload:   basePayload,
+			})
+
+			assert.Equal(t, "control_response", resp.Type)
+			assert.Equal(t, "success", resp.Response.Subtype)
+			assert.Equal(t, "req_elicit", resp.Response.RequestID)
+			assert.Equal(t, tt.want, resp.Response.Response)
+			if tt.noContent {
+				_, hasContent := resp.Response.Response["content"]
+				assert.False(t, hasContent)
+			}
+		})
+	}
+
+	t.Run("request fields propagated", func(t *testing.T) {
+		opts := NewOptions()
+		var got ElicitationRequest
+		opts.OnElicitation = func(ctx context.Context, req ElicitationRequest) (ElicitationResult, error) {
+			got = req
+			return ElicitationResult{Action: ElicitationActionDecline}, nil
+		}
+		protocol := NewProtocol(nil, opts)
+
+		resp := protocol.handleElicitationRequest(context.Background(), ControlRequest{
+			Type:      "control",
+			Subtype:   "elicitation",
+			RequestID: "req_fields",
+			Payload:   basePayload,
+		})
+
+		assert.Equal(t, "decline", resp.Response.Response["action"])
+		assert.Equal(t, "auth-server", got.ServerName)
+		assert.Equal(t, "Enter credentials", got.Message)
+		assert.Equal(t, "form", got.Mode)
+		assert.Equal(t, "https://example.com/auth", got.URL)
+		assert.Equal(t, "elicit_1", got.ElicitationID)
+		assert.Equal(t, map[string]interface{}{"type": "object"}, got.RequestedSchema)
+		assert.Equal(t, "Sign in", got.Title)
+		assert.Equal(t, "Auth Server", got.DisplayName)
+		assert.Equal(t, "Authentication required", got.Description)
 	})
 }
 


### PR DESCRIPTION
Adds `Options.OnElicitation` so user code can answer MCP server elicitation prompts (form input or URL auth). The new `case "elicitation"` arm in `Protocol.handleControlRequest` parses the inbound payload into a public `ElicitationRequest`, invokes the callback, and returns an `ElicitationResult` with the chosen `action` (`accept` / `decline` / `cancel`) and optional `content`.

Matches `OnElicitation` (sdk.d.ts L1110-L1112), `ElicitationRequest` (L492-L511), `ElicitationResult` (L517).

## Behavior
- **Nil callback** → auto-`decline` (no error).
- **Callback returns error** → response is `cancel` with no content (mirrors TS UX-as-cancel; control-channel itself stays in `success`).
- **Wire naming** — control payload arrives in snake_case (`mcp_server_name`, `elicitation_id`, `requested_schema`, `display_name`) per `sdk.mjs:61` and the existing `ElicitationInput` HOOK type. The public Go struct uses camelCase JSON tags to match the TS `ElicitationRequest` interface.

## Tests
`TestProtocolHandleElicitationRequest` table-drives accept-with-content, decline, cancel, callback-error→cancel, and nil-callback→decline. A separate `request fields propagated` subtest asserts every inbound field reaches the callback's `ElicitationRequest` argument.

`go test -count=1 ./...`, `go vet ./...`, `gofmt -l .` clean.

## Out of scope
- `Elicitation` / `ElicitationResult` HOOKS — already wired separately in PR 8.
- In-process MCP server elicitation flow (`McpSdkServerConfig`).
- Schema validation helpers.

Part of the v0.2.119 catchup (PR 12/N).