### PR TITLE
stream: await SDK control responses (PR 17 of v0.2.119 catchup)

### DIFF
--- a/client.go
+++ b/client.go
@@ -747,16 +747,12 @@ func (s *Stream) handleSends() {
 }
 
 // Interrupt sends an interrupt signal to stop the current generation.
+// It blocks until the CLI acknowledges the request or returns an error.
 func (s *Stream) Interrupt(ctx context.Context) error {
-	// Send interrupt control message in SDK format.
-	req := SDKControlRequest{
-		Type:      "control_request",
-		RequestID: s.client.protocol.nextRequestID(),
-		Request: SDKControlRequestBody{
-			Subtype: "interrupt",
-		},
-	}
-	return s.client.transport.Write(ctx, req)
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "interrupt",
+	})
+	return err
 }
 
 // RewindFiles restores files to a checkpoint at the specified user message.
@@ -776,44 +772,69 @@ func (s *Stream) RewindFiles(ctx context.Context, userMessageUUID string) error 
 }
 
 // SetPermissionMode dynamically changes the permission mode for this session.
+// It blocks until the CLI acknowledges the request or returns an error.
 func (s *Stream) SetPermissionMode(ctx context.Context, mode PermissionMode) error {
-	req := SDKControlRequest{
-		Type:      "control_request",
-		RequestID: s.client.protocol.nextRequestID(),
-		Request: SDKControlRequestBody{
-			Subtype: "set_permission_mode",
-			Mode:    string(mode),
-		},
-	}
-	return s.client.transport.Write(ctx, req)
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "set_permission_mode",
+		Mode:    string(mode),
+	})
+	return err
 }
 
 // SetModel dynamically changes the model for this session.
 // Pass empty string to reset to default.
+// It blocks until the CLI acknowledges the request or returns an error.
 func (s *Stream) SetModel(ctx context.Context, model string) error {
-	req := SDKControlRequest{
-		Type:      "control_request",
-		RequestID: s.client.protocol.nextRequestID(),
-		Request: SDKControlRequestBody{
-			Subtype: "set_model",
-			Model:   model,
-		},
-	}
-	return s.client.transport.Write(ctx, req)
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "set_model",
+		Model:   model,
+	})
+	return err
 }
 
 // SetMaxThinkingTokens dynamically changes the max thinking tokens limit.
 // Pass nil to remove the limit.
+// It blocks until the CLI acknowledges the request or returns an error.
 func (s *Stream) SetMaxThinkingTokens(ctx context.Context, tokens *int) error {
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype:           "set_max_thinking_tokens",
+		MaxThinkingTokens: tokens,
+	})
+	return err
+}
+
+// sendSDKControlRequest sends an SDK-format control request and waits for the
+// matching response.
+func (s *Stream) sendSDKControlRequest(
+	ctx context.Context, body SDKControlRequestBody,
+) (*SDKControlResponse, error) {
+	p := s.client.protocol
+	requestID := p.nextRequestID()
 	req := SDKControlRequest{
 		Type:      "control_request",
-		RequestID: s.client.protocol.nextRequestID(),
-		Request: SDKControlRequestBody{
-			Subtype:           "set_max_thinking_tokens",
-			MaxThinkingTokens: tokens,
-		},
+		RequestID: requestID,
+		Request:   body,
 	}
-	return s.client.transport.Write(ctx, req)
+
+	// Register before writing so a fast CLI response cannot race the waiter.
+	ch := make(chan SDKControlResponse, 1)
+	p.pendingReqs.Store(requestID, ch)
+
+	if err := s.client.transport.Write(ctx, req); err != nil {
+		p.pendingReqs.Delete(requestID)
+		return nil, fmt.Errorf("control request %q: write: %w", body.Subtype, err)
+	}
+
+	select {
+	case <-ctx.Done():
+		p.pendingReqs.Delete(requestID)
+		return nil, ctx.Err()
+	case resp := <-ch:
+		if resp.Response.Subtype == "error" {
+			return nil, fmt.Errorf("control request %q: %s", body.Subtype, resp.Response.Error)
+		}
+		return &resp, nil
+	}
 }
 
 // SupportedCommands returns the list of available slash commands.

