### PR TITLE
stream: introspection methods (PR 18 of v0.2.119 catchup)

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,11 +3,15 @@ package claudeagent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"sync"
 	"time"
 )
+
+// ErrNotInitialized indicates stream metadata was requested before SDK init.
+var ErrNotInitialized = errors.New("sdk not initialized")
 
 // Client is the high-level API for interacting with Claude Code CLI.
 //
@@ -837,124 +841,112 @@ func (s *Stream) sendSDKControlRequest(
 	}
 }
 
-// SupportedCommands returns the list of available slash commands.
-func (s *Stream) SupportedCommands(ctx context.Context) ([]SlashCommand, error) {
-	respCh := s.client.protocol.sendRequest(ctx, "supported_commands", nil)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case resp := <-respCh:
-		if resp.Error != nil {
-			return nil, &ErrProtocol{Message: resp.Error.Message}
-		}
-		// Parse response
-		commands, ok := resp.Result["commands"].([]interface{})
-		if !ok {
-			return nil, &ErrProtocol{Message: "invalid commands response"}
-		}
-		result := make([]SlashCommand, 0, len(commands))
-		for _, cmd := range commands {
-			cmdMap, ok := cmd.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			result = append(result, SlashCommand{
-				Name:         getString(cmdMap, "name"),
-				Description:  getString(cmdMap, "description"),
-				ArgumentHint: getString(cmdMap, "argumentHint"),
-			})
-		}
-		return result, nil
+// InitializationResult returns the cached initialize response.
+func (s *Stream) InitializationResult() (*SDKControlInitializeResponse, error) {
+	initResp := s.client.protocol.initResult()
+	if initResp == nil {
+		return nil, ErrNotInitialized
 	}
+	return cloneInitializeResponse(initResp), nil
 }
 
-// SupportedModels returns the list of available models.
-func (s *Stream) SupportedModels(ctx context.Context) ([]ModelInfo, error) {
-	respCh := s.client.protocol.sendRequest(ctx, "supported_models", nil)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case resp := <-respCh:
-		if resp.Error != nil {
-			return nil, &ErrProtocol{Message: resp.Error.Message}
-		}
-		// Parse response
-		models, ok := resp.Result["models"].([]interface{})
-		if !ok {
-			return nil, &ErrProtocol{Message: "invalid models response"}
-		}
-		result := make([]ModelInfo, 0, len(models))
-		for _, model := range models {
-			modelMap, ok := model.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			result = append(result, ModelInfo{
-				Value:       getString(modelMap, "value"),
-				DisplayName: getString(modelMap, "displayName"),
-				Description: getString(modelMap, "description"),
-			})
-		}
-		return result, nil
+// SupportedCommands returns the cached list of available slash commands.
+// The context is accepted for API compatibility and is not used.
+func (s *Stream) SupportedCommands(ctx context.Context) ([]SlashCommand, error) {
+	_ = ctx
+	initResp := s.client.protocol.initResult()
+	if initResp == nil {
+		return nil, ErrNotInitialized
 	}
+	return append([]SlashCommand(nil), initResp.Commands...), nil
+}
+
+// SupportedModels returns the cached list of available models.
+// The context is accepted for API compatibility and is not used.
+func (s *Stream) SupportedModels(ctx context.Context) ([]ModelInfo, error) {
+	_ = ctx
+	initResp := s.client.protocol.initResult()
+	if initResp == nil {
+		return nil, ErrNotInitialized
+	}
+	return append([]ModelInfo(nil), initResp.Models...), nil
+}
+
+// SupportedAgents returns the cached list of available agents.
+// The context is accepted for API compatibility and is not used.
+func (s *Stream) SupportedAgents(ctx context.Context) ([]AgentInfo, error) {
+	_ = ctx
+	initResp := s.client.protocol.initResult()
+	if initResp == nil {
+		return nil, ErrNotInitialized
+	}
+	return append([]AgentInfo(nil), initResp.Agents...), nil
 }
 
 // McpServerStatus returns the connection status of all MCP servers.
 func (s *Stream) McpServerStatus(ctx context.Context) ([]McpServerStatus, error) {
-	respCh := s.client.protocol.sendRequest(ctx, "mcp_server_status", nil)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case resp := <-respCh:
-		if resp.Error != nil {
-			return nil, &ErrProtocol{Message: resp.Error.Message}
-		}
-		// Parse response
-		servers, ok := resp.Result["servers"].([]interface{})
-		if !ok {
-			return nil, &ErrProtocol{Message: "invalid mcp_server_status response"}
-		}
-		result := make([]McpServerStatus, 0, len(servers))
-		for _, srv := range servers {
-			srvMap, ok := srv.(map[string]interface{})
-			if !ok {
-				continue
-			}
-			status := McpServerStatus{
-				Name:   getString(srvMap, "name"),
-				Status: McpServerState(getString(srvMap, "status")),
-			}
-			if info, ok := srvMap["serverInfo"].(map[string]interface{}); ok {
-				status.ServerInfo = &McpServerInfo{
-					Name:    getString(info, "name"),
-					Version: getString(info, "version"),
-				}
-			}
-			result = append(result, status)
-		}
-		return result, nil
+	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "mcp_status",
+	})
+	if err != nil {
+		return nil, err
 	}
+	raw, ok := resp.Response.Response["mcpServers"]
+	if !ok {
+		return nil, fmt.Errorf("mcp_status: missing mcpServers in response")
+	}
+	bytes, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("mcp_status: marshal: %w", err)
+	}
+	var out []McpServerStatus
+	if err := json.Unmarshal(bytes, &out); err != nil {
+		return nil, fmt.Errorf("mcp_status: unmarshal: %w", err)
+	}
+	return out, nil
 }
 
 // AccountInfo returns account information for the current session.
 func (s *Stream) AccountInfo(ctx context.Context) (*AccountInfo, error) {
-	respCh := s.client.protocol.sendRequest(ctx, "account_info", nil)
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case resp := <-respCh:
-		if resp.Error != nil {
-			return nil, &ErrProtocol{Message: resp.Error.Message}
-		}
-		// Parse response
-		return &AccountInfo{
-			Email:            getString(resp.Result, "email"),
-			Organization:     getString(resp.Result, "organization"),
-			SubscriptionType: getString(resp.Result, "subscriptionType"),
-			TokenSource:      getString(resp.Result, "tokenSource"),
-			APIKeySource:     getString(resp.Result, "apiKeySource"),
-		}, nil
+	_ = ctx
+	initResp := s.client.protocol.initResult()
+	if initResp == nil {
+		return nil, ErrNotInitialized
 	}
+	account := initResp.Account
+	return &account, nil
+}
+
+// GetContextUsage fetches the current context usage from the CLI.
+func (s *Stream) GetContextUsage(
+	ctx context.Context,
+) (*SDKControlGetContextUsageResponse, error) {
+	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "get_context_usage",
+	})
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := json.Marshal(resp.Response.Response)
+	if err != nil {
+		return nil, fmt.Errorf("get_context_usage: marshal: %w", err)
+	}
+	var out SDKControlGetContextUsageResponse
+	if err := json.Unmarshal(bytes, &out); err != nil {
+		return nil, fmt.Errorf("get_context_usage: unmarshal: %w", err)
+	}
+	return &out, nil
+}
+
+func cloneInitializeResponse(
+	src *SDKControlInitializeResponse,
+) *SDKControlInitializeResponse {
+	out := *src
+	out.Commands = append([]SlashCommand(nil), src.Commands...)
+	out.Agents = append([]AgentInfo(nil), src.Agents...)
+	out.AvailableOutputStyles = append([]string(nil), src.AvailableOutputStyles...)
+	out.Models = append([]ModelInfo(nil), src.Models...)
+	return &out
 }
 
 // SessionID returns the current session ID.

