### PR TITLE
messages: parse hook lifecycle system events

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,6 +50,11 @@ linters:
 
     misspell:
       locale: US
+      # Upstream Claude Code wire protocol uses British spelling for
+      # certain enum values (e.g. hook outcome "cancelled"); the Go SDK
+      # mirrors them verbatim to round-trip.
+      ignore-rules:
+        - cancelled
 
   exclusions:
     rules:

--- a/integration_test.go
+++ b/integration_test.go
@@ -1220,3 +1220,28 @@ func TestIntegrationWorkingDirectory(t *testing.T) {
 	assert.Contains(t, responseText, markerContent,
 		"expected response to contain the marker content, indicating cwd was set correctly")
 }
+
+// TestIntegrationHookLifecycleMessages exercises the wire-protocol hook
+// lifecycle messages (hook_started / hook_progress / hook_response) that are
+// emitted by the CLI when a settings.json subprocess hook fires.
+//
+// These wire messages are distinct from the SDK's callback hooks (see
+// TestIntegrationHooks): callback hooks are control-channel mediated and never
+// surface as system subtype messages. The lifecycle messages we parse here
+// only appear when the CLI runs an external command hook configured via a
+// settings file, and emission is gated on CLI behavior we have not been able
+// to reproduce locally with the v2.1.119 binary using --setting-sources
+// project + a UserPromptSubmit hook entry.
+//
+// TODO(integration): once we know the exact settings shape that triggers wire
+// hook emission in v2.1.119+ (or once a future SDK version exposes a way to
+// register subprocess hooks programmatically), drop the t.Skip and assert that
+// each lifecycle message round-trips with hook_id, hook_name, hook_event, and
+// the expected outcome.
+func TestIntegrationHookLifecycleMessages(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+	t.Skip("not triggerable from CLI yet: settings.json hook configuration " +
+		"shape that emits hook_started/hook_progress/hook_response in v2.1.119 " +
+		"is not reproducible from this test harness; see TODO above")
+}