--- a/stream_control_test.go
+++ b/stream_control_test.go
@@ -1,0 +1,300 @@
+package claudeagent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"iter"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type streamControlTransport struct {
+	mu       sync.Mutex
+	written  []Message
+	writeCh  chan Message
+	protocol *Protocol
+	response func(SDKControlRequest) SDKControlResponse
+	closed   atomic.Bool
+	ready    atomic.Bool
+}
+
+func newStreamControlTransport(
+	response func(SDKControlRequest) SDKControlResponse,
+) *streamControlTransport {
+	return &streamControlTransport{
+		writeCh:  make(chan Message, 8),
+		response: response,
+	}
+}
+
+func (t *streamControlTransport) Connect(ctx context.Context) error {
+	t.ready.Store(true)
+	return nil
+}
+
+func (t *streamControlTransport) Write(ctx context.Context, msg Message) error {
+	if t.closed.Load() {
+		return &ErrTransportClosed{}
+	}
+
+	t.mu.Lock()
+	t.written = append(t.written, msg)
+	t.mu.Unlock()
+
+	select {
+	case t.writeCh <- msg:
+	default:
+	}
+
+	if t.response != nil {
+		var req SDKControlRequest
+		data, err := json.Marshal(msg)
+		if err == nil {
+			err = json.Unmarshal(data, &req)
+		}
+		if err == nil {
+			resp := t.response(req)
+			go func() {
+				_ = t.protocol.handleSDKControlResponse(resp)
+			}()
+		}
+	}
+
+	return nil
+}
+
+func (t *streamControlTransport) ReadMessages(ctx context.Context) iter.Seq2[Message, error] {
+	return func(yield func(Message, error) bool) {
+		<-ctx.Done()
+	}
+}
+
+func (t *streamControlTransport) EndInput() error { return nil }
+
+func (t *streamControlTransport) Close() error {
+	t.closed.Store(true)
+	return nil
+}
+
+func (t *streamControlTransport) IsReady() bool {
+	return t.ready.Load() && !t.closed.Load()
+}
+
+func (t *streamControlTransport) writtenMessages() []Message {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	out := make([]Message, len(t.written))
+	copy(out, t.written)
+	return out
+}
+
+func newStreamControlTest(
+	response func(SDKControlRequest) SDKControlResponse,
+) (*Stream, *streamControlTransport, *Protocol) {
+	transport := newStreamControlTransport(response)
+	options := DefaultOptions()
+	protocol := NewProtocol(transport, &options)
+	transport.protocol = protocol
+	client := &Client{
+		options:   options,
+		transport: transport,
+		protocol:  protocol,
+	}
+	stream := &Stream{
+		client:  client,
+		ctx:     context.Background(),
+		sendCh:  make(chan string),
+		closeCh: make(chan struct{}),
+	}
+	return stream, transport, protocol
+}
+
+func successSDKControlResponse(req SDKControlRequest) SDKControlResponse {
+	return SDKControlResponse{
+		Type: "control_response",
+		Response: SDKControlResponseBody{
+			Subtype:   "success",
+			RequestID: req.RequestID,
+			Response:  map[string]interface{}{},
+		},
+	}
+}
+
+func decodeWrittenSDKControlRequest(
+	t *testing.T, transport *streamControlTransport,
+) (SDKControlRequest, map[string]interface{}) {
+	t.Helper()
+
+	written := transport.writtenMessages()
+	require.Len(t, written, 1)
+
+	data, err := json.Marshal(written[0])
+	require.NoError(t, err)
+
+	var req SDKControlRequest
+	require.NoError(t, json.Unmarshal(data, &req))
+
+	var generic map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &generic))
+	return req, generic
+}
+
+func genericRequestBody(t *testing.T, generic map[string]interface{}) map[string]interface{} {
+	t.Helper()
+
+	body, ok := generic["request"].(map[string]interface{})
+	require.True(t, ok, "request body missing from %+v", generic)
+	return body
+}
+
+func callWithTimeout(t *testing.T, fn func(context.Context) error) error {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	return fn(ctx)
+}
+
+func TestStreamInterruptSendsControlRequest(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	require.NoError(t, callWithTimeout(t, stream.Interrupt))
+
+	req, generic := decodeWrittenSDKControlRequest(t, transport)
+	assert.Equal(t, "control_request", req.Type)
+	assert.NotEmpty(t, req.RequestID)
+	body := genericRequestBody(t, generic)
+	assert.Equal(t, "interrupt", body["subtype"])
+	assert.NotContains(t, body, "mode")
+	assert.NotContains(t, body, "model")
+	assert.NotContains(t, body, "max_thinking_tokens")
+}
+
+func TestStreamSetPermissionModeSendsModeField(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.SetPermissionMode(ctx, PermissionModeAcceptEdits)
+	})
+	require.NoError(t, err)
+
+	_, generic := decodeWrittenSDKControlRequest(t, transport)
+	body := genericRequestBody(t, generic)
+	assert.Equal(t, "set_permission_mode", body["subtype"])
+	assert.Equal(t, "acceptEdits", body["mode"])
+}
+
+func TestStreamSetModelSendsModelField(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.SetModel(ctx, "claude-sonnet-4-5-20250929")
+	})
+	require.NoError(t, err)
+
+	_, generic := decodeWrittenSDKControlRequest(t, transport)
+	body := genericRequestBody(t, generic)
+	assert.Equal(t, "set_model", body["subtype"])
+	assert.Equal(t, "claude-sonnet-4-5-20250929", body["model"])
+}
+
+func TestStreamSetMaxThinkingTokensRoundTrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		tokens      *int
+		wantPresent bool
+		want        float64
+	}{
+		{name: "nil omitted", tokens: nil},
+		{name: "zero present", tokens: intPtr(0), wantPresent: true, want: 0},
+		{name: "nonzero present", tokens: intPtr(4096), wantPresent: true, want: 4096},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+			err := callWithTimeout(t, func(ctx context.Context) error {
+				return stream.SetMaxThinkingTokens(ctx, tt.tokens)
+			})
+			require.NoError(t, err)
+
+			_, generic := decodeWrittenSDKControlRequest(t, transport)
+			body := genericRequestBody(t, generic)
+			assert.Equal(t, "set_max_thinking_tokens", body["subtype"])
+
+			got, ok := body["max_thinking_tokens"]
+			if !tt.wantPresent {
+				assert.False(t, ok, "max_thinking_tokens should be omitted")
+				return
+			}
+			require.True(t, ok, "max_thinking_tokens should be present")
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStreamControlRequestSurfacesError(t *testing.T) {
+	stream, _, _ := newStreamControlTest(func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "error",
+				RequestID: req.RequestID,
+				Error:     "invalid mode",
+			},
+		}
+	})
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.SetPermissionMode(ctx, PermissionMode("invalid"))
+	})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "invalid mode"))
+}
+
+func TestStreamControlRequestRespectsContextCancel(t *testing.T) {
+	stream, transport, protocol := newStreamControlTest(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- stream.Interrupt(ctx)
+	}()
+
+	var msg Message
+	select {
+	case msg = <-transport.writeCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for control request write")
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+	var req SDKControlRequest
+	require.NoError(t, json.Unmarshal(data, &req))
+
+	_, exists := protocol.pendingReqs.Load(req.RequestID)
+	require.True(t, exists, "pending request should be registered before cancellation")
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, context.Canceled))
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for control method to return")
+	}
+
+	_, exists = protocol.pendingReqs.Load(req.RequestID)
+	assert.False(t, exists, "pending request should be cleaned up after cancellation")
+}