--- a/client_introspection_test.go
+++ b/client_introspection_test.go
@@ -1,0 +1,312 @@
+package claudeagent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func storeInitResponse(p *Protocol, init *SDKControlInitializeResponse) {
+	p.initResponse.Store(init)
+	p.initialized.Store(true)
+}
+
+func canonicalInitResponse() *SDKControlInitializeResponse {
+	return &SDKControlInitializeResponse{
+		Commands: []SlashCommand{
+			{Name: "help", Description: "show help", ArgumentHint: ""},
+			{Name: "model", Description: "switch model", ArgumentHint: "<name>"},
+		},
+		Agents: []AgentInfo{
+			{Name: "Explore", Description: "exploratory agent", Model: "haiku"},
+		},
+		OutputStyle:           "default",
+		AvailableOutputStyles: []string{"default", "concise"},
+		Models: []ModelInfo{
+			{Value: "claude-sonnet-4-5-20250929", DisplayName: "Sonnet 4.5", Description: "balanced"},
+		},
+		Account: AccountInfo{
+			Email:            "user@example.com",
+			Organization:     "ACME",
+			SubscriptionType: "pro",
+			TokenSource:      "oauth",
+			APIKeySource:     "user",
+			APIProvider:      "firstParty",
+		},
+		FastModeState: "off",
+	}
+}
+
+func TestStreamInitializationResultClonesCachedInit(t *testing.T) {
+	stream, _, protocol := newStreamControlTest(nil)
+	storeInitResponse(protocol, canonicalInitResponse())
+
+	got, err := stream.InitializationResult()
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, "default", got.OutputStyle)
+	require.Len(t, got.Commands, 2)
+	assert.Equal(t, "help", got.Commands[0].Name)
+	assert.Equal(t, "firstParty", got.Account.APIProvider)
+
+	// Mutate the returned slices/structs; second call must not see the mutation.
+	got.Commands[0].Name = "mutated"
+	got.Models = append(got.Models, ModelInfo{Value: "extra"})
+
+	again, err := stream.InitializationResult()
+	require.NoError(t, err)
+	assert.Equal(t, "help", again.Commands[0].Name)
+	assert.Len(t, again.Models, 1)
+}
+
+func TestStreamSupportedCommandsReadsCachedInit(t *testing.T) {
+	stream, _, protocol := newStreamControlTest(nil)
+	storeInitResponse(protocol, canonicalInitResponse())
+
+	cmds, err := stream.SupportedCommands(context.Background())
+	require.NoError(t, err)
+	require.Len(t, cmds, 2)
+	assert.Equal(t, "model", cmds[1].Name)
+
+	cmds[0].Name = "mutated"
+	again, err := stream.SupportedCommands(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "help", again[0].Name)
+}
+
+func TestStreamSupportedModelsReadsCachedInit(t *testing.T) {
+	stream, _, protocol := newStreamControlTest(nil)
+	storeInitResponse(protocol, canonicalInitResponse())
+
+	models, err := stream.SupportedModels(context.Background())
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+	assert.Equal(t, "Sonnet 4.5", models[0].DisplayName)
+
+	models[0].Value = "mutated"
+	again, err := stream.SupportedModels(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-4-5-20250929", again[0].Value)
+}
+
+func TestStreamSupportedAgentsReadsCachedInit(t *testing.T) {
+	stream, _, protocol := newStreamControlTest(nil)
+	storeInitResponse(protocol, canonicalInitResponse())
+
+	agents, err := stream.SupportedAgents(context.Background())
+	require.NoError(t, err)
+	require.Len(t, agents, 1)
+	assert.Equal(t, "Explore", agents[0].Name)
+
+	agents[0].Name = "mutated"
+	again, err := stream.SupportedAgents(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Explore", again[0].Name)
+}
+
+func TestStreamAccountInfoReadsCachedInit(t *testing.T) {
+	stream, _, protocol := newStreamControlTest(nil)
+	storeInitResponse(protocol, canonicalInitResponse())
+
+	acct, err := stream.AccountInfo(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, acct)
+	assert.Equal(t, "user@example.com", acct.Email)
+	assert.Equal(t, "firstParty", acct.APIProvider)
+
+	acct.Email = "mutated@example.com"
+	again, err := stream.AccountInfo(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "user@example.com", again.Email)
+}
+
+func TestStreamCachedReadersNotInitialized(t *testing.T) {
+	stream, _, _ := newStreamControlTest(nil)
+
+	_, err := stream.InitializationResult()
+	assert.True(t, errors.Is(err, ErrNotInitialized))
+
+	_, err = stream.SupportedCommands(context.Background())
+	assert.True(t, errors.Is(err, ErrNotInitialized))
+
+	_, err = stream.SupportedModels(context.Background())
+	assert.True(t, errors.Is(err, ErrNotInitialized))
+
+	_, err = stream.SupportedAgents(context.Background())
+	assert.True(t, errors.Is(err, ErrNotInitialized))
+
+	_, err = stream.AccountInfo(context.Background())
+	assert.True(t, errors.Is(err, ErrNotInitialized))
+}
+
+func TestStreamMcpServerStatusParsesMcpServersField(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "success",
+				RequestID: req.RequestID,
+				Response: map[string]interface{}{
+					"mcpServers": []interface{}{
+						map[string]interface{}{
+							"name":   "foo",
+							"status": "connected",
+							"serverInfo": map[string]interface{}{
+								"name":    "foo",
+								"version": "1.0",
+							},
+						},
+						map[string]interface{}{
+							"name":   "bar",
+							"status": "needs-auth",
+						},
+					},
+				},
+			},
+		}
+	})
+
+	got, err := stream.McpServerStatus(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "foo", got[0].Name)
+	assert.Equal(t, McpServerStateConnected, got[0].Status)
+	require.NotNil(t, got[0].ServerInfo)
+	assert.Equal(t, "1.0", got[0].ServerInfo.Version)
+	assert.Equal(t, McpServerStateNeedsAuth, got[1].Status)
+	assert.Nil(t, got[1].ServerInfo)
+
+	_, generic := decodeWrittenSDKControlRequest(t, transport)
+	body := genericRequestBody(t, generic)
+	assert.Equal(t, "mcp_status", body["subtype"])
+}
+
+func TestStreamMcpServerStatusMissingFieldErrors(t *testing.T) {
+	stream, _, _ := newStreamControlTest(func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "success",
+				RequestID: req.RequestID,
+				Response: map[string]interface{}{
+					"servers": []interface{}{},
+				},
+			},
+		}
+	})
+
+	_, err := stream.McpServerStatus(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mcpServers")
+}
+
+func TestStreamGetContextUsageParsesCanonicalPayload(t *testing.T) {
+	payload := map[string]interface{}{
+		"categories": []interface{}{
+			map[string]interface{}{"name": "system", "tokens": 1200, "color": "#fff"},
+			map[string]interface{}{"name": "tools", "tokens": 800, "color": "#aaa", "isDeferred": true},
+		},
+		"totalTokens":  2000,
+		"maxTokens":    200000,
+		"rawMaxTokens": 200000,
+		"percentage":   1.0,
+		"gridRows": []interface{}{
+			[]interface{}{
+				map[string]interface{}{
+					"color": "#fff", "isFilled": true, "categoryName": "system",
+					"tokens": 1200, "percentage": 0.6, "squareFullness": 1.0,
+				},
+			},
+		},
+		"model":       "claude-sonnet-4-5-20250929",
+		"memoryFiles": []interface{}{map[string]interface{}{"path": "/CLAUDE.md", "type": "project", "tokens": 100}},
+		"mcpTools": []interface{}{
+			map[string]interface{}{"name": "search", "serverName": "foo", "tokens": 50, "isLoaded": true},
+		},
+		"agents": []interface{}{
+			map[string]interface{}{"agentType": "Explore", "source": "builtin", "tokens": 30},
+		},
+		"slashCommands": map[string]interface{}{
+			"totalCommands": 10, "includedCommands": 8, "tokens": 200,
+		},
+		"isAutoCompactEnabled": true,
+		"apiUsage": map[string]interface{}{
+			"input_tokens": 100, "output_tokens": 50,
+			"cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+		},
+	}
+
+	stream, _, _ := newStreamControlTest(func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "success",
+				RequestID: req.RequestID,
+				Response:  payload,
+			},
+		}
+	})
+
+	got, err := stream.GetContextUsage(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, 2000, got.TotalTokens)
+	assert.Equal(t, "claude-sonnet-4-5-20250929", got.Model)
+	require.Len(t, got.Categories, 2)
+	assert.True(t, got.Categories[1].IsDeferred)
+	require.NotNil(t, got.SlashCommands)
+	assert.Equal(t, 8, got.SlashCommands.IncludedCommands)
+	require.NotNil(t, got.APIUsage)
+	assert.Equal(t, 100, got.APIUsage.InputTokens)
+	assert.True(t, got.IsAutoCompactEnabled)
+}
+
+func TestStreamGetContextUsageApiUsageNullable(t *testing.T) {
+	payload := map[string]interface{}{
+		"categories":           []interface{}{},
+		"totalTokens":          0,
+		"maxTokens":            200000,
+		"rawMaxTokens":         200000,
+		"percentage":           0.0,
+		"gridRows":             []interface{}{},
+		"model":                "claude-sonnet-4-5-20250929",
+		"memoryFiles":          []interface{}{},
+		"mcpTools":             []interface{}{},
+		"agents":               []interface{}{},
+		"isAutoCompactEnabled": false,
+		"apiUsage":             nil,
+	}
+
+	stream, _, _ := newStreamControlTest(func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "success",
+				RequestID: req.RequestID,
+				Response:  payload,
+			},
+		}
+	})
+
+	got, err := stream.GetContextUsage(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Nil(t, got.APIUsage)
+}
+
+// Sanity-check that AccountInfo with apiProvider round-trips through JSON.
+func TestAccountInfoAPIProviderJSON(t *testing.T) {
+	in := AccountInfo{Email: "x@y", APIProvider: "bedrock"}
+	bytes, err := json.Marshal(in)
+	require.NoError(t, err)
+	assert.Contains(t, string(bytes), `"apiProvider":"bedrock"`)
+
+	var out AccountInfo
+	require.NoError(t, json.Unmarshal(bytes, &out))
+	assert.Equal(t, "bedrock", out.APIProvider)
+}

