### PR TITLE
messages: additive field catchup for v0.2.119

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -19,13 +19,14 @@ type Message interface {
 // This message type initiates or continues a conversation. The ParentToolUseID
 // field links this message to a specific tool call when providing tool results.
 type UserMessage struct {
-	Type            string         `json:"type"`                      // Always "user"
-	UUID            string         `json:"uuid,omitempty"`            // Unique message ID
-	SessionID       string         `json:"session_id"`                // Session identifier
-	Message         APIUserMessage `json:"message"`                   // Message content
-	ParentToolUseID *string        `json:"parent_tool_use_id"`        // For tool results (null if not tool result)
-	IsSynthetic     bool           `json:"isSynthetic,omitempty"`     // True for system-generated messages
-	ToolUseResult   interface{}    `json:"tool_use_result,omitempty"` // Tool result JSON if applicable
+	Type            string               `json:"type"`                      // Always "user"
+	UUID            string               `json:"uuid,omitempty"`            // Unique message ID
+	SessionID       string               `json:"session_id"`                // Session identifier
+	Message         APIUserMessage       `json:"message"`                   // Message content
+	ParentToolUseID *string              `json:"parent_tool_use_id"`        // For tool results (null if not tool result)
+	IsSynthetic     bool                 `json:"isSynthetic,omitempty"`     // True for system-generated messages
+	ToolUseResult   interface{}          `json:"tool_use_result,omitempty"` // Tool result JSON if applicable
+	Priority        *UserMessagePriority `json:"priority,omitempty"`        // Scheduling priority
 }
 
 // APIUserMessage represents the message content in Anthropic API format.
@@ -42,13 +43,23 @@ type UserContentBlock struct {
 
 // UserMessageReplay represents a replayed user message during session resume.
 type UserMessageReplay struct {
-	Type            string         `json:"type"`       // Always "user"
-	UUID            string         `json:"uuid"`       // Unique message ID
-	SessionID       string         `json:"session_id"` // Session identifier
-	Message         APIUserMessage `json:"message"`    // Message content
-	ParentToolUseID *string        `json:"parent_tool_use_id"`
-	IsReplay        bool           `json:"isReplay"` // True for replayed messages
+	Type            string               `json:"type"`       // Always "user"
+	UUID            string               `json:"uuid"`       // Unique message ID
+	SessionID       string               `json:"session_id"` // Session identifier
+	Message         APIUserMessage       `json:"message"`    // Message content
+	ParentToolUseID *string              `json:"parent_tool_use_id"`
+	IsReplay        bool                 `json:"isReplay"` // True for replayed messages
+	Priority        *UserMessagePriority `json:"priority,omitempty"`
 }
+
+// UserMessagePriority indicates when a user message should be handled.
+type UserMessagePriority string
+
+const (
+	UserMessagePriorityNow   UserMessagePriority = "now"
+	UserMessagePriorityNext  UserMessagePriority = "next"
+	UserMessagePriorityLater UserMessagePriority = "later"
+)
 
 // MessageType implements Message.
 func (m UserMessage) MessageType() string { return "user" }
@@ -138,6 +149,9 @@ type ResultMessage struct {
 
 	PermissionDenials []PermissionDenial `json:"permission_denials,omitempty"` // Denied permissions
 	StructuredOutput  interface{}        `json:"structured_output,omitempty"`  // Structured output (if OutputFormat set)
+	StopReason        *string            `json:"stop_reason"`                  // Stop reason, explicitly null when absent
+	TerminalReason    *TerminalReason    `json:"terminal_reason,omitempty"`    // Terminal completion reason
+	FastModeState     *FastModeState     `json:"fast_mode_state,omitempty"`    // Fast mode state at completion
 }
 
 // MessageType implements Message.
@@ -355,6 +369,33 @@ const (
 	RateLimitStatusRejected       RateLimitStatus = "rejected"
 )
 
+// TerminalReason explains why a result message reached a terminal state.
+type TerminalReason string
+
+const (
+	TerminalReasonBlockingLimit      TerminalReason = "blocking_limit"
+	TerminalReasonRapidRefillBreaker TerminalReason = "rapid_refill_breaker"
+	TerminalReasonPromptTooLong      TerminalReason = "prompt_too_long"
+	TerminalReasonImageError         TerminalReason = "image_error"
+	TerminalReasonModelError         TerminalReason = "model_error"
+	TerminalReasonAbortedStreaming   TerminalReason = "aborted_streaming"
+	TerminalReasonAbortedTools       TerminalReason = "aborted_tools"
+	TerminalReasonStopHookPrevented  TerminalReason = "stop_hook_prevented"
+	TerminalReasonHookStopped        TerminalReason = "hook_stopped"
+	TerminalReasonToolDeferred       TerminalReason = "tool_deferred"
+	TerminalReasonMaxTurns           TerminalReason = "max_turns"
+	TerminalReasonCompleted          TerminalReason = "completed"
+)
+
+// FastModeState is the current state of Claude Code fast mode.
+type FastModeState string
+
+const (
+	FastModeStateOff      FastModeState = "off"
+	FastModeStateCooldown FastModeState = "cooldown"
+	FastModeStateOn       FastModeState = "on"
+)
+
 // RateLimitType identifies the quota window or overage bucket.
 type RateLimitType string
 
@@ -460,18 +501,24 @@ type Usage struct {
 // This message is sent at the start of a session and contains information
 // about available tools, MCP servers, models, and permissions.
 type SystemMessage struct {
-	Type           string          `json:"type"`           // Always "system"
-	Subtype        string          `json:"subtype"`        // "init" or "compact_boundary"
-	UUID           string          `json:"uuid"`           // Unique message ID
-	SessionID      string          `json:"session_id"`     // Session identifier
-	APIKeySource   string          `json:"apiKeySource"`   // Where the API key comes from
-	Cwd            string          `json:"cwd"`            // Current working directory
-	Tools          []string        `json:"tools"`          // Available tools
-	MCPServers     []MCPServerInfo `json:"mcp_servers"`    // MCP server status
-	Model          string          `json:"model"`          // Active model
-	PermissionMode PermissionMode  `json:"permissionMode"` // Current permission mode
-	SlashCommands  []string        `json:"slash_commands"` // Available slash commands
-	OutputStyle    string          `json:"output_style"`   // Output formatting style
+	Type              string          `json:"type"`                      // Always "system"
+	Subtype           string          `json:"subtype"`                   // "init" or "compact_boundary"
+	UUID              string          `json:"uuid"`                      // Unique message ID
+	SessionID         string          `json:"session_id"`                // Session identifier
+	APIKeySource      string          `json:"apiKeySource"`              // Where the API key comes from
+	Cwd               string          `json:"cwd"`                       // Current working directory
+	Tools             []string        `json:"tools"`                     // Available tools
+	MCPServers        []MCPServerInfo `json:"mcp_servers"`               // MCP server status
+	Model             string          `json:"model"`                     // Active model
+	PermissionMode    PermissionMode  `json:"permissionMode"`            // Current permission mode
+	SlashCommands     []string        `json:"slash_commands"`            // Available slash commands
+	OutputStyle       string          `json:"output_style"`              // Output formatting style
+	ClaudeCodeVersion string          `json:"claude_code_version"`       // Claude Code version
+	Skills            []string        `json:"skills"`                    // Available skills
+	Plugins           []SystemPlugin  `json:"plugins"`                   // Available plugins
+	Agents            []string        `json:"agents,omitempty"`          // Available agents
+	Betas             []string        `json:"betas,omitempty"`           // Enabled beta flags
+	FastModeState     *FastModeState  `json:"fast_mode_state,omitempty"` // Fast mode state
 }
 
 // MessageType implements Message.
@@ -481,6 +528,12 @@ func (m SystemMessage) MessageType() string { return "system" }
 type MCPServerInfo struct {
 	Name   string `json:"name"`   // Server name
 	Status string `json:"status"` // Connection status
+}
+
+// SystemPlugin contains metadata for an installed Claude Code plugin.
+type SystemPlugin struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
 }
 
 // PartialAssistantMessage represents a streaming partial message.
@@ -942,6 +995,7 @@ type ModelUsage struct {
 	WebSearchRequests        int     `json:"webSearchRequests"`        // Web search count
 	CostUSD                  float64 `json:"costUSD"`                  // Cost in USD
 	ContextWindow            int     `json:"contextWindow"`            // Context window size
+	MaxOutputTokens          int     `json:"maxOutputTokens"`          // Max output tokens for this model
 }
 
 // NonNullableUsage is like Usage but all fields are guaranteed non-zero.

--- a/messages_test.go
+++ b/messages_test.go
@@ -491,6 +491,12 @@ func int64Ptr(v int64) *int64       { return &v }
 func float64Ptr(v float64) *float64 { return &v }
 func boolPtr(v bool) *bool          { return &v }
 
+func terminalReasonPtr(v TerminalReason) *TerminalReason { return &v }
+func fastModeStatePtr(v FastModeState) *FastModeState    { return &v }
+func userMessagePriorityPtr(v UserMessagePriority) *UserMessagePriority {
+	return &v
+}
+
 func rateLimitTypePtr(v RateLimitType) *RateLimitType       { return &v }
 func rateLimitStatusPtr(v RateLimitStatus) *RateLimitStatus { return &v }
 func rateLimitOverageDisabledReasonPtr(v RateLimitOverageDisabledReason) *RateLimitOverageDisabledReason {
@@ -722,6 +728,363 @@ func TestToolProgressMessageTaskIDRoundTrip(t *testing.T) {
 		require.True(t, ok, "expected ToolProgressMessage")
 		assert.Nil(t, progressMsg.TaskID)
 	})
+}
+
+func TestResultMessageFieldAdditionsRoundTrip(t *testing.T) {
+	stopReason := "stop_sequence"
+	msg := ResultMessage{
+		Type:             "result",
+		Status:           "success",
+		Subtype:          "success",
+		UUID:             "550e8400-e29b-41d4-a716-446655440040",
+		SessionID:        "sess_result_123",
+		Result:           "done",
+		StructuredOutput: map[string]interface{}{"ok": true},
+		StopReason:       &stopReason,
+		TerminalReason:   terminalReasonPtr(TerminalReasonHookStopped),
+		FastModeState:    fastModeStatePtr(FastModeStateCooldown),
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.StopReason)
+	assert.Equal(t, stopReason, *decoded.StopReason)
+	require.NotNil(t, decoded.TerminalReason)
+	assert.Equal(t, TerminalReasonHookStopped, *decoded.TerminalReason)
+	require.NotNil(t, decoded.FastModeState)
+	assert.Equal(t, FastModeStateCooldown, *decoded.FastModeState)
+}
+
+func TestResultMessageStopReasonNullRoundTrip(t *testing.T) {
+	msg := ResultMessage{
+		Type:       "result",
+		Status:     "error",
+		Subtype:    "error_during_execution",
+		SessionID:  "sess_result_123",
+		StopReason: nil,
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.JSONEq(t, `null`, string(got["stop_reason"]))
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Nil(t, decoded.StopReason)
+}
+
+func TestResultMessageFieldAdditionsBackwardCompat(t *testing.T) {
+	input := []byte(`{
+		"type": "result",
+		"status": "success",
+		"subtype": "success",
+		"session_id": "sess_result_123",
+		"result": "done"
+	}`)
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(input, &decoded))
+	assert.Nil(t, decoded.StopReason)
+	assert.Nil(t, decoded.TerminalReason)
+	assert.Nil(t, decoded.FastModeState)
+}
+
+func TestSystemMessageFieldAdditionsRoundTrip(t *testing.T) {
+	msg := SystemMessage{
+		Type:              "system",
+		Subtype:           "init",
+		UUID:              "550e8400-e29b-41d4-a716-446655440041",
+		SessionID:         "sess_system_123",
+		APIKeySource:      "env",
+		Cwd:               "/workspace/project",
+		Tools:             []string{"Read", "Edit"},
+		MCPServers:        []MCPServerInfo{{Name: "github", Status: "connected"}},
+		Model:             "claude-opus-4-5-20250929",
+		PermissionMode:    PermissionModeAcceptEdits,
+		SlashCommands:     []string{"/help"},
+		OutputStyle:       "default",
+		ClaudeCodeVersion: "2.0.0",
+		Skills:            []string{"go", "review"},
+		Plugins:           []SystemPlugin{{Name: "github", Path: "/plugins/github"}},
+		Agents:            []string{"reviewer"},
+		Betas:             []string{"beta-flag"},
+		FastModeState:     fastModeStatePtr(FastModeStateOn),
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded SystemMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, msg, decoded)
+}
+
+func TestSystemMessageMinimalModernPayload(t *testing.T) {
+	msg := SystemMessage{
+		Type:              "system",
+		Subtype:           "init",
+		UUID:              "550e8400-e29b-41d4-a716-446655440042",
+		SessionID:         "sess_system_123",
+		APIKeySource:      "env",
+		Cwd:               "/workspace/project",
+		Tools:             []string{},
+		MCPServers:        []MCPServerInfo{},
+		Model:             "claude-sonnet-4-5-20250929",
+		PermissionMode:    PermissionModeDefault,
+		SlashCommands:     []string{},
+		OutputStyle:       "default",
+		ClaudeCodeVersion: "2.0.0",
+		Skills:            []string{},
+		Plugins:           []SystemPlugin{},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Contains(t, got, "claude_code_version")
+	assert.Contains(t, got, "skills")
+	assert.Contains(t, got, "plugins")
+	for _, key := range []string{"agents", "betas", "fast_mode_state"} {
+		assert.NotContains(t, got, key)
+	}
+
+	var decoded SystemMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Nil(t, decoded.FastModeState)
+	assert.Nil(t, decoded.Agents)
+	assert.Nil(t, decoded.Betas)
+}
+
+func TestSystemMessageFieldAdditionsBackwardCompat(t *testing.T) {
+	input := []byte(`{
+		"type": "system",
+		"subtype": "init",
+		"uuid": "550e8400-e29b-41d4-a716-446655440043",
+		"session_id": "sess_system_123",
+		"apiKeySource": "env",
+		"cwd": "/workspace/project",
+		"tools": ["Read"],
+		"mcp_servers": [],
+		"model": "claude-sonnet-4-5-20250929",
+		"permissionMode": "default",
+		"slash_commands": [],
+		"output_style": "default"
+	}`)
+
+	var decoded SystemMessage
+	require.NoError(t, json.Unmarshal(input, &decoded))
+	assert.Empty(t, decoded.ClaudeCodeVersion)
+	assert.Nil(t, decoded.Skills)
+	assert.Nil(t, decoded.Plugins)
+	assert.Nil(t, decoded.Agents)
+	assert.Nil(t, decoded.Betas)
+	assert.Nil(t, decoded.FastModeState)
+}
+
+func TestModelUsageMaxOutputTokensRoundTrip(t *testing.T) {
+	usage := ModelUsage{
+		InputTokens:              10,
+		OutputTokens:             20,
+		CacheReadInputTokens:     3,
+		CacheCreationInputTokens: 4,
+		WebSearchRequests:        1,
+		CostUSD:                  0.25,
+		ContextWindow:            200000,
+		MaxOutputTokens:          32000,
+	}
+
+	data, err := json.Marshal(usage)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"inputTokens": 10,
+		"outputTokens": 20,
+		"cacheReadInputTokens": 3,
+		"cacheCreationInputTokens": 4,
+		"webSearchRequests": 1,
+		"costUSD": 0.25,
+		"contextWindow": 200000,
+		"maxOutputTokens": 32000
+	}`, string(data))
+
+	var decoded ModelUsage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, usage, decoded)
+}
+
+func TestUserMessagePriorityRoundTrip(t *testing.T) {
+	for _, priority := range []UserMessagePriority{
+		UserMessagePriorityNow,
+		UserMessagePriorityNext,
+		UserMessagePriorityLater,
+	} {
+		t.Run(string(priority), func(t *testing.T) {
+			msg := UserMessage{
+				Type:            "user",
+				SessionID:       "sess_user_123",
+				ParentToolUseID: nil,
+				Message: APIUserMessage{
+					Role:    "user",
+					Content: []UserContentBlock{{Type: "text", Text: "hello"}},
+				},
+				Priority: userMessagePriorityPtr(priority),
+			}
+
+			data, err := json.Marshal(msg)
+			require.NoError(t, err)
+
+			var decoded UserMessage
+			require.NoError(t, json.Unmarshal(data, &decoded))
+			require.NotNil(t, decoded.Priority)
+			assert.Equal(t, priority, *decoded.Priority)
+		})
+	}
+
+	data, err := json.Marshal(UserMessage{Type: "user", SessionID: "sess_user_123"})
+	require.NoError(t, err)
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.NotContains(t, got, "priority")
+}
+
+func TestUserMessageReplayPriorityRoundTrip(t *testing.T) {
+	for _, priority := range []UserMessagePriority{
+		UserMessagePriorityNow,
+		UserMessagePriorityNext,
+		UserMessagePriorityLater,
+	} {
+		t.Run(string(priority), func(t *testing.T) {
+			msg := UserMessageReplay{
+				Type:            "user",
+				UUID:            "550e8400-e29b-41d4-a716-446655440044",
+				SessionID:       "sess_user_123",
+				ParentToolUseID: nil,
+				IsReplay:        true,
+				Message: APIUserMessage{
+					Role:    "user",
+					Content: []UserContentBlock{{Type: "text", Text: "hello"}},
+				},
+				Priority: userMessagePriorityPtr(priority),
+			}
+
+			data, err := json.Marshal(msg)
+			require.NoError(t, err)
+
+			var decoded UserMessageReplay
+			require.NoError(t, json.Unmarshal(data, &decoded))
+			require.NotNil(t, decoded.Priority)
+			assert.Equal(t, priority, *decoded.Priority)
+		})
+	}
+
+	data, err := json.Marshal(UserMessageReplay{Type: "user", UUID: "uuid", SessionID: "sess_user_123"})
+	require.NoError(t, err)
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.NotContains(t, got, "priority")
+}
+
+func TestParseMessageDispatchWithFieldAdditions(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		check func(t *testing.T, msg Message)
+	}{
+		{
+			name: "result",
+			input: `{
+				"type": "result",
+				"status": "success",
+				"subtype": "success",
+				"session_id": "sess_result_123",
+				"result": "done",
+				"stop_reason": "end_turn",
+				"terminal_reason": "completed",
+				"fast_mode_state": "cooldown"
+			}`,
+			check: func(t *testing.T, msg Message) {
+				t.Helper()
+				resultMsg, ok := msg.(ResultMessage)
+				require.True(t, ok, "expected ResultMessage")
+				require.NotNil(t, resultMsg.StopReason)
+				assert.Equal(t, "end_turn", *resultMsg.StopReason)
+				require.NotNil(t, resultMsg.TerminalReason)
+				assert.Equal(t, TerminalReasonCompleted, *resultMsg.TerminalReason)
+				require.NotNil(t, resultMsg.FastModeState)
+				assert.Equal(t, FastModeStateCooldown, *resultMsg.FastModeState)
+			},
+		},
+		{
+			name: "system",
+			input: `{
+				"type": "system",
+				"subtype": "init",
+				"uuid": "550e8400-e29b-41d4-a716-446655440045",
+				"session_id": "sess_system_123",
+				"apiKeySource": "env",
+				"cwd": "/workspace/project",
+				"tools": ["Read"],
+				"mcp_servers": [],
+				"model": "claude-sonnet-4-5-20250929",
+				"permissionMode": "default",
+				"slash_commands": [],
+				"output_style": "default",
+				"claude_code_version": "2.0.0",
+				"skills": ["go"],
+				"plugins": [{"name": "github", "path": "/plugins/github"}],
+				"agents": ["reviewer"],
+				"betas": ["beta-flag"],
+				"fast_mode_state": "on"
+			}`,
+			check: func(t *testing.T, msg Message) {
+				t.Helper()
+				systemMsg, ok := msg.(SystemMessage)
+				require.True(t, ok, "expected SystemMessage")
+				assert.Equal(t, "2.0.0", systemMsg.ClaudeCodeVersion)
+				assert.Equal(t, []string{"go"}, systemMsg.Skills)
+				assert.Equal(t, []SystemPlugin{{Name: "github", Path: "/plugins/github"}}, systemMsg.Plugins)
+				assert.Equal(t, []string{"reviewer"}, systemMsg.Agents)
+				assert.Equal(t, []string{"beta-flag"}, systemMsg.Betas)
+				require.NotNil(t, systemMsg.FastModeState)
+				assert.Equal(t, FastModeStateOn, *systemMsg.FastModeState)
+			},
+		},
+		{
+			name: "user",
+			input: `{
+				"type": "user",
+				"session_id": "sess_user_123",
+				"parent_tool_use_id": null,
+				"message": {
+					"role": "user",
+					"content": [{"type": "text", "text": "hello"}]
+				},
+				"priority": "later"
+			}`,
+			check: func(t *testing.T, msg Message) {
+				t.Helper()
+				userMsg, ok := msg.(UserMessage)
+				require.True(t, ok, "expected UserMessage")
+				require.NotNil(t, userMsg.Priority)
+				assert.Equal(t, UserMessagePriorityLater, *userMsg.Priority)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseMessage([]byte(tt.input))
+			require.NoError(t, err)
+			tt.check(t, msg)
+		})
+	}
 }
 
 func TestParseMessageSystemInit(t *testing.T) {


### PR DESCRIPTION
Adds the additive fields on existing message types from `@anthropic-ai/claude-agent-sdk@0.2.119`: `ResultMessage` (`stop_reason`, `terminal_reason`, `fast_mode_state`), `SystemMessage` (`claude_code_version`, `skills`, `plugins`, `agents`, `betas`, `fast_mode_state`), `ModelUsage.maxOutputTokens`, `UserMessage.priority` / `UserMessageReplay.priority`.

Also introduces the supporting typed enums `TerminalReason`, `FastModeState`, `UserMessagePriority`, and a new `SystemPlugin` nested type.

All changes are additive — old payloads continue to parse unchanged. `stop_reason` is mapped to `*string` with no `omitempty` because the upstream field is required-nullable (same convention used on `parent_tool_use_id`); a regression test asserts that the wire form is `\"stop_reason\":null` rather than empty-string or absent.

Deferred to follow-up PRs (deliberate carve-outs):
- `SDKMessageOrigin` — discriminated union, deserves its own PR.
- `shouldQuery`, `timestamp` on `UserMessage` — bundle with the `origin` PR.
- `api_error_status`, `deferred_tool_use` on `SDKResultSuccess` — niche, defer.

`NonNullableUsage` — audited, no change (upstream shape `[K in keyof BetaUsage]: NonNullable<BetaUsage[K]>` matches today).

Tests cover round-trips for every new field, the `stop_reason: null` wire form, backward-compat parsing of pre-0.2.119 payloads on both `ResultMessage` and `SystemMessage`, omitempty behavior on `priority` for both `UserMessage` and `UserMessageReplay`, and `ParseMessage` dispatch sanity for `result`/`system`/`user` payloads carrying the new fields.

Part of the v0.2.119 catchup (PR 15, follow-up to 14a/b/c/d at #42, #43, #44, #45).