### PR DESCRIPTION
## What

Rewires the four `Stream` runtime control methods — `Interrupt`,
`SetPermissionMode`, `SetModel`, `SetMaxThinkingTokens` — to await the matching
`SDKControlResponse` instead of fire-and-forget, matching the TS SDK contract
(`sdk.d.ts` L1960-2001, `sdk.mjs` `await this.request(...)`).

## Why

Pre-PR, each method built an `SDKControlRequest` and called
`transport.Write(ctx, req)` without registering a pending-response slot. That
diverged from upstream in three ways:

- A caller could not tell whether the CLI accepted the change.
- An `error` reply (e.g. invalid permission mode) was silently dropped.
- The pending-request slot in `protocol.pendingReqs` was never registered, so
  even if a response arrived it would be matched against nothing.

This PR fixes all three.

## How

Added a single `sendSDKControlRequest` helper on `*Stream` that:

1. Registers the pending-response slot **before** writing, to avoid a race
   where a fast CLI reply lands before the waiter is in the map.
2. Writes the request via the transport.
3. Selects on `ctx.Done()` and the response channel.
4. Surfaces `error`-subtype responses as a wrapped Go error.

The four methods now delegate to that helper. Helper returns
`*SDKControlResponse` even though PR 17's four callers ignore it — PRs 18–20
will need the parsed body for introspection methods, so no churn later.

### Out of scope (deferred)

`Protocol.waitForSDKResponse` registers the channel **after** the write, which
has the same race the helper here avoids by reversing the order. Not touched
in this PR; flagging for a follow-up.

## Tests

New `stream_control_test.go`. Hand-rolled `*Protocol` + mock transport so the
tests drive the real `Stream` methods end-to-end without spawning a subprocess.

| Test | What it asserts |
|------|-----------------|
| `TestStreamInterruptSendsControlRequest` | Wire shape: `{type:control_request, request:{subtype:interrupt}}`, no spurious mode/model/max_thinking_tokens fields |
| `TestStreamSetPermissionModeSendsModeField` | `subtype=set_permission_mode`, `mode=acceptEdits` |
| `TestStreamSetModelSendsModelField` | `subtype=set_model`, `model=claude-sonnet-4-5-20250929` |
| `TestStreamSetMaxThinkingTokensRoundTrip` | Three subtests: `nil` → field omitted; `*int(0)` → present as 0; `*int(4096)` → present as 4096 |
| `TestStreamControlRequestSurfacesError` | CLI returns `{subtype:error, error:"invalid mode"}` → method returns wrapped error |
| `TestStreamControlRequestRespectsContextCancel` | Cancelling `ctx` returns `context.Canceled` AND deletes the pending slot |

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `go test -race ./...` green.

## Catchup context

Phase 6, second PR of the v0.2.119 catchup (`@anthropic-ai/claude-agent-sdk@0.2.119`).
This unblocks PRs 18–20 by establishing the await-helper pattern the rest of the
control surface (`SupportedCommands`, `RewindFiles`, `AccountInfo`, etc.) will
adopt.