--- a/client_introspection_test.go
+++ b/client_introspection_test.go
@@ -234,6 +234,41 @@ func TestStreamGetContextUsageParsesCanonicalPayload(t *testing.T) {
 		"slashCommands": map[string]interface{}{
 			"totalCommands": 10, "includedCommands": 8, "tokens": 200,
 		},
+		"deferredBuiltinTools": []interface{}{
+			map[string]interface{}{"name": "Write", "tokens": 40, "isLoaded": false},
+		},
+		"systemTools": []interface{}{
+			map[string]interface{}{"name": "Read", "tokens": 25},
+		},
+		"systemPromptSections": []interface{}{
+			map[string]interface{}{"name": "preamble", "tokens": 75},
+		},
+		"skills": map[string]interface{}{
+			"totalSkills":    5,
+			"includedSkills": 3,
+			"tokens":         60,
+			"skillFrontmatter": []interface{}{
+				map[string]interface{}{"name": "init", "source": "user", "tokens": 20},
+			},
+		},
+		"autoCompactThreshold": 0.85,
+		"messageBreakdown": map[string]interface{}{
+			"toolCallTokens":          12,
+			"toolResultTokens":        18,
+			"attachmentTokens":        4,
+			"assistantMessageTokens":  300,
+			"userMessageTokens":       200,
+			"redirectedContextTokens": 0,
+			"unattributedTokens":      6,
+			"toolCallsByType": []interface{}{
+				map[string]interface{}{
+					"name": "Read", "callTokens": 4, "resultTokens": 8,
+				},
+			},
+			"attachmentsByType": []interface{}{
+				map[string]interface{}{"name": "image", "tokens": 4},
+			},
+		},
 		"isAutoCompactEnabled": true,
 		"apiUsage": map[string]interface{}{
 			"input_tokens": 100, "output_tokens": 50,
@@ -264,6 +299,31 @@ func TestStreamGetContextUsageParsesCanonicalPayload(t *testing.T) {
 	require.NotNil(t, got.APIUsage)
 	assert.Equal(t, 100, got.APIUsage.InputTokens)
 	assert.True(t, got.IsAutoCompactEnabled)
+
+	require.Len(t, got.DeferredBuiltinTools, 1)
+	assert.Equal(t, "Write", got.DeferredBuiltinTools[0].Name)
+	assert.False(t, got.DeferredBuiltinTools[0].IsLoaded)
+
+	require.Len(t, got.SystemTools, 1)
+	assert.Equal(t, "Read", got.SystemTools[0].Name)
+
+	require.Len(t, got.SystemPromptSections, 1)
+	assert.Equal(t, "preamble", got.SystemPromptSections[0].Name)
+
+	require.NotNil(t, got.Skills)
+	assert.Equal(t, 5, got.Skills.TotalSkills)
+	require.Len(t, got.Skills.SkillFrontmatter, 1)
+	assert.Equal(t, "init", got.Skills.SkillFrontmatter[0].Name)
+
+	require.NotNil(t, got.AutoCompactThreshold)
+	assert.InDelta(t, 0.85, *got.AutoCompactThreshold, 1e-9)
+
+	require.NotNil(t, got.MessageBreakdown)
+	assert.Equal(t, 300, got.MessageBreakdown.AssistantMessageTokens)
+	require.Len(t, got.MessageBreakdown.ToolCallsByType, 1)
+	assert.Equal(t, 8, got.MessageBreakdown.ToolCallsByType[0].ResultTokens)
+	require.Len(t, got.MessageBreakdown.AttachmentsByType, 1)
+	assert.Equal(t, "image", got.MessageBreakdown.AttachmentsByType[0].Name)
 }
 
 func TestStreamGetContextUsageApiUsageNullable(t *testing.T) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -1245,3 +1245,42 @@ func TestIntegrationHookLifecycleMessages(t *testing.T) {
 		"shape that emits hook_started/hook_progress/hook_response in v2.1.119 " +
 		"is not reproducible from this test harness; see TODO above")
 }
+
+// TestIntegrationStreamIntrospection exercises the cached-init readers added
+// in PR 18 against the live CLI. The CLI's initialize response populates
+// commands and models; we assert both are non-empty and that AccountInfo
+// returns without error.
+func TestIntegrationStreamIntrospection(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant."),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	stream, err := client.Stream(ctx)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	init, err := stream.InitializationResult()
+	require.NoError(t, err)
+	require.NotNil(t, init)
+
+	commands, err := stream.SupportedCommands(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, commands, "expected at least one slash command from CLI")
+
+	models, err := stream.SupportedModels(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, models, "expected at least one model from CLI")
+
+	// Account may be empty under OAuth-token-only auth; just ensure no error.
+	_, err = stream.AccountInfo(ctx)
+	require.NoError(t, err)
+}

--- a/protocol.go
+++ b/protocol.go
@@ -1280,8 +1280,13 @@ func (p *Protocol) nextRequestID() string {
 	return fmt.Sprintf("req_%d", id)
 }
 
-// sendRequest sends a control request and returns a channel for the response.
-// The caller should select on both the returned channel and ctx.Done().
+// sendRequest sends a legacy-shape control request and returns a channel for
+// the response. Currently no callers remain after the v0.2.119 catchup moved
+// stream introspection to the cached-init / SDKControlRequest paths; kept so
+// a follow-up cleanup PR can remove this and the legacy ControlResponse type
+// in one focused diff.
+//
+//nolint:unused // see comment above; scheduled removal in follow-up
 func (p *Protocol) sendRequest(ctx context.Context, subtype string, payload map[string]interface{}) <-chan ControlResponse {
 	respCh := make(chan ControlResponse, 1)
 

--- a/protocol.go
+++ b/protocol.go
@@ -23,6 +23,7 @@ type Protocol struct {
 	pendingReqs   sync.Map                // requestID -> chan ControlResponse
 	hookCallbacks map[string]HookCallback // hookID -> callback
 	sdkMcpServers map[string]*McpServer   // serverName -> server (in-process MCP)
+	initResponse  atomic.Pointer[SDKControlInitializeResponse]
 	initialized   atomic.Bool
 }
 
@@ -135,8 +136,21 @@ func (p *Protocol) Initialize(ctx context.Context) error {
 		return fmt.Errorf("initialization error: %s", resp.Response.Error)
 	}
 
+	bytes, err := json.Marshal(resp.Response.Response)
+	if err != nil {
+		return fmt.Errorf("failed to parse initialization response: %w", err)
+	}
+	var initResp SDKControlInitializeResponse
+	if err := json.Unmarshal(bytes, &initResp); err != nil {
+		return fmt.Errorf("failed to parse initialization response: %w", err)
+	}
+	p.initResponse.Store(&initResp)
 	p.initialized.Store(true)
 	return nil
+}
+
+func (p *Protocol) initResult() *SDKControlInitializeResponse {
+	return p.initResponse.Load()
 }
 
 // SendMessage sends a user message to the CLI.

--- a/query_types.go
+++ b/query_types.go
@@ -14,6 +14,24 @@ type ModelInfo struct {
 	Description string `json:"description"` // Model capabilities description
 }
 
+// AgentInfo describes a subagent available to the Task tool.
+type AgentInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Model       string `json:"model,omitempty"`
+}
+
+// SDKControlInitializeResponse is the parsed initialize control response.
+type SDKControlInitializeResponse struct {
+	Commands              []SlashCommand `json:"commands"`
+	Agents                []AgentInfo    `json:"agents"`
+	OutputStyle           string         `json:"output_style"`
+	AvailableOutputStyles []string       `json:"available_output_styles"`
+	Models                []ModelInfo    `json:"models"`
+	Account               AccountInfo    `json:"account"`
+	FastModeState         string         `json:"fast_mode_state,omitempty"`
+}
+
 // McpServerStatus reports the connection status of an MCP server.
 type McpServerStatus struct {
 	Name       string         `json:"name"`       // Server name
@@ -48,4 +66,128 @@ type AccountInfo struct {
 	SubscriptionType string `json:"subscriptionType,omitempty"` // Subscription tier
 	TokenSource      string `json:"tokenSource,omitempty"`      // How token was obtained
 	APIKeySource     string `json:"apiKeySource,omitempty"`     // API key source
+	APIProvider      string `json:"apiProvider,omitempty"`      // Active API backend
+}
+
+// SDKControlGetContextUsageResponse mirrors the context usage control response.
+type SDKControlGetContextUsageResponse struct {
+	Categories           []ContextUsageCategory        `json:"categories"`
+	TotalTokens          int                           `json:"totalTokens"`
+	MaxTokens            int                           `json:"maxTokens"`
+	RawMaxTokens         int                           `json:"rawMaxTokens"`
+	Percentage           float64                       `json:"percentage"`
+	GridRows             [][]ContextUsageGridCell      `json:"gridRows"`
+	Model                string                        `json:"model"`
+	MemoryFiles          []ContextUsageMemoryFile      `json:"memoryFiles"`
+	McpTools             []ContextUsageMcpTool         `json:"mcpTools"`
+	DeferredBuiltinTools []ContextUsageBuiltinTool     `json:"deferredBuiltinTools,omitempty"`
+	SystemTools          []ContextUsageSystemTool      `json:"systemTools,omitempty"`
+	SystemPromptSections []ContextUsageSection         `json:"systemPromptSections,omitempty"`
+	Agents               []ContextUsageAgent           `json:"agents"`
+	SlashCommands        *ContextUsageSlashCommands    `json:"slashCommands,omitempty"`
+	Skills               *ContextUsageSkills           `json:"skills,omitempty"`
+	AutoCompactThreshold *float64                      `json:"autoCompactThreshold,omitempty"`
+	IsAutoCompactEnabled bool                          `json:"isAutoCompactEnabled"`
+	MessageBreakdown     *ContextUsageMessageBreakdown `json:"messageBreakdown,omitempty"`
+	APIUsage             *ContextUsageAPIUsage         `json:"apiUsage"`
+}
+
+type ContextUsageCategory struct {
+	Name       string `json:"name"`
+	Tokens     int    `json:"tokens"`
+	Color      string `json:"color"`
+	IsDeferred bool   `json:"isDeferred,omitempty"`
+}
+
+type ContextUsageGridCell struct {
+	Color          string  `json:"color"`
+	IsFilled       bool    `json:"isFilled"`
+	CategoryName   string  `json:"categoryName"`
+	Tokens         int     `json:"tokens"`
+	Percentage     float64 `json:"percentage"`
+	SquareFullness float64 `json:"squareFullness"`
+}
+
+type ContextUsageMemoryFile struct {
+	Path   string `json:"path"`
+	Type   string `json:"type"`
+	Tokens int    `json:"tokens"`
+}
+
+type ContextUsageMcpTool struct {
+	Name       string `json:"name"`
+	ServerName string `json:"serverName"`
+	Tokens     int    `json:"tokens"`
+	IsLoaded   bool   `json:"isLoaded,omitempty"`
+}
+
+type ContextUsageBuiltinTool struct {
+	Name     string `json:"name"`
+	Tokens   int    `json:"tokens"`
+	IsLoaded bool   `json:"isLoaded"`
+}
+
+type ContextUsageSystemTool struct {
+	Name   string `json:"name"`
+	Tokens int    `json:"tokens"`
+}
+
+type ContextUsageSection struct {
+	Name   string `json:"name"`
+	Tokens int    `json:"tokens"`
+}
+
+type ContextUsageAgent struct {
+	AgentType string `json:"agentType"`
+	Source    string `json:"source"`
+	Tokens    int    `json:"tokens"`
+}
+
+type ContextUsageSlashCommands struct {
+	TotalCommands    int `json:"totalCommands"`
+	IncludedCommands int `json:"includedCommands"`
+	Tokens           int `json:"tokens"`
+}
+
+type ContextUsageSkills struct {
+	TotalSkills      int                       `json:"totalSkills"`
+	IncludedSkills   int                       `json:"includedSkills"`
+	Tokens           int                       `json:"tokens"`
+	SkillFrontmatter []ContextUsageSkillSource `json:"skillFrontmatter"`
+}
+
+type ContextUsageSkillSource struct {
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Tokens int    `json:"tokens"`
+}
+
+type ContextUsageMessageBreakdown struct {
+	ToolCallTokens          int                        `json:"toolCallTokens"`
+	ToolResultTokens        int                        `json:"toolResultTokens"`
+	AttachmentTokens        int                        `json:"attachmentTokens"`
+	AssistantMessageTokens  int                        `json:"assistantMessageTokens"`
+	UserMessageTokens       int                        `json:"userMessageTokens"`
+	RedirectedContextTokens int                        `json:"redirectedContextTokens"`
+	UnattributedTokens      int                        `json:"unattributedTokens"`
+	ToolCallsByType         []ContextUsageToolCallType `json:"toolCallsByType"`
+	AttachmentsByType       []ContextUsageAttachment   `json:"attachmentsByType"`
+}
+
+type ContextUsageToolCallType struct {
+	Name         string `json:"name"`
+	CallTokens   int    `json:"callTokens"`
+	ResultTokens int    `json:"resultTokens"`
+}
+
+type ContextUsageAttachment struct {
+	Name   string `json:"name"`
+	Tokens int    `json:"tokens"`
+}
+
+type ContextUsageAPIUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
 }