--- a/messages.go
+++ b/messages.go
@@ -439,11 +439,11 @@ const (
 type HookStartedMessage struct {
 	Type      string `json:"type"`       // Always "system"
 	Subtype   string `json:"subtype"`    // "hook_started"
-	HookID    string `json:"hook_id"`     // Hook invocation ID
-	HookName  string `json:"hook_name"`   // Hook name
-	HookEvent string `json:"hook_event"`  // Hook event name
-	UUID      string `json:"uuid"`        // Unique message ID
-	SessionID string `json:"session_id"`  // Session identifier
+	HookID    string `json:"hook_id"`    // Hook invocation ID
+	HookName  string `json:"hook_name"`  // Hook name
+	HookEvent string `json:"hook_event"` // Hook event name
+	UUID      string `json:"uuid"`       // Unique message ID
+	SessionID string `json:"session_id"` // Session identifier
 }
 
 // MessageType implements Message.
@@ -453,14 +453,14 @@ func (m HookStartedMessage) MessageType() string { return "system" }
 type HookProgressMessage struct {
 	Type      string `json:"type"`       // Always "system"
 	Subtype   string `json:"subtype"`    // "hook_progress"
-	HookID    string `json:"hook_id"`     // Hook invocation ID
-	HookName  string `json:"hook_name"`   // Hook name
-	HookEvent string `json:"hook_event"`  // Hook event name
-	Stdout    string `json:"stdout"`      // Standard output
-	Stderr    string `json:"stderr"`      // Standard error
-	Output    string `json:"output"`      // Combined output
-	UUID      string `json:"uuid"`        // Unique message ID
-	SessionID string `json:"session_id"`  // Session identifier
+	HookID    string `json:"hook_id"`    // Hook invocation ID
+	HookName  string `json:"hook_name"`  // Hook name
+	HookEvent string `json:"hook_event"` // Hook event name
+	Stdout    string `json:"stdout"`     // Standard output
+	Stderr    string `json:"stderr"`     // Standard error
+	Output    string `json:"output"`     // Combined output
+	UUID      string `json:"uuid"`       // Unique message ID
+	SessionID string `json:"session_id"` // Session identifier
 }
 
 // MessageType implements Message.

--- a/messages.go
+++ b/messages.go
@@ -430,9 +430,9 @@ func (m CompactBoundaryMessage) MessageType() string { return "system" }
 type HookOutcome string
 
 const (
-	HookOutcomeSuccess   HookOutcome = "success"
-	HookOutcomeError     HookOutcome = "error"
-	HookOutcomeCancelled HookOutcome = "cancelled"
+	HookOutcomeSuccess  HookOutcome = "success"
+	HookOutcomeError    HookOutcome = "error"
+	HookOutcomeCanceled HookOutcome = "cancelled" //nolint:misspell // upstream wire format spelling
 )
 
 // HookStartedMessage reports that a hook has started executing.

--- a/messages.go
+++ b/messages.go
@@ -426,6 +426,65 @@ type CompactBoundaryMessage struct {
 // MessageType implements Message.
 func (m CompactBoundaryMessage) MessageType() string { return "system" }
 
+// HookOutcome describes the terminal status of a hook execution.
+type HookOutcome string
+
+const (
+	HookOutcomeSuccess   HookOutcome = "success"
+	HookOutcomeError     HookOutcome = "error"
+	HookOutcomeCancelled HookOutcome = "cancelled"
+)
+
+// HookStartedMessage reports that a hook has started executing.
+type HookStartedMessage struct {
+	Type      string `json:"type"`       // Always "system"
+	Subtype   string `json:"subtype"`    // "hook_started"
+	HookID    string `json:"hook_id"`     // Hook invocation ID
+	HookName  string `json:"hook_name"`   // Hook name
+	HookEvent string `json:"hook_event"`  // Hook event name
+	UUID      string `json:"uuid"`        // Unique message ID
+	SessionID string `json:"session_id"`  // Session identifier
+}
+
+// MessageType implements Message.
+func (m HookStartedMessage) MessageType() string { return "system" }
+
+// HookProgressMessage reports intermediate hook execution output.
+type HookProgressMessage struct {
+	Type      string `json:"type"`       // Always "system"
+	Subtype   string `json:"subtype"`    // "hook_progress"
+	HookID    string `json:"hook_id"`     // Hook invocation ID
+	HookName  string `json:"hook_name"`   // Hook name
+	HookEvent string `json:"hook_event"`  // Hook event name
+	Stdout    string `json:"stdout"`      // Standard output
+	Stderr    string `json:"stderr"`      // Standard error
+	Output    string `json:"output"`      // Combined output
+	UUID      string `json:"uuid"`        // Unique message ID
+	SessionID string `json:"session_id"`  // Session identifier
+}
+
+// MessageType implements Message.
+func (m HookProgressMessage) MessageType() string { return "system" }
+
+// HookResponseMessage reports terminal hook execution output.
+type HookResponseMessage struct {
+	Type      string      `json:"type"`                // Always "system"
+	Subtype   string      `json:"subtype"`             // "hook_response"
+	HookID    string      `json:"hook_id"`             // Hook invocation ID
+	HookName  string      `json:"hook_name"`           // Hook name
+	HookEvent string      `json:"hook_event"`          // Hook event name
+	Output    string      `json:"output"`              // Combined output
+	Stdout    string      `json:"stdout"`              // Standard output
+	Stderr    string      `json:"stderr"`              // Standard error
+	ExitCode  *int        `json:"exit_code,omitempty"` // Process exit code
+	Outcome   HookOutcome `json:"outcome"`             // Terminal status
+	UUID      string      `json:"uuid"`                // Unique message ID
+	SessionID string      `json:"session_id"`          // Session identifier
+}
+
+// MessageType implements Message.
+func (m HookResponseMessage) MessageType() string { return "system" }
+
 // CompactMetadata contains details about a compaction event.
 type CompactMetadata struct {
 	Trigger   string `json:"trigger"`    // "manual" or "auto"
@@ -499,7 +558,7 @@ func ParseMessage(data []byte) (Message, error) {
 		return msg, err
 
 	case "system":
-		// System messages have subtypes: "init" or "compact_boundary"
+		// System messages have subtypes: "init", "compact_boundary", and lifecycle events.
 		var base struct {
 			Subtype string `json:"subtype"`
 		}
@@ -507,16 +566,29 @@ func ParseMessage(data []byte) (Message, error) {
 			return nil, err
 		}
 
-		if base.Subtype == "compact_boundary" {
+		switch base.Subtype {
+		case "compact_boundary":
 			var msg CompactBoundaryMessage
 			err := json.Unmarshal(data, &msg)
 			return msg, err
+		case "hook_started":
+			var msg HookStartedMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "hook_progress":
+			var msg HookProgressMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "hook_response":
+			var msg HookResponseMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		default:
+			// Includes "init" and any forward-compatible unknown subtypes.
+			var msg SystemMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
 		}
-
-		// Default: init message
-		var msg SystemMessage
-		err := json.Unmarshal(data, &msg)
-		return msg, err
 
 	case "todo_update":
 		var msg TodoUpdateMessage

--- a/messages_test.go
+++ b/messages_test.go
@@ -629,21 +629,21 @@ func TestParseMessageHookResponse(t *testing.T) {
 			wantOutcome: HookOutcomeError,
 		},
 		{
-			name: "cancelled without exit code",
+			name: "canceled without exit code",
 			input: `{
 				"type": "system",
 				"subtype": "hook_response",
 				"hook_id": "hook_01J8Z8Y2X3K4M5N6P7Q8R9S0T5",
 				"hook_name": "slow-check",
 				"hook_event": "PreToolUse",
-				"output": "cancelled by user\n",
+				"output": "canceled by user\n",
 				"stdout": "",
 				"stderr": "",
 				"outcome": "cancelled",
 				"uuid": "550e8400-e29b-41d4-a716-446655440005",
 				"session_id": "sess_hook_123"
-			}`,
-			wantOutcome: HookOutcomeCancelled,
+			}`, //nolint:misspell // upstream wire format spelling
+			wantOutcome: HookOutcomeCanceled,
 		},
 	}
 

--- a/messages_test.go
+++ b/messages_test.go
@@ -487,6 +487,194 @@ func TestParseMessageSubagentResult(t *testing.T) {
 	assert.Contains(t, subagentMsg.Result, "strong fundamentals")
 }
 
+func TestParseMessageSystemInit(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "init",
+		"uuid": "550e8400-e29b-41d4-a716-446655440000",
+		"session_id": "sess_hook_123",
+		"apiKeySource": "env",
+		"cwd": "/workspace/project",
+		"tools": ["Read", "Edit"],
+		"mcp_servers": [{"name": "github", "status": "connected"}],
+		"model": "claude-opus-4-5-20250929",
+		"permissionMode": "acceptEdits",
+		"slash_commands": ["/help"],
+		"output_style": "default"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	systemMsg, ok := msg.(SystemMessage)
+	require.True(t, ok, "expected SystemMessage")
+
+	assert.Equal(t, "system", systemMsg.MessageType())
+	assert.Equal(t, "init", systemMsg.Subtype)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440000", systemMsg.UUID)
+	assert.Equal(t, "sess_hook_123", systemMsg.SessionID)
+	assert.Equal(t, "env", systemMsg.APIKeySource)
+	assert.Equal(t, "/workspace/project", systemMsg.Cwd)
+	assert.Equal(t, []string{"Read", "Edit"}, systemMsg.Tools)
+	require.Len(t, systemMsg.MCPServers, 1)
+	assert.Equal(t, "github", systemMsg.MCPServers[0].Name)
+	assert.Equal(t, "connected", systemMsg.MCPServers[0].Status)
+	assert.Equal(t, "claude-opus-4-5-20250929", systemMsg.Model)
+	assert.Equal(t, PermissionModeAcceptEdits, systemMsg.PermissionMode)
+	assert.Equal(t, []string{"/help"}, systemMsg.SlashCommands)
+	assert.Equal(t, "default", systemMsg.OutputStyle)
+}
+
+func TestParseMessageHookStarted(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "hook_started",
+		"hook_id": "hook_01J8Z8Y2X3K4M5N6P7Q8R9S0T1",
+		"hook_name": "format-go",
+		"hook_event": "PostToolUse",
+		"uuid": "550e8400-e29b-41d4-a716-446655440001",
+		"session_id": "sess_hook_123"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	hookMsg, ok := msg.(HookStartedMessage)
+	require.True(t, ok, "expected HookStartedMessage")
+
+	assert.Equal(t, "system", hookMsg.MessageType())
+	assert.Equal(t, "system", hookMsg.Type)
+	assert.Equal(t, "hook_started", hookMsg.Subtype)
+	assert.Equal(t, "hook_01J8Z8Y2X3K4M5N6P7Q8R9S0T1", hookMsg.HookID)
+	assert.Equal(t, "format-go", hookMsg.HookName)
+	assert.Equal(t, "PostToolUse", hookMsg.HookEvent)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440001", hookMsg.UUID)
+	assert.Equal(t, "sess_hook_123", hookMsg.SessionID)
+}
+
+func TestParseMessageHookProgress(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "hook_progress",
+		"hook_id": "hook_01J8Z8Y2X3K4M5N6P7Q8R9S0T2",
+		"hook_name": "format-go",
+		"hook_event": "PostToolUse",
+		"stdout": "gofmt messages.go\n",
+		"stderr": "",
+		"output": "gofmt messages.go\n",
+		"uuid": "550e8400-e29b-41d4-a716-446655440002",
+		"session_id": "sess_hook_123"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	hookMsg, ok := msg.(HookProgressMessage)
+	require.True(t, ok, "expected HookProgressMessage")
+
+	assert.Equal(t, "system", hookMsg.MessageType())
+	assert.Equal(t, "system", hookMsg.Type)
+	assert.Equal(t, "hook_progress", hookMsg.Subtype)
+	assert.Equal(t, "hook_01J8Z8Y2X3K4M5N6P7Q8R9S0T2", hookMsg.HookID)
+	assert.Equal(t, "format-go", hookMsg.HookName)
+	assert.Equal(t, "PostToolUse", hookMsg.HookEvent)
+	assert.Equal(t, "gofmt messages.go\n", hookMsg.Stdout)
+	assert.Empty(t, hookMsg.Stderr)
+	assert.Equal(t, "gofmt messages.go\n", hookMsg.Output)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440002", hookMsg.UUID)
+	assert.Equal(t, "sess_hook_123", hookMsg.SessionID)
+}
+
+func TestParseMessageHookResponse(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantOutcome  HookOutcome
+		wantExitCode *int
+	}{
+		{
+			name: "success with exit code",
+			input: `{
+				"type": "system",
+				"subtype": "hook_response",
+				"hook_id": "hook_01J8Z8Y2X3K4M5N6P7Q8R9S0T3",
+				"hook_name": "format-go",
+				"hook_event": "PostToolUse",
+				"output": "formatted files\n",
+				"stdout": "formatted files\n",
+				"stderr": "",
+				"exit_code": 0,
+				"outcome": "success",
+				"uuid": "550e8400-e29b-41d4-a716-446655440003",
+				"session_id": "sess_hook_123"
+			}`,
+			wantOutcome:  HookOutcomeSuccess,
+			wantExitCode: intPtr(0),
+		},
+		{
+			name: "error without exit code",
+			input: `{
+				"type": "system",
+				"subtype": "hook_response",
+				"hook_id": "hook_01J8Z8Y2X3K4M5N6P7Q8R9S0T4",
+				"hook_name": "lint-go",
+				"hook_event": "PostToolUse",
+				"output": "lint failed\n",
+				"stdout": "",
+				"stderr": "lint failed\n",
+				"outcome": "error",
+				"uuid": "550e8400-e29b-41d4-a716-446655440004",
+				"session_id": "sess_hook_123"
+			}`,
+			wantOutcome: HookOutcomeError,
+		},
+		{
+			name: "cancelled without exit code",
+			input: `{
+				"type": "system",
+				"subtype": "hook_response",
+				"hook_id": "hook_01J8Z8Y2X3K4M5N6P7Q8R9S0T5",
+				"hook_name": "slow-check",
+				"hook_event": "PreToolUse",
+				"output": "cancelled by user\n",
+				"stdout": "",
+				"stderr": "",
+				"outcome": "cancelled",
+				"uuid": "550e8400-e29b-41d4-a716-446655440005",
+				"session_id": "sess_hook_123"
+			}`,
+			wantOutcome: HookOutcomeCancelled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseMessage([]byte(tt.input))
+			require.NoError(t, err)
+
+			hookMsg, ok := msg.(HookResponseMessage)
+			require.True(t, ok, "expected HookResponseMessage")
+
+			assert.Equal(t, "system", hookMsg.MessageType())
+			assert.Equal(t, "system", hookMsg.Type)
+			assert.Equal(t, "hook_response", hookMsg.Subtype)
+			assert.NotEmpty(t, hookMsg.HookID)
+			assert.NotEmpty(t, hookMsg.HookName)
+			assert.NotEmpty(t, hookMsg.HookEvent)
+			assert.NotEmpty(t, hookMsg.Output)
+			assert.Equal(t, tt.wantOutcome, hookMsg.Outcome)
+			if tt.wantExitCode == nil {
+				assert.Nil(t, hookMsg.ExitCode)
+			} else {
+				require.NotNil(t, hookMsg.ExitCode)
+				assert.Equal(t, *tt.wantExitCode, *hookMsg.ExitCode)
+			}
+			assert.NotEmpty(t, hookMsg.UUID)
+			assert.Equal(t, "sess_hook_123", hookMsg.SessionID)
+		})
+	}
+}
+
 // TestParseMessageControlRequest tests parsing control requests.
 func TestParseMessageControlRequest(t *testing.T) {
 	input := `{
@@ -663,6 +851,8 @@ func BenchmarkParseMessage(b *testing.B) {
 		_, _ = ParseMessage(input)
 	}
 }
+
+func intPtr(i int) *int { return &i }
 
 // BenchmarkContentText benchmarks content text extraction.
 func BenchmarkContentText(b *testing.B) {

--- a/messages_test.go
+++ b/messages_test.go
@@ -525,6 +525,33 @@ func TestParseMessageSystemInit(t *testing.T) {
 	assert.Equal(t, "default", systemMsg.OutputStyle)
 }
 
+func TestParseMessageCompactBoundary(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "compact_boundary",
+		"uuid": "550e8400-e29b-41d4-a716-446655440010",
+		"session_id": "sess_compact_123",
+		"compact_metadata": {
+			"trigger": "auto",
+			"pre_tokens": 198732
+		}
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	compactMsg, ok := msg.(CompactBoundaryMessage)
+	require.True(t, ok, "expected CompactBoundaryMessage")
+
+	assert.Equal(t, "system", compactMsg.MessageType())
+	assert.Equal(t, "system", compactMsg.Type)
+	assert.Equal(t, "compact_boundary", compactMsg.Subtype)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440010", compactMsg.UUID)
+	assert.Equal(t, "sess_compact_123", compactMsg.SessionID)
+	assert.Equal(t, "auto", compactMsg.CompactMetadata.Trigger)
+	assert.Equal(t, 198732, compactMsg.CompactMetadata.PreTokens)
+}
+
 func TestParseMessageHookStarted(t *testing.T) {
 	input := `{
 		"type": "system",


### PR DESCRIPTION
## Summary
- Add `HookStartedMessage`, `HookProgressMessage`, and `HookResponseMessage` for the upstream hook lifecycle system subtypes (`hook_started` / `hook_progress` / `hook_response`).
- Switch `ParseMessage` system-subtype dispatch to a `switch`, routing the three new subtypes and falling through to `SystemMessage` for `init` and any forward-compatible unknown subtypes.
- Tests cover all three lifecycle messages plus the `exit_code` present/absent variants and unchanged `init` fallback behavior.

## Test plan
- [x] `go test ./...`
- [x] `go vet ./...`