### PR TITLE
permissions: add PermissionDecisionClassification to PermissionResult

### DIFF
--- a/options.go
+++ b/options.go
@@ -719,13 +719,29 @@ type PermissionContext struct {
 	Metadata  map[string]interface{}
 }
 
+// PermissionDecisionClassification labels how a permission decision was reached
+// for SDK-host telemetry. If unset, the CLI infers conservatively.
+type PermissionDecisionClassification string
+
+const (
+	// PermissionClassificationUserTemporary is "allow-once".
+	PermissionClassificationUserTemporary PermissionDecisionClassification = "user_temporary"
+	// PermissionClassificationUserPermanent is "always-allow" and later cache hits.
+	PermissionClassificationUserPermanent PermissionDecisionClassification = "user_permanent"
+	// PermissionClassificationUserReject is "deny".
+	PermissionClassificationUserReject PermissionDecisionClassification = "user_reject"
+)
+
 // PermissionResult is the outcome of a permission check.
 type PermissionResult interface {
 	IsAllow() bool
 }
 
 // PermissionAllow indicates permission granted.
-type PermissionAllow struct{}
+type PermissionAllow struct {
+	// Classification optionally labels the decision for telemetry. Empty = unset.
+	Classification PermissionDecisionClassification
+}
 
 // IsAllow implements PermissionResult.
 func (PermissionAllow) IsAllow() bool { return true }
@@ -733,6 +749,8 @@ func (PermissionAllow) IsAllow() bool { return true }
 // PermissionDeny indicates permission denied.
 type PermissionDeny struct {
 	Reason string
+	// Classification optionally labels the decision for telemetry. Empty = unset.
+	Classification PermissionDecisionClassification
 }
 
 // IsAllow implements PermissionResult.

