### PR TITLE
transport: extract Transport interface; add EndInput/IsReady

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ import (
 // iter.Seq for streaming message iteration.
 type Client struct {
 	options   Options
-	transport *SubprocessTransport
+	transport Transport
 	protocol  *Protocol
 	skills    []Skill
 	mu        sync.Mutex
@@ -87,26 +87,31 @@ func (c *Client) Connect(ctx context.Context) error {
 		return nil // Already connected
 	}
 
-	// Create transport.
-	transport, err := NewSubprocessTransport(&c.options)
-	if err != nil {
-		return err
-	}
-	c.transport = transport
+	var transport Transport
+	if c.options.Transport != nil {
+		transport = c.options.Transport
+	} else {
+		subprocess, err := NewSubprocessTransport(&c.options)
+		if err != nil {
+			return err
+		}
 
-	// Wire stderr callback to transport if configured. The Options.Stderr
-	// callback receives each line as a string, while the transport expects
-	// an io.Writer. The adapter bridges the two interfaces.
-	if c.options.Stderr != nil {
-		transport.SetStderrLogger(&stderrCallbackWriter{
-			callback: c.options.Stderr,
-		})
+		// Wire stderr callback to transport if configured. The Options.Stderr
+		// callback receives each line as a string, while the transport expects
+		// an io.Writer. The adapter bridges the two interfaces.
+		if c.options.Stderr != nil {
+			subprocess.SetStderrLogger(&stderrCallbackWriter{
+				callback: c.options.Stderr,
+			})
+		}
+		transport = subprocess
 	}
 
 	// Connect transport.
 	if err := transport.Connect(ctx); err != nil {
 		return err
 	}
+	c.transport = transport
 
 	// Create protocol handler.
 	c.protocol = NewProtocol(transport, &c.options)

--- a/options.go
+++ b/options.go
@@ -175,6 +175,11 @@ type Options struct {
 	// Stderr is a callback for stderr output from the CLI.
 	Stderr func(data string)
 
+	// Transport, when non-nil, is used in place of the default subprocess
+	// transport. Primarily for testing with mock transports; real users should
+	// leave this unset.
+	Transport Transport `json:"-"`
+
 	// Verbose enables debug logging from the CLI.
 	Verbose bool
 
@@ -453,6 +458,15 @@ func WithForwardSubagentText(enable bool) Option {
 func WithCLIPath(path string) Option {
 	return func(o *Options) {
 		o.CLIPath = path
+	}
+}
+
+// WithTransport supplies a custom Transport implementation, bypassing the
+// default subprocess. The transport's Connect method will be called by the
+// client; do not call it yourself.
+func WithTransport(t Transport) Option {
+	return func(o *Options) {
+		o.Transport = t
 	}
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -17,7 +17,7 @@ import (
 // - Hook callback invocation
 // - Control request/response correlation
 type Protocol struct {
-	transport     *SubprocessTransport
+	transport     Transport
 	options       *Options
 	requestID     atomic.Uint64
 	pendingReqs   sync.Map                // requestID -> chan ControlResponse
@@ -27,7 +27,7 @@ type Protocol struct {
 }
 
 // NewProtocol creates a new protocol handler.
-func NewProtocol(transport *SubprocessTransport, options *Options) *Protocol {
+func NewProtocol(transport Transport, options *Options) *Protocol {
 	// Copy SDK MCP servers from options.
 	sdkMcpServers := make(map[string]*McpServer)
 	for name, server := range options.SDKMcpServers {

--- a/transport.go
+++ b/transport.go
@@ -26,6 +26,40 @@ type writerRef struct {
 	w io.Writer
 }
 
+// Transport abstracts CLI communication so the SDK can swap implementations
+// (subprocess today; in-memory or network transports in the future).
+//
+// All methods must be safe for concurrent use unless documented otherwise:
+// implementations are responsible for serializing Write calls. ReadMessages
+// returns an iterator whose lifetime is bound by the supplied context.
+type Transport interface {
+	// Connect establishes the underlying connection. Must be called before
+	// Write / ReadMessages. Idempotent: subsequent calls return nil.
+	Connect(ctx context.Context) error
+
+	// Write sends a single SDK message. Implementations must serialize
+	// concurrent Write calls.
+	Write(ctx context.Context, msg Message) error
+
+	// ReadMessages returns an iterator over inbound messages. The iterator
+	// ends when the connection closes or ctx is canceled. Parse errors are
+	// yielded via the second return value.
+	ReadMessages(ctx context.Context) iter.Seq2[Message, error]
+
+	// EndInput closes the input side of the transport (stdin for subprocess
+	// transports) without tearing down the read side. Used to signal "no
+	// more user messages" while still draining replies. Safe to call
+	// multiple times.
+	EndInput() error
+
+	// Close terminates the transport and releases all resources. Safe to
+	// call multiple times. After Close, Write returns ErrTransportClosed.
+	Close() error
+
+	// IsReady reports whether the transport is connected and able to send.
+	IsReady() bool
+}
+
 type SubprocessTransport struct {
 	runner    SubprocessRunner
 	stdin     io.WriteCloser
@@ -445,6 +479,25 @@ func (t *SubprocessTransport) ReadMessages(ctx context.Context) iter.Seq2[Messag
 	}
 }
 
+// EndInput closes the CLI subprocess's stdin without terminating the process.
+// Use this to signal end-of-input while continuing to drain stdout. Idempotent.
+func (t *SubprocessTransport) EndInput() error {
+	if t.closed.Load() {
+		return nil
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.stdin == nil {
+		return nil
+	}
+
+	err := t.stdin.Close()
+	t.stdin = nil
+	return err
+}
+
 // Close terminates the CLI subprocess and cleans up resources.
 //
 // Close attempts a graceful shutdown by closing stdin, which signals the
@@ -497,3 +550,10 @@ func (t *SubprocessTransport) IsAlive() bool {
 	}
 	return t.runner.IsAlive()
 }
+
+// IsReady reports whether the subprocess is connected and able to send messages.
+func (t *SubprocessTransport) IsReady() bool {
+	return t.IsAlive()
+}
+
+var _ Transport = (*SubprocessTransport)(nil)

--- a/transport_test.go
+++ b/transport_test.go
@@ -126,6 +126,72 @@ func (m *mockTransport) IsReady() bool {
 
 var _ Transport = (*mockTransport)(nil)
 
+// TestMockTransportReadMessagesRoundTrip drives the mock's iterator end-to-end:
+// pushes messages onto incoming, asserts each is yielded in order, and verifies
+// the iterator returns when context is canceled. Also covers Close idempotence
+// (the Close path closes the incoming channel; a second Close must be a no-op).
+func TestMockTransportReadMessagesRoundTrip(t *testing.T) {
+	mock := newMockTransport(4)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, mock.Connect(ctx))
+	assert.True(t, mock.IsReady())
+
+	want := []Message{
+		UserMessage{Type: "user", SessionID: "one"},
+		UserMessage{Type: "user", SessionID: "two"},
+		UserMessage{Type: "user", SessionID: "three"},
+	}
+	for _, msg := range want {
+		mock.incoming <- msg
+	}
+
+	got := make([]Message, 0, len(want))
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for msg, err := range mock.ReadMessages(ctx) {
+			require.NoError(t, err)
+			got = append(got, msg)
+			if len(got) == len(want) {
+				cancel()
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReadMessages did not yield all messages within timeout")
+	}
+	assert.Equal(t, want, got)
+
+	require.NoError(t, mock.Close())
+	require.NoError(t, mock.Close())
+	assert.False(t, mock.IsReady())
+
+	err := mock.Write(context.Background(), UserMessage{})
+	assert.IsType(t, &ErrTransportClosed{}, err)
+}
+
+// TestWithTransportOptionPlumbed verifies that WithTransport stores the
+// injected transport on Options so Client.Connect's injection branch picks it
+// up. End-to-end coverage through Client.Connect is deferred until the
+// control-channel initialize handshake is easier to fixture against a mock.
+func TestWithTransportOptionPlumbed(t *testing.T) {
+	mock := newMockTransport(1)
+
+	opts := NewOptions()
+	WithTransport(mock)(opts)
+
+	got, ok := opts.Transport.(*mockTransport)
+	require.True(t, ok, "Options.Transport should hold the injected mockTransport")
+	require.Same(t, mock, got)
+}
+
 // TestSubprocessTransportBasicCommunication tests stdin/stdout communication.
 func TestSubprocessTransportBasicCommunication(t *testing.T) {
 	// Create mock subprocess

--- a/transport_test.go
+++ b/transport_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"iter"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -59,6 +61,70 @@ func decodeMCPConfigArgs(t *testing.T, args []string) map[string]map[string]inte
 func stringPtr(s string) *string {
 	return &s
 }
+
+type mockTransport struct {
+	mu       sync.Mutex
+	written  []Message
+	incoming chan Message
+	closed   atomic.Bool
+	ended    atomic.Bool
+	ready    atomic.Bool
+}
+
+func newMockTransport(buf int) *mockTransport {
+	return &mockTransport{incoming: make(chan Message, buf)}
+}
+
+func (m *mockTransport) Connect(ctx context.Context) error {
+	m.ready.Store(true)
+	return nil
+}
+
+func (m *mockTransport) Write(ctx context.Context, msg Message) error {
+	if m.closed.Load() {
+		return &ErrTransportClosed{}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.written = append(m.written, msg)
+	return nil
+}
+
+func (m *mockTransport) ReadMessages(ctx context.Context) iter.Seq2[Message, error] {
+	return func(yield func(Message, error) bool) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-m.incoming:
+				if !ok || !yield(msg, nil) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (m *mockTransport) EndInput() error {
+	m.ended.Store(true)
+	return nil
+}
+
+func (m *mockTransport) Close() error {
+	if !m.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	m.ready.Store(false)
+	close(m.incoming)
+	return nil
+}
+
+func (m *mockTransport) IsReady() bool {
+	return m.ready.Load() && !m.closed.Load()
+}
+
+var _ Transport = (*mockTransport)(nil)
 
 // TestSubprocessTransportBasicCommunication tests stdin/stdout communication.
 func TestSubprocessTransportBasicCommunication(t *testing.T) {
@@ -166,6 +232,56 @@ func TestSubprocessTransportGracefulShutdown(t *testing.T) {
 	// Verify transport is closed
 	assert.True(t, transport.closed.Load())
 	assert.False(t, transport.IsAlive())
+}
+
+func TestSubprocessTransportEndInput(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	ctx := context.Background()
+	err := transport.Connect(ctx)
+	require.NoError(t, err)
+	defer transport.Close()
+
+	err = transport.EndInput()
+	require.NoError(t, err)
+	assert.Nil(t, transport.stdin)
+	assert.True(t, runner.IsAlive())
+	assert.True(t, transport.IsReady())
+}
+
+func TestSubprocessTransportEndInputIdempotent(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	ctx := context.Background()
+	err := transport.Connect(ctx)
+	require.NoError(t, err)
+	defer transport.Close()
+
+	require.NoError(t, transport.EndInput())
+	require.NoError(t, transport.EndInput())
+	assert.Nil(t, transport.stdin)
+}
+
+func TestSubprocessTransportCloseAfterEndInput(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	ctx := context.Background()
+	err := transport.Connect(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, transport.EndInput())
+	require.NoError(t, transport.Close())
+	assert.True(t, transport.closed.Load())
+	assert.False(t, transport.IsReady())
 }
 
 // TestSubprocessTransportContextCancellation tests that context cancellation


### PR DESCRIPTION
Closes #16.

## Summary
Extracts a `Transport` interface so callers can swap the subprocess for in-memory or networked transports without touching `Protocol` or `Client`. `SubprocessTransport` keeps its current semantics and now implements the new interface, picking up `EndInput` (close stdin without tearing down the read side) and `IsReady`.

## Changes
- `transport.go` — new `Transport` interface (`Connect`, `Write`, `ReadMessages`, `EndInput`, `Close`, `IsReady`); `SubprocessTransport` implements it; compile-time assertion via `var _ Transport = (*SubprocessTransport)(nil)`.
- `client.go` — `Client.transport` field is now `Transport`. `Connect` uses `Options.Transport` if set, otherwise builds the default subprocess. Stderr wiring stays subprocess-only (in-memory transports don't have stderr).
- `options.go` — `Options.Transport Transport` field (`json:"-"`) and `WithTransport` functional option.
- `protocol.go` — `Protocol.transport` typed as `Transport`; protocol only ever calls `Write`, fully covered by the interface.
- `transport_test.go` — adds a `mockTransport` that satisfies `Transport`, plus `EndInput` coverage (basic, idempotent, plays nicely with `Close`).

## Notes
- `EndInput` and `Write` share `t.mu`, so they serialize. Calling `Write` after `EndInput` is a contract violation per the interface doc — no defensive guard added; behavior is loud nil-deref by design.
- No behavior change for the default subprocess path. Existing tests continue to construct `SubprocessTransport` directly and exercise the same code paths.

## Test plan
- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `go test ./...`
- [ ] CI green on the PR