### PR TITLE
messages: add tool_use_summary, prompt_suggestion, rate_limit_event

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -376,9 +376,9 @@ const (
 	RateLimitOverageDisabledReasonOutOfCredits            RateLimitOverageDisabledReason = "out_of_credits"
 	RateLimitOverageDisabledReasonSeatTierLevelDisabled   RateLimitOverageDisabledReason = "seat_tier_level_disabled"
 	RateLimitOverageDisabledReasonMemberLevelDisabled     RateLimitOverageDisabledReason = "member_level_disabled"
-	RateLimitOverageDisabledReasonSeatTierZeroCreditLimit RateLimitOverageDisabledReason = "seat_tier_zero_credit_limit"
-	RateLimitOverageDisabledReasonGroupZeroCreditLimit    RateLimitOverageDisabledReason = "group_zero_credit_limit"
-	RateLimitOverageDisabledReasonMemberZeroCreditLimit   RateLimitOverageDisabledReason = "member_zero_credit_limit"
+	RateLimitOverageDisabledReasonSeatTierZeroCreditLimit RateLimitOverageDisabledReason = "seat_tier_zero_credit_limit" //nolint:gosec // G101: upstream enum literal, not a credential
+	RateLimitOverageDisabledReasonGroupZeroCreditLimit    RateLimitOverageDisabledReason = "group_zero_credit_limit"     //nolint:gosec // G101: upstream enum literal, not a credential
+	RateLimitOverageDisabledReasonMemberZeroCreditLimit   RateLimitOverageDisabledReason = "member_zero_credit_limit"    //nolint:gosec // G101: upstream enum literal, not a credential
 	RateLimitOverageDisabledReasonOrgServiceLevelDisabled RateLimitOverageDisabledReason = "org_service_level_disabled"
 	RateLimitOverageDisabledReasonNoLimitsConfigured      RateLimitOverageDisabledReason = "no_limits_configured"
 	RateLimitOverageDisabledReasonFetchError              RateLimitOverageDisabledReason = "fetch_error"

--- a/messages.go
+++ b/messages.go
@@ -304,12 +304,99 @@ type ToolProgressMessage struct {
 	ToolName           string  `json:"tool_name"`            // Tool name
 	ParentToolUseID    *string `json:"parent_tool_use_id"`   // Parent tool if nested
 	ElapsedTimeSeconds float64 `json:"elapsed_time_seconds"` // Time elapsed
+	TaskID             *string `json:"task_id,omitempty"`    // Task ID if associated with a task
 	UUID               string  `json:"uuid"`                 // Message UUID
 	SessionID          string  `json:"session_id"`           // Session ID
 }
 
 // MessageType implements Message.
 func (m ToolProgressMessage) MessageType() string { return "tool_progress" }
+
+// ToolUseSummaryMessage reports a summary of preceding tool uses.
+type ToolUseSummaryMessage struct {
+	Type                string   `json:"type"`                   // Always "tool_use_summary"
+	Summary             string   `json:"summary"`                // Summary text
+	PrecedingToolUseIDs []string `json:"preceding_tool_use_ids"` // Tool use IDs summarized
+	UUID                string   `json:"uuid"`                   // Message UUID
+	SessionID           string   `json:"session_id"`             // Session ID
+}
+
+// MessageType implements Message.
+func (m ToolUseSummaryMessage) MessageType() string { return "tool_use_summary" }
+
+// PromptSuggestionMessage contains a predicted next user prompt.
+type PromptSuggestionMessage struct {
+	Type       string `json:"type"`       // Always "prompt_suggestion"
+	Suggestion string `json:"suggestion"` // Suggested prompt text
+	UUID       string `json:"uuid"`       // Message UUID
+	SessionID  string `json:"session_id"` // Session ID
+}
+
+// MessageType implements Message.
+func (m PromptSuggestionMessage) MessageType() string { return "prompt_suggestion" }
+
+// RateLimitEventMessage reports rate limit information changes.
+type RateLimitEventMessage struct {
+	Type          string        `json:"type"`            // Always "rate_limit_event"
+	RateLimitInfo RateLimitInfo `json:"rate_limit_info"` // Rate limit details
+	UUID          string        `json:"uuid"`            // Message UUID
+	SessionID     string        `json:"session_id"`      // Session ID
+}
+
+// MessageType implements Message.
+func (m RateLimitEventMessage) MessageType() string { return "rate_limit_event" }
+
+// RateLimitStatus is the status of a rate limit check.
+type RateLimitStatus string
+
+const (
+	RateLimitStatusAllowed        RateLimitStatus = "allowed"
+	RateLimitStatusAllowedWarning RateLimitStatus = "allowed_warning"
+	RateLimitStatusRejected       RateLimitStatus = "rejected"
+)
+
+// RateLimitType identifies the quota window or overage bucket.
+type RateLimitType string
+
+const (
+	RateLimitTypeFiveHour       RateLimitType = "five_hour"
+	RateLimitTypeSevenDay       RateLimitType = "seven_day"
+	RateLimitTypeSevenDayOpus   RateLimitType = "seven_day_opus"
+	RateLimitTypeSevenDaySonnet RateLimitType = "seven_day_sonnet"
+	RateLimitTypeOverage        RateLimitType = "overage"
+)
+
+// RateLimitOverageDisabledReason explains why overage is unavailable.
+type RateLimitOverageDisabledReason string
+
+const (
+	RateLimitOverageDisabledReasonOverageNotProvisioned   RateLimitOverageDisabledReason = "overage_not_provisioned"
+	RateLimitOverageDisabledReasonOrgLevelDisabled        RateLimitOverageDisabledReason = "org_level_disabled"
+	RateLimitOverageDisabledReasonOrgLevelDisabledUntil   RateLimitOverageDisabledReason = "org_level_disabled_until"
+	RateLimitOverageDisabledReasonOutOfCredits            RateLimitOverageDisabledReason = "out_of_credits"
+	RateLimitOverageDisabledReasonSeatTierLevelDisabled   RateLimitOverageDisabledReason = "seat_tier_level_disabled"
+	RateLimitOverageDisabledReasonMemberLevelDisabled     RateLimitOverageDisabledReason = "member_level_disabled"
+	RateLimitOverageDisabledReasonSeatTierZeroCreditLimit RateLimitOverageDisabledReason = "seat_tier_zero_credit_limit"
+	RateLimitOverageDisabledReasonGroupZeroCreditLimit    RateLimitOverageDisabledReason = "group_zero_credit_limit"
+	RateLimitOverageDisabledReasonMemberZeroCreditLimit   RateLimitOverageDisabledReason = "member_zero_credit_limit"
+	RateLimitOverageDisabledReasonOrgServiceLevelDisabled RateLimitOverageDisabledReason = "org_service_level_disabled"
+	RateLimitOverageDisabledReasonNoLimitsConfigured      RateLimitOverageDisabledReason = "no_limits_configured"
+	RateLimitOverageDisabledReasonFetchError              RateLimitOverageDisabledReason = "fetch_error"
+	RateLimitOverageDisabledReasonUnknown                 RateLimitOverageDisabledReason = "unknown"
+)
+
+// RateLimitInfo contains rate limit details for claude.ai subscription users.
+type RateLimitInfo struct {
+	Status                RateLimitStatus                 `json:"status"`
+	ResetsAt              *int64                          `json:"resetsAt,omitempty"`
+	RateLimitType         *RateLimitType                  `json:"rateLimitType,omitempty"`
+	Utilization           *float64                        `json:"utilization,omitempty"`
+	OverageStatus         *RateLimitStatus                `json:"overageStatus,omitempty"`
+	OverageResetsAt       *int64                          `json:"overageResetsAt,omitempty"`
+	OverageDisabledReason *RateLimitOverageDisabledReason `json:"overageDisabledReason,omitempty"`
+	IsUsingOverage        *bool                           `json:"isUsingOverage,omitempty"`
+	SurpassedThreshold    *float64                        `json:"surpassedThreshold,omitempty"`
+}
 
 // AuthStatusMessage reports authentication status.
 type AuthStatusMessage struct {
@@ -1024,6 +1111,21 @@ func ParseMessage(data []byte) (Message, error) {
 
 	case "tool_progress":
 		var msg ToolProgressMessage
+		err := json.Unmarshal(data, &msg)
+		return msg, err
+
+	case "tool_use_summary":
+		var msg ToolUseSummaryMessage
+		err := json.Unmarshal(data, &msg)
+		return msg, err
+
+	case "prompt_suggestion":
+		var msg PromptSuggestionMessage
+		err := json.Unmarshal(data, &msg)
+		return msg, err
+
+	case "rate_limit_event":
+		var msg RateLimitEventMessage
 		err := json.Unmarshal(data, &msg)
 		return msg, err
 

--- a/messages_test.go
+++ b/messages_test.go
@@ -487,6 +487,243 @@ func TestParseMessageSubagentResult(t *testing.T) {
 	assert.Contains(t, subagentMsg.Result, "strong fundamentals")
 }
 
+func int64Ptr(v int64) *int64       { return &v }
+func float64Ptr(v float64) *float64 { return &v }
+func boolPtr(v bool) *bool          { return &v }
+
+func rateLimitTypePtr(v RateLimitType) *RateLimitType       { return &v }
+func rateLimitStatusPtr(v RateLimitStatus) *RateLimitStatus { return &v }
+func rateLimitOverageDisabledReasonPtr(v RateLimitOverageDisabledReason) *RateLimitOverageDisabledReason {
+	return &v
+}
+
+func TestToolUseSummaryMessageRoundTripAndParse(t *testing.T) {
+	msg := ToolUseSummaryMessage{
+		Type:                "tool_use_summary",
+		Summary:             "Read and Edit completed",
+		PrecedingToolUseIDs: []string{"toolu_read", "toolu_edit"},
+		UUID:                "550e8400-e29b-41d4-a716-446655440030",
+		SessionID:           "sess_top_123",
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"type": "tool_use_summary",
+		"summary": "Read and Edit completed",
+		"preceding_tool_use_ids": ["toolu_read", "toolu_edit"],
+		"uuid": "550e8400-e29b-41d4-a716-446655440030",
+		"session_id": "sess_top_123"
+	}`, string(data))
+
+	parsed, err := ParseMessage(data)
+	require.NoError(t, err)
+	summaryMsg, ok := parsed.(ToolUseSummaryMessage)
+	require.True(t, ok, "expected ToolUseSummaryMessage")
+	assert.Equal(t, msg, summaryMsg)
+}
+
+func TestPromptSuggestionMessageRoundTripAndParse(t *testing.T) {
+	msg := PromptSuggestionMessage{
+		Type:       "prompt_suggestion",
+		Suggestion: "Run the test suite",
+		UUID:       "550e8400-e29b-41d4-a716-446655440031",
+		SessionID:  "sess_top_123",
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"type": "prompt_suggestion",
+		"suggestion": "Run the test suite",
+		"uuid": "550e8400-e29b-41d4-a716-446655440031",
+		"session_id": "sess_top_123"
+	}`, string(data))
+
+	parsed, err := ParseMessage(data)
+	require.NoError(t, err)
+	suggestionMsg, ok := parsed.(PromptSuggestionMessage)
+	require.True(t, ok, "expected PromptSuggestionMessage")
+	assert.Equal(t, msg, suggestionMsg)
+}
+
+func TestRateLimitEventMessageRoundTripAndParse(t *testing.T) {
+	t.Run("minimal", func(t *testing.T) {
+		msg := RateLimitEventMessage{
+			Type: "rate_limit_event",
+			RateLimitInfo: RateLimitInfo{
+				Status: RateLimitStatusAllowed,
+			},
+			UUID:      "550e8400-e29b-41d4-a716-446655440032",
+			SessionID: "sess_top_123",
+		}
+
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"type": "rate_limit_event",
+			"rate_limit_info": {
+				"status": "allowed"
+			},
+			"uuid": "550e8400-e29b-41d4-a716-446655440032",
+			"session_id": "sess_top_123"
+		}`, string(data))
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		info, ok := got["rate_limit_info"].(map[string]interface{})
+		require.True(t, ok)
+		for _, key := range []string{
+			"resetsAt",
+			"rateLimitType",
+			"utilization",
+			"overageStatus",
+			"overageResetsAt",
+			"overageDisabledReason",
+			"isUsingOverage",
+			"surpassedThreshold",
+		} {
+			assert.NotContains(t, info, key)
+		}
+
+		parsed, err := ParseMessage(data)
+		require.NoError(t, err)
+		rateLimitMsg, ok := parsed.(RateLimitEventMessage)
+		require.True(t, ok, "expected RateLimitEventMessage")
+		assert.Equal(t, msg, rateLimitMsg)
+	})
+
+	t.Run("populated", func(t *testing.T) {
+		msg := RateLimitEventMessage{
+			Type: "rate_limit_event",
+			RateLimitInfo: RateLimitInfo{
+				Status:                RateLimitStatusAllowedWarning,
+				ResetsAt:              int64Ptr(1763856000),
+				RateLimitType:         rateLimitTypePtr(RateLimitTypeSevenDaySonnet),
+				Utilization:           float64Ptr(0.87),
+				OverageStatus:         rateLimitStatusPtr(RateLimitStatusRejected),
+				OverageResetsAt:       int64Ptr(1763942400),
+				OverageDisabledReason: rateLimitOverageDisabledReasonPtr(RateLimitOverageDisabledReasonOutOfCredits),
+				IsUsingOverage:        boolPtr(true),
+				SurpassedThreshold:    float64Ptr(0.8),
+			},
+			UUID:      "550e8400-e29b-41d4-a716-446655440033",
+			SessionID: "sess_top_123",
+		}
+
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"type": "rate_limit_event",
+			"rate_limit_info": {
+				"status": "allowed_warning",
+				"resetsAt": 1763856000,
+				"rateLimitType": "seven_day_sonnet",
+				"utilization": 0.87,
+				"overageStatus": "rejected",
+				"overageResetsAt": 1763942400,
+				"overageDisabledReason": "out_of_credits",
+				"isUsingOverage": true,
+				"surpassedThreshold": 0.8
+			},
+			"uuid": "550e8400-e29b-41d4-a716-446655440033",
+			"session_id": "sess_top_123"
+		}`, string(data))
+
+		parsed, err := ParseMessage(data)
+		require.NoError(t, err)
+		rateLimitMsg, ok := parsed.(RateLimitEventMessage)
+		require.True(t, ok, "expected RateLimitEventMessage")
+		assert.Equal(t, msg, rateLimitMsg)
+	})
+
+	t.Run("unknown enum values parse", func(t *testing.T) {
+		input := []byte(`{
+			"type": "rate_limit_event",
+			"rate_limit_info": {
+				"status": "future_status",
+				"rateLimitType": "future_limit",
+				"overageStatus": "future_overage_status",
+				"overageDisabledReason": "future_reason"
+			},
+			"uuid": "550e8400-e29b-41d4-a716-446655440034",
+			"session_id": "sess_top_123"
+		}`)
+
+		parsed, err := ParseMessage(input)
+		require.NoError(t, err)
+		rateLimitMsg, ok := parsed.(RateLimitEventMessage)
+		require.True(t, ok, "expected RateLimitEventMessage")
+		assert.Equal(t, RateLimitStatus("future_status"), rateLimitMsg.RateLimitInfo.Status)
+		require.NotNil(t, rateLimitMsg.RateLimitInfo.RateLimitType)
+		assert.Equal(t, RateLimitType("future_limit"), *rateLimitMsg.RateLimitInfo.RateLimitType)
+		require.NotNil(t, rateLimitMsg.RateLimitInfo.OverageStatus)
+		assert.Equal(t, RateLimitStatus("future_overage_status"), *rateLimitMsg.RateLimitInfo.OverageStatus)
+		require.NotNil(t, rateLimitMsg.RateLimitInfo.OverageDisabledReason)
+		assert.Equal(t, RateLimitOverageDisabledReason("future_reason"), *rateLimitMsg.RateLimitInfo.OverageDisabledReason)
+	})
+}
+
+func TestToolProgressMessageTaskIDRoundTrip(t *testing.T) {
+	t.Run("with task id", func(t *testing.T) {
+		parentID := "toolu_parent"
+		msg := ToolProgressMessage{
+			Type:               "tool_progress",
+			ToolUseID:          "toolu_child",
+			ToolName:           "Bash",
+			ParentToolUseID:    &parentID,
+			ElapsedTimeSeconds: 1.25,
+			TaskID:             stringPtr("task_123"),
+			UUID:               "550e8400-e29b-41d4-a716-446655440035",
+			SessionID:          "sess_top_123",
+		}
+
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"type": "tool_progress",
+			"tool_use_id": "toolu_child",
+			"tool_name": "Bash",
+			"parent_tool_use_id": "toolu_parent",
+			"elapsed_time_seconds": 1.25,
+			"task_id": "task_123",
+			"uuid": "550e8400-e29b-41d4-a716-446655440035",
+			"session_id": "sess_top_123"
+		}`, string(data))
+
+		parsed, err := ParseMessage(data)
+		require.NoError(t, err)
+		progressMsg, ok := parsed.(ToolProgressMessage)
+		require.True(t, ok, "expected ToolProgressMessage")
+		require.NotNil(t, progressMsg.TaskID)
+		assert.Equal(t, "task_123", *progressMsg.TaskID)
+	})
+
+	t.Run("without task id", func(t *testing.T) {
+		msg := ToolProgressMessage{
+			Type:               "tool_progress",
+			ToolUseID:          "toolu_child",
+			ToolName:           "Bash",
+			ElapsedTimeSeconds: 1.25,
+			UUID:               "550e8400-e29b-41d4-a716-446655440036",
+			SessionID:          "sess_top_123",
+		}
+
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "task_id")
+
+		parsed, err := ParseMessage(data)
+		require.NoError(t, err)
+		progressMsg, ok := parsed.(ToolProgressMessage)
+		require.True(t, ok, "expected ToolProgressMessage")
+		assert.Nil(t, progressMsg.TaskID)
+	})
+}
+
 func TestParseMessageSystemInit(t *testing.T) {
 	input := `{
 		"type": "system",


### PR DESCRIPTION
## Summary

Adds the three remaining `SDKMessage` variants from `@anthropic-ai/claude-agent-sdk@0.2.119`: `tool_use_summary`, `prompt_suggestion`, `rate_limit_event`.

After this PR the `ParseMessage` switch covers every variant of `SDKMessage` enumerated at `scratch/ts-sdk/package/sdk.d.ts` line 2919.

### What's added

- **`ToolUseSummaryMessage`** (`tool_use_summary`) — summary text + `preceding_tool_use_ids []string`.
- **`PromptSuggestionMessage`** (`prompt_suggestion`) — predicted next user prompt.
- **`RateLimitEventMessage`** (`rate_limit_event`) — wraps a new `RateLimitInfo` struct. The status, rate-limit-type, and overage-disabled-reason fields are typed string enums (`RateLimitStatus`, `RateLimitType`, `RateLimitOverageDisabledReason`) with named constants for every documented value. Unknown enum values still parse (typed strings allow it). Wire tags are camelCase (`resetsAt`, `rateLimitType`, `isUsingOverage`, …) — matching the TS upstream — while the outer event uses snake_case (`rate_limit_info`).

### Audit fixes

- **`tool_progress`** was missing `task_id` — added as optional `*string` with `omitempty` so absence round-trips as absence.
- **`auth_status`** was audited against upstream lines 2285–2292 — already matches, no change required.

### Tests (in `messages_test.go`)

- Round-trip + `ParseMessage` dispatch for each new top-level type.
- `rate_limit_event` covers minimal payload (status only, all optionals confirmed absent on the wire), fully populated payload, and unknown-enum forward-compat.
- `tool_progress` covers both with-`task_id` and without-`task_id` (asserts no empty-string serialization).

### Closes the 14-series split

- 14a (#42): hook lifecycle subtypes + `system` dispatch refactor
- 14b (#43): task lifecycle subtypes
- 14c (#44): ten misc system subtypes
- **14d (this PR):** three new top-level types + the `tool_progress.task_id` audit fix

### Acceptance

- `gofmt -l messages.go messages_test.go` empty
- `go vet ./...` clean
- `go test ./... -count=1 -race` passes
- `go build ./...` clean