### PR TITLE
messages: add misc system subtype message types

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -610,15 +610,15 @@ const (
 
 // APIRetryMessage reports that a failed API request will be retried.
 type APIRetryMessage struct {
-	Type         string        `json:"type"`                   // Always "system"
-	Subtype      string        `json:"subtype"`                // "api_retry"
-	Attempt      int           `json:"attempt"`                // Current retry attempt
-	MaxRetries   int           `json:"max_retries"`            // Maximum retry attempts
-	RetryDelayMS int           `json:"retry_delay_ms"`         // Delay before retry
-	ErrorStatus  *int          `json:"error_status,omitempty"` // HTTP status, nil for connection errors
-	Error        APIRetryError `json:"error"`                  // Retryable error category
-	UUID         string        `json:"uuid"`                   // Unique message ID
-	SessionID    string        `json:"session_id"`             // Session identifier
+	Type         string        `json:"type"`           // Always "system"
+	Subtype      string        `json:"subtype"`        // "api_retry"
+	Attempt      int           `json:"attempt"`        // Current retry attempt
+	MaxRetries   int           `json:"max_retries"`    // Maximum retry attempts
+	RetryDelayMS int           `json:"retry_delay_ms"` // Delay before retry
+	ErrorStatus  *int          `json:"error_status"`   // HTTP status, nil represents JSON null (connection errors)
+	Error        APIRetryError `json:"error"`          // Retryable error category
+	UUID         string        `json:"uuid"`           // Unique message ID
+	SessionID    string        `json:"session_id"`     // Session identifier
 }
 
 // MessageType implements Message.

--- a/messages.go
+++ b/messages.go
@@ -593,6 +593,246 @@ type TaskNotificationMessage struct {
 // MessageType implements Message.
 func (m TaskNotificationMessage) MessageType() string { return "system" }
 
+// Misc system subtype messages.
+
+// APIRetryError is the retryable assistant-message error category.
+type APIRetryError string
+
+const (
+	APIRetryErrorAuthenticationFailed APIRetryError = "authentication_failed"
+	APIRetryErrorBillingError         APIRetryError = "billing_error"
+	APIRetryErrorRateLimit            APIRetryError = "rate_limit"
+	APIRetryErrorInvalidRequest       APIRetryError = "invalid_request"
+	APIRetryErrorServerError          APIRetryError = "server_error"
+	APIRetryErrorUnknown              APIRetryError = "unknown"
+	APIRetryErrorMaxOutputTokens      APIRetryError = "max_output_tokens"
+)
+
+// APIRetryMessage reports that a failed API request will be retried.
+type APIRetryMessage struct {
+	Type         string        `json:"type"`                   // Always "system"
+	Subtype      string        `json:"subtype"`                // "api_retry"
+	Attempt      int           `json:"attempt"`                // Current retry attempt
+	MaxRetries   int           `json:"max_retries"`            // Maximum retry attempts
+	RetryDelayMS int           `json:"retry_delay_ms"`         // Delay before retry
+	ErrorStatus  *int          `json:"error_status,omitempty"` // HTTP status, nil for connection errors
+	Error        APIRetryError `json:"error"`                  // Retryable error category
+	UUID         string        `json:"uuid"`                   // Unique message ID
+	SessionID    string        `json:"session_id"`             // Session identifier
+}
+
+// MessageType implements Message.
+func (m APIRetryMessage) MessageType() string { return "system" }
+
+// ElicitationCompleteMessage reports completion of a URL-mode MCP elicitation.
+type ElicitationCompleteMessage struct {
+	Type          string `json:"type"`            // Always "system"
+	Subtype       string `json:"subtype"`         // "elicitation_complete"
+	MCPServerName string `json:"mcp_server_name"` // MCP server name
+	ElicitationID string `json:"elicitation_id"`  // Elicitation identifier
+	UUID          string `json:"uuid"`            // Unique message ID
+	SessionID     string `json:"session_id"`      // Session identifier
+}
+
+// MessageType implements Message.
+func (m ElicitationCompleteMessage) MessageType() string { return "system" }
+
+// FilesPersistedSuccess describes a successfully persisted file.
+type FilesPersistedSuccess struct {
+	Filename string `json:"filename"`
+	FileID   string `json:"file_id"`
+}
+
+// FilesPersistedFailure describes a file that failed to persist.
+type FilesPersistedFailure struct {
+	Filename string `json:"filename"`
+	Error    string `json:"error"`
+}
+
+// FilesPersistedEvent reports persisted files and per-file failures.
+type FilesPersistedEvent struct {
+	Type        string                  `json:"type"`         // Always "system"
+	Subtype     string                  `json:"subtype"`      // "files_persisted"
+	Files       []FilesPersistedSuccess `json:"files"`        // Persisted files
+	Failed      []FilesPersistedFailure `json:"failed"`       // Failed files
+	ProcessedAt string                  `json:"processed_at"` // Processing timestamp
+	UUID        string                  `json:"uuid"`         // Unique message ID
+	SessionID   string                  `json:"session_id"`   // Session identifier
+}
+
+// MessageType implements Message.
+func (m FilesPersistedEvent) MessageType() string { return "system" }
+
+// LocalCommandOutputMessage reports output from a local slash command.
+type LocalCommandOutputMessage struct {
+	Type      string `json:"type"`       // Always "system"
+	Subtype   string `json:"subtype"`    // "local_command_output"
+	Content   string `json:"content"`    // Command output
+	UUID      string `json:"uuid"`       // Unique message ID
+	SessionID string `json:"session_id"` // Session identifier
+}
+
+// MessageType implements Message.
+func (m LocalCommandOutputMessage) MessageType() string { return "system" }
+
+// MemoryRecallMode describes how memories were surfaced.
+type MemoryRecallMode string
+
+const (
+	MemoryRecallModeSelect     MemoryRecallMode = "select"
+	MemoryRecallModeSynthesize MemoryRecallMode = "synthesize"
+)
+
+// MemoryScope identifies the source scope for a recalled memory.
+type MemoryScope string
+
+const (
+	MemoryScopePersonal MemoryScope = "personal"
+	MemoryScopeTeam     MemoryScope = "team"
+)
+
+// MemoryRecallEntry describes one recalled memory or synthesis.
+type MemoryRecallEntry struct {
+	Path    string      `json:"path"`
+	Scope   MemoryScope `json:"scope"`
+	Content string      `json:"content,omitempty"`
+}
+
+// MemoryRecallMessage reports memories surfaced into the current turn.
+type MemoryRecallMessage struct {
+	Type      string              `json:"type"`       // Always "system"
+	Subtype   string              `json:"subtype"`    // "memory_recall"
+	Mode      MemoryRecallMode    `json:"mode"`       // Recall mode
+	Memories  []MemoryRecallEntry `json:"memories"`   // Recalled memories
+	UUID      string              `json:"uuid"`       // Unique message ID
+	SessionID string              `json:"session_id"` // Session identifier
+}
+
+// MessageType implements Message.
+func (m MemoryRecallMessage) MessageType() string { return "system" }
+
+// MirrorErrorKey identifies the transcript mirror batch that failed.
+type MirrorErrorKey struct {
+	ProjectKey string `json:"projectKey"`
+	SessionID  string `json:"sessionId"`
+	Subpath    string `json:"subpath,omitempty"`
+}
+
+// MirrorErrorMessage reports a transcript mirror append failure.
+type MirrorErrorMessage struct {
+	Type      string         `json:"type"`       // Always "system"
+	Subtype   string         `json:"subtype"`    // "mirror_error"
+	Error     string         `json:"error"`      // Error text
+	Key       MirrorErrorKey `json:"key"`        // Mirror batch key
+	UUID      string         `json:"uuid"`       // Unique message ID
+	SessionID string         `json:"session_id"` // Session identifier
+}
+
+// MessageType implements Message.
+func (m MirrorErrorMessage) MessageType() string { return "system" }
+
+// NotificationPriority is the display urgency for a loop-side notification.
+type NotificationPriority string
+
+const (
+	NotificationPriorityLow       NotificationPriority = "low"
+	NotificationPriorityMedium    NotificationPriority = "medium"
+	NotificationPriorityHigh      NotificationPriority = "high"
+	NotificationPriorityImmediate NotificationPriority = "immediate"
+)
+
+// NotificationMessage reports a loop-side text notification.
+type NotificationMessage struct {
+	Type      string               `json:"type"`                 // Always "system"
+	Subtype   string               `json:"subtype"`              // "notification"
+	Key       string               `json:"key"`                  // Notification key
+	Text      string               `json:"text"`                 // Notification text
+	Priority  NotificationPriority `json:"priority"`             // Display urgency
+	Color     string               `json:"color,omitempty"`      // Optional display color
+	TimeoutMS *int                 `json:"timeout_ms,omitempty"` // Optional timeout
+	UUID      string               `json:"uuid"`                 // Unique message ID
+	SessionID string               `json:"session_id"`           // Session identifier
+}
+
+// MessageType implements Message.
+func (m NotificationMessage) MessageType() string { return "system" }
+
+// PluginInstallStatus is the plugin installation progress state.
+type PluginInstallStatus string
+
+const (
+	PluginInstallStatusStarted   PluginInstallStatus = "started"
+	PluginInstallStatusInstalled PluginInstallStatus = "installed"
+	PluginInstallStatusFailed    PluginInstallStatus = "failed"
+	PluginInstallStatusCompleted PluginInstallStatus = "completed"
+)
+
+// PluginInstallMessage reports headless plugin installation progress.
+type PluginInstallMessage struct {
+	Type      string              `json:"type"`            // Always "system"
+	Subtype   string              `json:"subtype"`         // "plugin_install"
+	Status    PluginInstallStatus `json:"status"`          // Installation status
+	Name      string              `json:"name,omitempty"`  // Marketplace or plugin name
+	Error     string              `json:"error,omitempty"` // Failure text
+	UUID      string              `json:"uuid"`            // Unique message ID
+	SessionID string              `json:"session_id"`      // Session identifier
+}
+
+// MessageType implements Message.
+func (m PluginInstallMessage) MessageType() string { return "system" }
+
+// SessionState is the current session run state.
+type SessionState string
+
+const (
+	SessionStateIdle           SessionState = "idle"
+	SessionStateRunning        SessionState = "running"
+	SessionStateRequiresAction SessionState = "requires_action"
+)
+
+// SessionStateChangedMessage reports authoritative turn-over state changes.
+type SessionStateChangedMessage struct {
+	Type      string       `json:"type"`       // Always "system"
+	Subtype   string       `json:"subtype"`    // "session_state_changed"
+	State     SessionState `json:"state"`      // Session state
+	UUID      string       `json:"uuid"`       // Unique message ID
+	SessionID string       `json:"session_id"` // Session identifier
+}
+
+// MessageType implements Message.
+func (m SessionStateChangedMessage) MessageType() string { return "system" }
+
+// SDKStatusValue is the non-null status payload for a status message.
+type SDKStatusValue string
+
+const (
+	SDKStatusCompacting SDKStatusValue = "compacting"
+	SDKStatusRequesting SDKStatusValue = "requesting"
+)
+
+// CompactResult is the terminal compaction result carried by status messages.
+type CompactResult string
+
+const (
+	CompactResultSuccess CompactResult = "success"
+	CompactResultFailed  CompactResult = "failed"
+)
+
+// StatusMessage reports current SDK status.
+type StatusMessage struct {
+	Type           string          `json:"type"`                     // Always "system"
+	Subtype        string          `json:"subtype"`                  // "status"
+	Status         *SDKStatusValue `json:"status"`                   // Nil represents JSON null
+	PermissionMode PermissionMode  `json:"permissionMode,omitempty"` // Optional permission mode
+	CompactResult  CompactResult   `json:"compact_result,omitempty"` // Optional compact result
+	CompactError   string          `json:"compact_error,omitempty"`  // Optional compact error
+	UUID           string          `json:"uuid"`                     // Unique message ID
+	SessionID      string          `json:"session_id"`               // Session identifier
+}
+
+// MessageType implements Message.
+func (m StatusMessage) MessageType() string { return "system" }
+
 // CompactMetadata contains details about a compaction event.
 type CompactMetadata struct {
 	Trigger   string `json:"trigger"`    // "manual" or "auto"
@@ -705,6 +945,46 @@ func ParseMessage(data []byte) (Message, error) {
 			return msg, err
 		case "task_notification":
 			var msg TaskNotificationMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "api_retry":
+			var msg APIRetryMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "elicitation_complete":
+			var msg ElicitationCompleteMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "files_persisted":
+			var msg FilesPersistedEvent
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "local_command_output":
+			var msg LocalCommandOutputMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "memory_recall":
+			var msg MemoryRecallMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "mirror_error":
+			var msg MirrorErrorMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "notification":
+			var msg NotificationMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "plugin_install":
+			var msg PluginInstallMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "session_state_changed":
+			var msg SessionStateChangedMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "status":
+			var msg StatusMessage
 			err := json.Unmarshal(data, &msg)
 			return msg, err
 		default:

--- a/messages_test.go
+++ b/messages_test.go
@@ -1053,6 +1053,540 @@ func TestParseMessageTaskNotification(t *testing.T) {
 	}
 }
 
+func TestParseMessageAPIRetry(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		wantErrorStatus *int
+		wantError       APIRetryError
+	}{
+		{
+			name: "rate limit with HTTP status",
+			input: `{
+				"type": "system",
+				"subtype": "api_retry",
+				"attempt": 2,
+				"max_retries": 5,
+				"retry_delay_ms": 1500,
+				"error_status": 429,
+				"error": "rate_limit",
+				"uuid": "550e8400-e29b-41d4-a716-446655440200",
+				"session_id": "sess_misc_001"
+			}`,
+			wantErrorStatus: intPtr(429),
+			wantError:       APIRetryErrorRateLimit,
+		},
+		{
+			name: "connection error with null status",
+			input: `{
+				"type": "system",
+				"subtype": "api_retry",
+				"attempt": 1,
+				"max_retries": 3,
+				"retry_delay_ms": 250,
+				"error_status": null,
+				"error": "server_error",
+				"uuid": "550e8400-e29b-41d4-a716-446655440201",
+				"session_id": "sess_misc_001"
+			}`,
+			wantError: APIRetryErrorServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseMessage([]byte(tt.input))
+			require.NoError(t, err)
+
+			retryMsg, ok := msg.(APIRetryMessage)
+			require.True(t, ok, "expected APIRetryMessage")
+
+			assert.Equal(t, "system", retryMsg.MessageType())
+			assert.Equal(t, "api_retry", retryMsg.Subtype)
+			assert.Equal(t, tt.wantError, retryMsg.Error)
+
+			if tt.wantErrorStatus == nil {
+				assert.Nil(t, retryMsg.ErrorStatus)
+			} else {
+				require.NotNil(t, retryMsg.ErrorStatus)
+				assert.Equal(t, *tt.wantErrorStatus, *retryMsg.ErrorStatus)
+			}
+		})
+	}
+}
+
+func TestParseMessageElicitationComplete(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "elicitation_complete",
+		"mcp_server_name": "github",
+		"elicitation_id": "elic_01HXYZ",
+		"uuid": "550e8400-e29b-41d4-a716-446655440210",
+		"session_id": "sess_misc_002"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	elicMsg, ok := msg.(ElicitationCompleteMessage)
+	require.True(t, ok, "expected ElicitationCompleteMessage")
+
+	assert.Equal(t, "system", elicMsg.MessageType())
+	assert.Equal(t, "elicitation_complete", elicMsg.Subtype)
+	assert.Equal(t, "github", elicMsg.MCPServerName)
+	assert.Equal(t, "elic_01HXYZ", elicMsg.ElicitationID)
+	assert.Equal(t, "sess_misc_002", elicMsg.SessionID)
+}
+
+func TestParseMessageFilesPersisted(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantFiles  int
+		wantFailed int
+	}{
+		{
+			name: "successes and failures",
+			input: `{
+				"type": "system",
+				"subtype": "files_persisted",
+				"files": [
+					{ "filename": "a.txt", "file_id": "file_001" },
+					{ "filename": "b.txt", "file_id": "file_002" }
+				],
+				"failed": [
+					{ "filename": "c.txt", "error": "io error" }
+				],
+				"processed_at": "2026-04-25T18:30:00Z",
+				"uuid": "550e8400-e29b-41d4-a716-446655440220",
+				"session_id": "sess_misc_003"
+			}`,
+			wantFiles:  2,
+			wantFailed: 1,
+		},
+		{
+			name: "only successes",
+			input: `{
+				"type": "system",
+				"subtype": "files_persisted",
+				"files": [
+					{ "filename": "only.txt", "file_id": "file_010" }
+				],
+				"failed": [],
+				"processed_at": "2026-04-25T18:31:00Z",
+				"uuid": "550e8400-e29b-41d4-a716-446655440221",
+				"session_id": "sess_misc_003"
+			}`,
+			wantFiles:  1,
+			wantFailed: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseMessage([]byte(tt.input))
+			require.NoError(t, err)
+
+			fpMsg, ok := msg.(FilesPersistedEvent)
+			require.True(t, ok, "expected FilesPersistedEvent")
+
+			assert.Equal(t, "system", fpMsg.MessageType())
+			assert.Equal(t, "files_persisted", fpMsg.Subtype)
+			assert.Len(t, fpMsg.Files, tt.wantFiles)
+			assert.Len(t, fpMsg.Failed, tt.wantFailed)
+			assert.NotEmpty(t, fpMsg.ProcessedAt)
+			if tt.wantFiles > 0 {
+				assert.NotEmpty(t, fpMsg.Files[0].Filename)
+				assert.NotEmpty(t, fpMsg.Files[0].FileID)
+			}
+			if tt.wantFailed > 0 {
+				assert.NotEmpty(t, fpMsg.Failed[0].Filename)
+				assert.NotEmpty(t, fpMsg.Failed[0].Error)
+			}
+		})
+	}
+}
+
+func TestParseMessageLocalCommandOutput(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "local_command_output",
+		"content": "Usage: 1234 tokens this turn",
+		"uuid": "550e8400-e29b-41d4-a716-446655440230",
+		"session_id": "sess_misc_004"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	cmdMsg, ok := msg.(LocalCommandOutputMessage)
+	require.True(t, ok, "expected LocalCommandOutputMessage")
+
+	assert.Equal(t, "system", cmdMsg.MessageType())
+	assert.Equal(t, "local_command_output", cmdMsg.Subtype)
+	assert.Equal(t, "Usage: 1234 tokens this turn", cmdMsg.Content)
+	assert.Equal(t, "sess_misc_004", cmdMsg.SessionID)
+}
+
+func TestParseMessageMemoryRecall(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            string
+		wantMode         MemoryRecallMode
+		wantEntries      int
+		wantContentEntry int // index of entry expected to have non-empty content; -1 = none
+	}{
+		{
+			name: "select mode without content",
+			input: `{
+				"type": "system",
+				"subtype": "memory_recall",
+				"mode": "select",
+				"memories": [
+					{ "path": "/memo/a.md", "scope": "personal" },
+					{ "path": "/memo/b.md", "scope": "team" }
+				],
+				"uuid": "550e8400-e29b-41d4-a716-446655440240",
+				"session_id": "sess_misc_005"
+			}`,
+			wantMode:         MemoryRecallModeSelect,
+			wantEntries:      2,
+			wantContentEntry: -1,
+		},
+		{
+			name: "synthesize mode with content",
+			input: `{
+				"type": "system",
+				"subtype": "memory_recall",
+				"mode": "synthesize",
+				"memories": [
+					{ "path": "<synthesis:/memo>", "scope": "team", "content": "Distilled paragraph." }
+				],
+				"uuid": "550e8400-e29b-41d4-a716-446655440241",
+				"session_id": "sess_misc_005"
+			}`,
+			wantMode:         MemoryRecallModeSynthesize,
+			wantEntries:      1,
+			wantContentEntry: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseMessage([]byte(tt.input))
+			require.NoError(t, err)
+
+			recallMsg, ok := msg.(MemoryRecallMessage)
+			require.True(t, ok, "expected MemoryRecallMessage")
+
+			assert.Equal(t, "system", recallMsg.MessageType())
+			assert.Equal(t, "memory_recall", recallMsg.Subtype)
+			assert.Equal(t, tt.wantMode, recallMsg.Mode)
+			assert.Len(t, recallMsg.Memories, tt.wantEntries)
+
+			for i, entry := range recallMsg.Memories {
+				assert.NotEmpty(t, entry.Path)
+				assert.NotEmpty(t, string(entry.Scope))
+				if i == tt.wantContentEntry {
+					assert.NotEmpty(t, entry.Content)
+				} else {
+					assert.Empty(t, entry.Content)
+				}
+			}
+		})
+	}
+}
+
+func TestParseMessageMirrorError(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantSubpath string
+	}{
+		{
+			name: "with subpath",
+			input: `{
+				"type": "system",
+				"subtype": "mirror_error",
+				"error": "store unavailable",
+				"key": {
+					"projectKey": "proj_001",
+					"sessionId": "sess_xyz",
+					"subpath": "transcript/v1"
+				},
+				"uuid": "550e8400-e29b-41d4-a716-446655440250",
+				"session_id": "sess_misc_006"
+			}`,
+			wantSubpath: "transcript/v1",
+		},
+		{
+			name: "without subpath",
+			input: `{
+				"type": "system",
+				"subtype": "mirror_error",
+				"error": "timeout after 3 retries",
+				"key": {
+					"projectKey": "proj_002",
+					"sessionId": "sess_uvw"
+				},
+				"uuid": "550e8400-e29b-41d4-a716-446655440251",
+				"session_id": "sess_misc_006"
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseMessage([]byte(tt.input))
+			require.NoError(t, err)
+
+			mirMsg, ok := msg.(MirrorErrorMessage)
+			require.True(t, ok, "expected MirrorErrorMessage")
+
+			assert.Equal(t, "system", mirMsg.MessageType())
+			assert.Equal(t, "mirror_error", mirMsg.Subtype)
+			assert.NotEmpty(t, mirMsg.Error)
+			assert.NotEmpty(t, mirMsg.Key.ProjectKey)
+			assert.NotEmpty(t, mirMsg.Key.SessionID)
+			assert.Equal(t, tt.wantSubpath, mirMsg.Key.Subpath)
+		})
+	}
+}
+
+func TestParseMessageNotification(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantPriority  NotificationPriority
+		wantColor     string
+		wantTimeoutMS *int
+	}{
+		{
+			name: "low with no optional fields",
+			input: `{
+				"type": "system",
+				"subtype": "notification",
+				"key": "low_test",
+				"text": "low priority message",
+				"priority": "low",
+				"uuid": "550e8400-e29b-41d4-a716-446655440260",
+				"session_id": "sess_misc_007"
+			}`,
+			wantPriority: NotificationPriorityLow,
+		},
+		{
+			name: "medium with color and timeout",
+			input: `{
+				"type": "system",
+				"subtype": "notification",
+				"key": "medium_test",
+				"text": "medium priority message",
+				"priority": "medium",
+				"color": "#ffaa00",
+				"timeout_ms": 5000,
+				"uuid": "550e8400-e29b-41d4-a716-446655440261",
+				"session_id": "sess_misc_007"
+			}`,
+			wantPriority:  NotificationPriorityMedium,
+			wantColor:     "#ffaa00",
+			wantTimeoutMS: intPtr(5000),
+		},
+		{
+			name: "high",
+			input: `{
+				"type": "system",
+				"subtype": "notification",
+				"key": "high_test",
+				"text": "high priority",
+				"priority": "high",
+				"uuid": "550e8400-e29b-41d4-a716-446655440262",
+				"session_id": "sess_misc_007"
+			}`,
+			wantPriority: NotificationPriorityHigh,
+		},
+		{
+			name: "immediate",
+			input: `{
+				"type": "system",
+				"subtype": "notification",
+				"key": "immediate_test",
+				"text": "act now",
+				"priority": "immediate",
+				"uuid": "550e8400-e29b-41d4-a716-446655440263",
+				"session_id": "sess_misc_007"
+			}`,
+			wantPriority: NotificationPriorityImmediate,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseMessage([]byte(tt.input))
+			require.NoError(t, err)
+
+			notifMsg, ok := msg.(NotificationMessage)
+			require.True(t, ok, "expected NotificationMessage")
+
+			assert.Equal(t, "system", notifMsg.MessageType())
+			assert.Equal(t, "notification", notifMsg.Subtype)
+			assert.NotEmpty(t, notifMsg.Key)
+			assert.NotEmpty(t, notifMsg.Text)
+			assert.Equal(t, tt.wantPriority, notifMsg.Priority)
+			assert.Equal(t, tt.wantColor, notifMsg.Color)
+
+			if tt.wantTimeoutMS == nil {
+				assert.Nil(t, notifMsg.TimeoutMS)
+			} else {
+				require.NotNil(t, notifMsg.TimeoutMS)
+				assert.Equal(t, *tt.wantTimeoutMS, *notifMsg.TimeoutMS)
+			}
+		})
+	}
+}
+
+func TestParseMessagePluginInstall(t *testing.T) {
+	cases := []struct {
+		status PluginInstallStatus
+		name   string
+		err    string
+	}{
+		{status: PluginInstallStatusStarted},
+		{status: PluginInstallStatusInstalled, name: "marketplace-foo"},
+		{status: PluginInstallStatusFailed, name: "marketplace-bar", err: "checksum mismatch"},
+		{status: PluginInstallStatusCompleted},
+	}
+
+	for i, c := range cases {
+		t.Run(string(c.status), func(t *testing.T) {
+			body := `"status":"` + string(c.status) + `"`
+			if c.name != "" {
+				body += `,"name":"` + c.name + `"`
+			}
+			if c.err != "" {
+				body += `,"error":"` + c.err + `"`
+			}
+			input := `{
+				"type": "system",
+				"subtype": "plugin_install",
+				` + body + `,
+				"uuid": "550e8400-e29b-41d4-a716-44665544027` + string(rune('0'+i)) + `",
+				"session_id": "sess_misc_008"
+			}`
+
+			msg, err := ParseMessage([]byte(input))
+			require.NoError(t, err)
+
+			plugMsg, ok := msg.(PluginInstallMessage)
+			require.True(t, ok, "expected PluginInstallMessage")
+
+			assert.Equal(t, "system", plugMsg.MessageType())
+			assert.Equal(t, "plugin_install", plugMsg.Subtype)
+			assert.Equal(t, c.status, plugMsg.Status)
+			assert.Equal(t, c.name, plugMsg.Name)
+			assert.Equal(t, c.err, plugMsg.Error)
+		})
+	}
+}
+
+func TestParseMessageSessionStateChanged(t *testing.T) {
+	for _, state := range []SessionState{SessionStateIdle, SessionStateRunning, SessionStateRequiresAction} {
+		t.Run(string(state), func(t *testing.T) {
+			input := `{
+				"type": "system",
+				"subtype": "session_state_changed",
+				"state": "` + string(state) + `",
+				"uuid": "550e8400-e29b-41d4-a716-446655440290",
+				"session_id": "sess_misc_009"
+			}`
+
+			msg, err := ParseMessage([]byte(input))
+			require.NoError(t, err)
+
+			stateMsg, ok := msg.(SessionStateChangedMessage)
+			require.True(t, ok, "expected SessionStateChangedMessage")
+
+			assert.Equal(t, "system", stateMsg.MessageType())
+			assert.Equal(t, "session_state_changed", stateMsg.Subtype)
+			assert.Equal(t, state, stateMsg.State)
+		})
+	}
+}
+
+func TestParseMessageStatus(t *testing.T) {
+	tests := []struct {
+		name               string
+		input              string
+		wantStatusNil      bool
+		wantStatus         SDKStatusValue
+		wantPermissionMode PermissionMode
+		wantCompactResult  CompactResult
+		wantCompactError   string
+	}{
+		{
+			name: "compacting with permission mode",
+			input: `{
+				"type": "system",
+				"subtype": "status",
+				"status": "compacting",
+				"permissionMode": "acceptEdits",
+				"uuid": "550e8400-e29b-41d4-a716-4466554402A0",
+				"session_id": "sess_misc_010"
+			}`,
+			wantStatus:         SDKStatusCompacting,
+			wantPermissionMode: PermissionModeAcceptEdits,
+		},
+		{
+			name: "null status",
+			input: `{
+				"type": "system",
+				"subtype": "status",
+				"status": null,
+				"uuid": "550e8400-e29b-41d4-a716-4466554402A1",
+				"session_id": "sess_misc_010"
+			}`,
+			wantStatusNil: true,
+		},
+		{
+			name: "compact failed with error",
+			input: `{
+				"type": "system",
+				"subtype": "status",
+				"status": "requesting",
+				"compact_result": "failed",
+				"compact_error": "context too large",
+				"uuid": "550e8400-e29b-41d4-a716-4466554402A2",
+				"session_id": "sess_misc_010"
+			}`,
+			wantStatus:        SDKStatusRequesting,
+			wantCompactResult: CompactResultFailed,
+			wantCompactError:  "context too large",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseMessage([]byte(tt.input))
+			require.NoError(t, err)
+
+			statusMsg, ok := msg.(StatusMessage)
+			require.True(t, ok, "expected StatusMessage")
+
+			assert.Equal(t, "system", statusMsg.MessageType())
+			assert.Equal(t, "status", statusMsg.Subtype)
+
+			if tt.wantStatusNil {
+				assert.Nil(t, statusMsg.Status)
+			} else {
+				require.NotNil(t, statusMsg.Status)
+				assert.Equal(t, tt.wantStatus, *statusMsg.Status)
+			}
+			assert.Equal(t, tt.wantPermissionMode, statusMsg.PermissionMode)
+			assert.Equal(t, tt.wantCompactResult, statusMsg.CompactResult)
+			assert.Equal(t, tt.wantCompactError, statusMsg.CompactError)
+		})
+	}
+}
+
 // TestParseMessageControlRequest tests parsing control requests.
 func TestParseMessageControlRequest(t *testing.T) {
 	input := `{


### PR DESCRIPTION
## Summary

Adds parsers for the ten remaining system-subtype messages in `@anthropic-ai/claude-agent-sdk@0.2.119`:

| Subtype                | Go type                          | sdk.d.ts |
|------------------------|----------------------------------|----------|
| `api_retry`            | `APIRetryMessage`                | L2262 |
| `elicitation_complete` | `ElicitationCompleteMessage`     | L2780 |
| `files_persisted`      | `FilesPersistedEvent`            | L2789 |
| `local_command_output` | `LocalCommandOutputMessage`      | L2872 |
| `memory_recall`        | `MemoryRecallMessage`            | L2897 |
| `mirror_error`         | `MirrorErrorMessage`             | L2942 |
| `notification`         | `NotificationMessage`            | L2958 |
| `plugin_install`       | `PluginInstallMessage`           | L3002 |
| `session_state_changed`| `SessionStateChangedMessage`     | L3243 |
| `status`               | `StatusMessage`                  | L3271 |

Adds the supporting typed string enums (`APIRetryError`, `MemoryRecallMode`, `MemoryScope`, `NotificationPriority`, `PluginInstallStatus`, `SessionState`, `SDKStatusValue`, `CompactResult`) and nested sub-structs (`FilesPersistedSuccess` / `FilesPersistedFailure`, `MemoryRecallEntry`, `MirrorErrorKey`). `StatusMessage.Status` is `*SDKStatusValue` so JSON `null` is preserved as nil.

Continuation of the PR 14 split:
- 14a (#42, merged): hook lifecycle subtypes + dispatch refactor.
- 14b (#43, merged): task lifecycle subtypes.
- **14c (this PR):** the remaining ten misc system subtypes.
- 14d (next): top-level message types (`tool_use_summary`, `prompt_suggestion`, `rate_limit_event`, `auth_status` integration).

Default switch arm and pre-existing dispatch arms are untouched. No `client.go` / `transport.go` changes.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test ./...` green; ten new tests cover all ten message types, including null/nullable cases (`error_status: null`, `status: null`), enum round-trip for all values where the wire is multi-valued, and nested struct optionality (`mirror_error.key.subpath`, `notification.timeout_ms`)
- [ ] CI green on push