### PR TITLE
permissions: add JSON tags + typed Type/Destination constants on PermissionUpdate

### DIFF
--- a/options.go
+++ b/options.go
@@ -1316,20 +1316,55 @@ type HookJSONOutput struct {
 }
 
 // PermissionUpdate represents an operation for updating permissions.
+// Field usage depends on Type; zero-valued fields are omitted from the wire.
 type PermissionUpdate struct {
-	Type        string             // "addRules", "replaceRules", "removeRules", "setMode", "addDirectories", "removeDirectories"
-	Rules       []PermissionRule   // For rule operations
-	Behavior    PermissionBehavior // "allow", "deny", "ask"
-	Destination string             // "userSettings", "projectSettings", "localSettings", "session"
-	Mode        PermissionMode     // For setMode
-	Directories []string           // For directory operations
+	Type        PermissionUpdateType        `json:"type"`
+	Rules       []PermissionRule            `json:"rules,omitempty"`    // addRules / replaceRules / removeRules
+	Behavior    PermissionBehavior          `json:"behavior,omitempty"` // addRules / replaceRules / removeRules
+	Destination PermissionUpdateDestination `json:"destination"`
+	Mode        PermissionMode              `json:"mode,omitempty"`        // setMode
+	Directories []string                    `json:"directories,omitempty"` // addDirectories / removeDirectories
 }
 
 // PermissionRule represents a permission rule value.
 type PermissionRule struct {
-	ToolName    string
-	RuleContent string
+	ToolName    string `json:"toolName"`
+	RuleContent string `json:"ruleContent,omitempty"`
 }
+
+// PermissionUpdateType identifies which PermissionUpdate variant a value represents.
+type PermissionUpdateType string
+
+const (
+	// PermissionUpdateTypeAddRules appends rules to the destination.
+	PermissionUpdateTypeAddRules PermissionUpdateType = "addRules"
+	// PermissionUpdateTypeReplaceRules replaces rules in the destination.
+	PermissionUpdateTypeReplaceRules PermissionUpdateType = "replaceRules"
+	// PermissionUpdateTypeRemoveRules removes rules from the destination.
+	PermissionUpdateTypeRemoveRules PermissionUpdateType = "removeRules"
+	// PermissionUpdateTypeSetMode updates the permission mode.
+	PermissionUpdateTypeSetMode PermissionUpdateType = "setMode"
+	// PermissionUpdateTypeAddDirectories appends directories to the destination.
+	PermissionUpdateTypeAddDirectories PermissionUpdateType = "addDirectories"
+	// PermissionUpdateTypeRemoveDirectories removes directories from the destination.
+	PermissionUpdateTypeRemoveDirectories PermissionUpdateType = "removeDirectories"
+)
+
+// PermissionUpdateDestination indicates where a PermissionUpdate writes its changes.
+type PermissionUpdateDestination string
+
+const (
+	// PermissionDestinationUserSettings writes to user settings.
+	PermissionDestinationUserSettings PermissionUpdateDestination = "userSettings"
+	// PermissionDestinationProjectSettings writes to project settings.
+	PermissionDestinationProjectSettings PermissionUpdateDestination = "projectSettings"
+	// PermissionDestinationLocalSettings writes to local settings.
+	PermissionDestinationLocalSettings PermissionUpdateDestination = "localSettings"
+	// PermissionDestinationSession writes to the current session.
+	PermissionDestinationSession PermissionUpdateDestination = "session"
+	// PermissionDestinationCLIArg writes to the CLI argument source.
+	PermissionDestinationCLIArg PermissionUpdateDestination = "cliArg"
+)
 
 // PermissionBehavior controls permission behavior for rules.
 type PermissionBehavior string