### PR DESCRIPTION
## Summary

Phase 6, third PR of the v0.2.119 catchup. Adds the seven introspection methods the TS SDK exposes on `Query`/`Stream` (sdk.d.ts L2015–2077). Fixes two latent bugs in `McpServerStatus` that were never test-covered.

| Method | Backing path |
|---|---|
| `InitializationResult()` | cached init |
| `SupportedCommands()` | cached init |
| `SupportedModels()` | cached init |
| `SupportedAgents()` | cached init (new) |
| `AccountInfo()` | cached init |
| `McpServerStatus()` | live `subtype:"mcp_status"` |
| `GetContextUsage()` | live `subtype:"get_context_usage"` (new) |

`Protocol.Initialize` now parses and stores the `SDKControlInitializeResponse` so the five cached-init readers return defensive copies of that data instead of issuing fresh requests, matching `(await this.initialization).x` in `sdk.mjs`. `ErrNotInitialized` is returned if a cached-init reader is called before init.

`McpServerStatus` previously sent subtype `mcp_server_status` (CLI uses `mcp_status`) and parsed `result["servers"]` (CLI returns `response.mcpServers`). Both fixed; both round-tripped through typed JSON unmarshal.

`AccountInfo` gains `apiProvider` (v0.2.119, `firstParty | bedrock | vertex | foundry | anthropicAws | mantle`).

`SDKControlGetContextUsageResponse` and its nested `ContextUsage*` structs mirror the TS shape; `apiUsage` is `*ContextUsageAPIUsage` (no `omitempty`) to round-trip a `null` reply correctly.

Unblocks PRs 19–20 (remaining MCP/file/plugin Stream methods) by establishing the cached-init + typed-marshal patterns.

## Test plan

- [x] `go test ./...`
- [x] `go vet ./...` (with and without `-tags integration`)
- [x] `gofmt -l .` empty
- [x] `client_introspection_test.go` — per-method cached reads, defensive-copy verification, `ErrNotInitialized` path, `mcp_status` outbound wire shape, `get_context_usage` canonical payload, `apiUsage: null` handling, `apiProvider` JSON round-trip
- [x] `TestIntegrationStreamIntrospection` — passes against live CLI in 0.7s