--- a/protocol.go
+++ b/protocol.go
@@ -230,8 +230,18 @@ func (p *Protocol) handlePermissionRequest(ctx context.Context, req ControlReque
 	respData := map[string]interface{}{
 		"allowed": result.IsAllow(),
 	}
-	if deny, ok := result.(PermissionDeny); ok && !result.IsAllow() {
-		respData["reason"] = deny.Reason
+	var classification PermissionDecisionClassification
+	switch r := result.(type) {
+	case PermissionAllow:
+		classification = r.Classification
+	case PermissionDeny:
+		classification = r.Classification
+		if !result.IsAllow() {
+			respData["reason"] = r.Reason
+		}
+	}
+	if classification != "" {
+		respData["decisionClassification"] = string(classification)
 	}
 
 	return SDKControlResponse{
@@ -750,14 +760,22 @@ func (p *Protocol) handleSDKPermissionRequest(ctx context.Context, req SDKContro
 	responseData := map[string]interface{}{
 		"behavior": "allow",
 	}
+	var classification PermissionDecisionClassification
 	if result.IsAllow() {
 		// Pass the original tool input through unchanged.
 		responseData["updatedInput"] = arguments
+		if allow, ok := result.(PermissionAllow); ok {
+			classification = allow.Classification
+		}
 	} else {
 		responseData["behavior"] = "deny"
 		if deny, ok := result.(PermissionDeny); ok {
 			responseData["message"] = deny.Reason
+			classification = deny.Classification
 		}
+	}
+	if classification != "" {
+		responseData["decisionClassification"] = string(classification)
 	}
 	responseData["toolUseID"] = req.Request.ToolUseID
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -512,6 +512,168 @@ func TestProtocolPermissionRequest(t *testing.T) {
 	})
 }
 
+func TestProtocolHandlePermissionRequestClassification(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     PermissionResult
+		expected   map[string]interface{}
+		unexpected []string
+	}{
+		{
+			name:   "allow without classification",
+			result: PermissionAllow{},
+			expected: map[string]interface{}{
+				"allowed": true,
+			},
+			unexpected: []string{"decisionClassification"},
+		},
+		{
+			name: "allow with classification",
+			result: PermissionAllow{
+				Classification: PermissionClassificationUserPermanent,
+			},
+			expected: map[string]interface{}{
+				"allowed":                true,
+				"decisionClassification": "user_permanent",
+			},
+		},
+		{
+			name:   "deny without classification",
+			result: PermissionDeny{Reason: "no"},
+			expected: map[string]interface{}{
+				"allowed": false,
+				"reason":  "no",
+			},
+			unexpected: []string{"decisionClassification"},
+		},
+		{
+			name: "deny with classification",
+			result: PermissionDeny{
+				Reason:         "no",
+				Classification: PermissionClassificationUserReject,
+			},
+			expected: map[string]interface{}{
+				"allowed":                false,
+				"reason":                 "no",
+				"decisionClassification": "user_reject",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := NewOptions()
+			opts.CanUseTool = func(ctx context.Context, req ToolPermissionRequest) PermissionResult {
+				return tt.result
+			}
+			protocol := NewProtocol(nil, opts)
+
+			resp := protocol.handlePermissionRequest(context.Background(), ControlRequest{
+				Type:      "control",
+				Subtype:   "can_use_tool",
+				RequestID: "req_1",
+				Payload: map[string]interface{}{
+					"tool_name":   "fetch_quote",
+					"tool_use_id": "tool_1",
+					"input":       map[string]interface{}{},
+				},
+			})
+
+			require.Equal(t, "success", resp.Response.Subtype)
+			respData := resp.Response.Response
+			for key, want := range tt.expected {
+				assert.Equal(t, want, respData[key])
+			}
+			for _, key := range tt.unexpected {
+				assert.NotContains(t, respData, key)
+			}
+		})
+	}
+}
+
+func TestProtocolHandleSDKPermissionRequestClassification(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     PermissionResult
+		expected   map[string]interface{}
+		unexpected []string
+	}{
+		{
+			name:   "allow without classification",
+			result: PermissionAllow{},
+			expected: map[string]interface{}{
+				"behavior":  "allow",
+				"toolUseID": "tool_1",
+			},
+			unexpected: []string{"decisionClassification"},
+		},
+		{
+			name: "allow with classification",
+			result: PermissionAllow{
+				Classification: PermissionClassificationUserPermanent,
+			},
+			expected: map[string]interface{}{
+				"behavior":               "allow",
+				"decisionClassification": "user_permanent",
+				"toolUseID":              "tool_1",
+			},
+		},
+		{
+			name:   "deny without classification",
+			result: PermissionDeny{Reason: "no"},
+			expected: map[string]interface{}{
+				"behavior":  "deny",
+				"message":   "no",
+				"toolUseID": "tool_1",
+			},
+			unexpected: []string{"decisionClassification"},
+		},
+		{
+			name: "deny with classification",
+			result: PermissionDeny{
+				Reason:         "no",
+				Classification: PermissionClassificationUserReject,
+			},
+			expected: map[string]interface{}{
+				"behavior":               "deny",
+				"message":                "no",
+				"decisionClassification": "user_reject",
+				"toolUseID":              "tool_1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := NewOptions()
+			opts.CanUseTool = func(ctx context.Context, req ToolPermissionRequest) PermissionResult {
+				return tt.result
+			}
+			protocol := NewProtocol(nil, opts)
+
+			resp := protocol.handleSDKPermissionRequest(context.Background(), SDKControlRequest{
+				Type:      "control_request",
+				RequestID: "req_1",
+				Request: SDKControlRequestBody{
+					Subtype:   "can_use_tool",
+					ToolName:  "fetch_quote",
+					ToolUseID: "tool_1",
+					Input:     map[string]interface{}{},
+				},
+			})
+
+			require.Equal(t, "success", resp.Response.Subtype)
+			respData := resp.Response.Response
+			for key, want := range tt.expected {
+				assert.Equal(t, want, respData[key])
+			}
+			for _, key := range tt.unexpected {
+				assert.NotContains(t, respData, key)
+			}
+		})
+	}
+}
+
 func TestProtocolHandleElicitationRequest(t *testing.T) {
 	basePayload := map[string]interface{}{
 		"mcp_server_name":  "auth-server",


### PR DESCRIPTION
Adds the optional `Classification PermissionDecisionClassification` field to `PermissionAllow` / `PermissionDeny` so SDK hosts can stamp user intent on the permission response for telemetry. Empty value is invisible on the wire — the CLI infers conservatively, matching the doc comment at `sdk.d.ts:1736-1739`.

## Wire paths covered
- `handlePermissionRequest` — the older `can_use_tool` `{allowed, reason?}` response shape — emits `decisionClassification` when set.
- `handleSDKPermissionRequest` — the richer TS `PermissionResult` shape (`{behavior, updatedInput?, message?, toolUseID, decisionClassification?}` per `sdk.d.ts:1779-1791`) — emits `decisionClassification` on both `behavior: 'allow'` and `behavior: 'deny'` branches.

## Tests
`TestProtocolHandlePermissionRequestClassification` and `TestProtocolHandleSDKPermissionRequestClassification` table-drive the four cases on each path: allow w/o, allow w/, deny w/o, deny w/. Each verifies presence + absence of the `decisionClassification` key.

`go test -count=1 ./...`, `go vet ./...`, `gofmt -l .` clean. Existing `PermissionAllow{}` / `PermissionDeny{Reason: "..."}` literal usage stays valid (zero-value field).

## Out of scope (PR 13b)
PLAN.md PR 13 originally bundled this with the `PermissionUpdate` discriminated-union rewrite (addRules/replaceRules/removeRules/setMode/addDirectories/removeDirectories) and `PermissionRequest` hook support. Splitting per the 08a/08b/08c precedent — those land in a follow-up PR (13b).

Part of the v0.2.119 catchup (PR 13a/N).