--- a/permission_update_test.go
+++ b/permission_update_test.go
@@ -1,0 +1,183 @@
+package claudeagent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermissionUpdateJSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name       string
+		update     PermissionUpdate
+		want       map[string]interface{}
+		absentKeys []string
+	}{
+		{
+			name: "addRules",
+			update: PermissionUpdate{
+				Type: PermissionUpdateTypeAddRules,
+				Rules: []PermissionRule{
+					{ToolName: "Bash", RuleContent: "git status"},
+				},
+				Behavior:    PermissionBehaviorAllow,
+				Destination: PermissionDestinationProjectSettings,
+			},
+			want: map[string]interface{}{
+				"type":        "addRules",
+				"rules":       []interface{}{map[string]interface{}{"toolName": "Bash", "ruleContent": "git status"}},
+				"behavior":    "allow",
+				"destination": "projectSettings",
+			},
+			absentKeys: []string{"mode", "directories"},
+		},
+		{
+			name: "replaceRules",
+			update: PermissionUpdate{
+				Type: PermissionUpdateTypeReplaceRules,
+				Rules: []PermissionRule{
+					{ToolName: "Read", RuleContent: "/tmp/*"},
+				},
+				Behavior:    PermissionBehaviorAsk,
+				Destination: PermissionDestinationUserSettings,
+			},
+			want: map[string]interface{}{
+				"type":        "replaceRules",
+				"rules":       []interface{}{map[string]interface{}{"toolName": "Read", "ruleContent": "/tmp/*"}},
+				"behavior":    "ask",
+				"destination": "userSettings",
+			},
+			absentKeys: []string{"mode", "directories"},
+		},
+		{
+			name: "removeRules",
+			update: PermissionUpdate{
+				Type: PermissionUpdateTypeRemoveRules,
+				Rules: []PermissionRule{
+					{ToolName: "Write", RuleContent: "/tmp/out"},
+				},
+				Behavior:    PermissionBehaviorDeny,
+				Destination: PermissionDestinationLocalSettings,
+			},
+			want: map[string]interface{}{
+				"type":        "removeRules",
+				"rules":       []interface{}{map[string]interface{}{"toolName": "Write", "ruleContent": "/tmp/out"}},
+				"behavior":    "deny",
+				"destination": "localSettings",
+			},
+			absentKeys: []string{"mode", "directories"},
+		},
+		{
+			name: "setMode",
+			update: PermissionUpdate{
+				Type:        PermissionUpdateTypeSetMode,
+				Mode:        PermissionModePlan,
+				Destination: PermissionDestinationSession,
+			},
+			want: map[string]interface{}{
+				"type":        "setMode",
+				"mode":        "plan",
+				"destination": "session",
+			},
+			absentKeys: []string{"rules", "behavior", "directories"},
+		},
+		{
+			name: "addDirectories",
+			update: PermissionUpdate{
+				Type:        PermissionUpdateTypeAddDirectories,
+				Directories: []string{"/a", "/b"},
+				Destination: PermissionDestinationCLIArg,
+			},
+			want: map[string]interface{}{
+				"type":        "addDirectories",
+				"directories": []interface{}{"/a", "/b"},
+				"destination": "cliArg",
+			},
+			absentKeys: []string{"rules", "behavior", "mode"},
+		},
+		{
+			name: "removeDirectories",
+			update: PermissionUpdate{
+				Type:        PermissionUpdateTypeRemoveDirectories,
+				Directories: []string{"/c", "/d"},
+				Destination: PermissionDestinationProjectSettings,
+			},
+			want: map[string]interface{}{
+				"type":        "removeDirectories",
+				"directories": []interface{}{"/c", "/d"},
+				"destination": "projectSettings",
+			},
+			absentKeys: []string{"rules", "behavior", "mode"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.update)
+			require.NoError(t, err)
+
+			var got map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &got))
+
+			for key, value := range tt.want {
+				assert.Equal(t, value, got[key])
+			}
+			for _, key := range tt.absentKeys {
+				assert.NotContains(t, got, key)
+			}
+
+			var decoded PermissionUpdate
+			require.NoError(t, json.Unmarshal(data, &decoded))
+			assert.Equal(t, tt.update, decoded)
+		})
+	}
+}
+
+func TestPermissionRuleJSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name       string
+		rule       PermissionRule
+		want       map[string]interface{}
+		absentKeys []string
+	}{
+		{
+			name: "withRuleContent",
+			rule: PermissionRule{ToolName: "Bash", RuleContent: "git status"},
+			want: map[string]interface{}{
+				"toolName":    "Bash",
+				"ruleContent": "git status",
+			},
+		},
+		{
+			name: "withoutRuleContent",
+			rule: PermissionRule{ToolName: "Read"},
+			want: map[string]interface{}{
+				"toolName": "Read",
+			},
+			absentKeys: []string{"ruleContent"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.rule)
+			require.NoError(t, err)
+
+			var got map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &got))
+
+			for key, value := range tt.want {
+				assert.Equal(t, value, got[key])
+			}
+			for _, key := range tt.absentKeys {
+				assert.NotContains(t, got, key)
+			}
+
+			var decoded PermissionRule
+			require.NoError(t, json.Unmarshal(data, &decoded))
+			assert.Equal(t, tt.rule, decoded)
+		})
+	}
+}


### PR DESCRIPTION
`PermissionUpdate` and `PermissionRule` had no JSON tags, so `PermissionRequestInput.PermissionSuggestions` would round-trip with PascalCase keys — TS expects camelCase per `sdk.d.ts:1793-1827`. Adds tags with `omitempty` on the variant-conditional fields so each of the six TS union arms serializes to the expected shape.

## Type-safety
- New `PermissionUpdateType` typed string enum with constants for all six variants (`addRules`, `replaceRules`, `removeRules`, `setMode`, `addDirectories`, `removeDirectories`).
- New `PermissionUpdateDestination` typed string enum with all five destinations including the previously-missing `cliArg`.
- Untyped string literals at construction sites (e.g. `PermissionUpdate{Type: "addRules"}`) still compile — Go assigns untyped string constants to typed string fields without a conversion.

## Tests
`TestPermissionUpdateJSONRoundTrip` covers all six variants with marshal-then-decode round trips. Each subtest asserts presence of the variant's keys and absence of the others (so e.g. `setMode` has no `rules`/`behavior`/`directories`). `TestPermissionRuleJSONRoundTrip` covers `RuleContent` set vs omitted (omitempty wire behavior).

`go test -count=1 ./...`, `go vet ./...`, `gofmt -l .` clean.

## Out of scope
- Discriminated-union rewrite as separate variant types — kept the all-fields-optional shape per the precedent set by `MCPServerConfig` (PR 11). `omitempty` does the work.
- `updatedInput` / `updatedPermissions` on `PermissionResult` — needs a `PermissionResult` shape change, separate work.
- `PermissionRequestInput` / `PermissionDeniedInput` HOOK types and `HookTypePermissionRequest` constant — already exist.

Part of the v0.2.119 catchup (PR 13b/N).