### PR TITLE
stream: MCP runtime control (PR 19 of v0.2.119 catchup)

### DIFF
--- a/client.go
+++ b/client.go
@@ -938,6 +938,62 @@ func (s *Stream) GetContextUsage(
 	return &out, nil
 }
 
+// ReconnectMcpServer asks the CLI to reconnect the named MCP server.
+// Returns an error if the server is unknown or reconnection fails.
+func (s *Stream) ReconnectMcpServer(ctx context.Context, serverName string) error {
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype:       "mcp_reconnect",
+		MCPServerName: serverName,
+	})
+	return err
+}
+
+// ToggleMcpServer enables or disables the named MCP server.
+// Returns an error if the server is unknown or the toggle fails.
+func (s *Stream) ToggleMcpServer(
+	ctx context.Context,
+	serverName string,
+	enabled bool,
+) error {
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype:       "mcp_toggle",
+		MCPServerName: serverName,
+		Enabled:       &enabled,
+	})
+	return err
+}
+
+// SetMcpServers replaces the dynamically-added MCP servers for this session
+// with the supplied set. Servers omitted from the new map are disconnected;
+// new entries are connected.
+//
+// Process-based servers only: stdio, sse, http. In-process SDK MCP servers
+// (Options.SDKMcpServers) are static for the lifetime of the client.
+func (s *Stream) SetMcpServers(
+	ctx context.Context,
+	servers map[string]MCPServerConfig,
+) (*McpSetServersResult, error) {
+	if servers == nil {
+		servers = map[string]MCPServerConfig{}
+	}
+	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "mcp_set_servers",
+		Servers: &servers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := json.Marshal(resp.Response.Response)
+	if err != nil {
+		return nil, fmt.Errorf("mcp_set_servers: marshal: %w", err)
+	}
+	var out McpSetServersResult
+	if err := json.Unmarshal(bytes, &out); err != nil {
+		return nil, fmt.Errorf("mcp_set_servers: unmarshal: %w", err)
+	}
+	return &out, nil
+}
+
 func cloneInitializeResponse(
 	src *SDKControlInitializeResponse,
 ) *SDKControlInitializeResponse {

--- a/client_mcp_runtime_test.go
+++ b/client_mcp_runtime_test.go
@@ -1,0 +1,214 @@
+package claudeagent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rawWrittenSDKControlRequest(
+	t *testing.T,
+	transport *streamControlTransport,
+) string {
+	t.Helper()
+
+	written := transport.writtenMessages()
+	require.Len(t, written, 1)
+
+	data, err := json.Marshal(written[0])
+	require.NoError(t, err)
+	return string(data)
+}
+
+func successSDKControlResponseWithPayload(
+	payload map[string]interface{},
+) func(SDKControlRequest) SDKControlResponse {
+	return func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "success",
+				RequestID: req.RequestID,
+				Response:  payload,
+			},
+		}
+	}
+}
+
+func TestStreamReconnectMcpServerWireShape(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.ReconnectMcpServer(ctx, "foo")
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"mcp_reconnect","serverName":"foo"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamToggleMcpServerWireShapeTrue(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.ToggleMcpServer(ctx, "foo", true)
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"mcp_toggle","serverName":"foo","enabled":true}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamToggleMcpServerWireShapeFalse(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.ToggleMcpServer(ctx, "foo", false)
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"mcp_toggle","serverName":"foo","enabled":false}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamSetMcpServersWireShape(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{
+			"added":   []interface{}{},
+			"removed": []interface{}{},
+			"errors":  map[string]interface{}{},
+		}),
+	)
+
+	got, err := stream.SetMcpServers(context.Background(), map[string]MCPServerConfig{
+		"myserver": {
+			Type:    "stdio",
+			Command: "node",
+			Args:    []string{"server.js"},
+			Env:     map[string]string{"TOKEN": "abc"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"mcp_set_servers","servers":{"myserver":{"type":"stdio","command":"node","args":["server.js"],"env":{"TOKEN":"abc"}}}}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamSetMcpServersEmpty(t *testing.T) {
+	tests := []struct {
+		name    string
+		servers map[string]MCPServerConfig
+	}{
+		{name: "nil", servers: nil},
+		{name: "empty", servers: map[string]MCPServerConfig{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream, transport, _ := newStreamControlTest(
+				successSDKControlResponseWithPayload(map[string]interface{}{
+					"added":   []interface{}{},
+					"removed": []interface{}{},
+					"errors":  map[string]interface{}{},
+				}),
+			)
+
+			got, err := stream.SetMcpServers(context.Background(), tt.servers)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+
+			assert.JSONEq(t,
+				`{"type":"control_request","request_id":"req_1","request":{"subtype":"mcp_set_servers","servers":{}}}`,
+				rawWrittenSDKControlRequest(t, transport),
+			)
+		})
+	}
+}
+
+func TestStreamSetMcpServersParsesResult(t *testing.T) {
+	stream, _, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{
+			"added":   []interface{}{"a", "b"},
+			"removed": []interface{}{"c"},
+			"errors":  map[string]interface{}{"d": "timeout"},
+		}),
+	)
+
+	got, err := stream.SetMcpServers(context.Background(), map[string]MCPServerConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, []string{"a", "b"}, got.Added)
+	assert.Equal(t, []string{"c"}, got.Removed)
+	assert.Equal(t, map[string]string{"d": "timeout"}, got.Errors)
+}
+
+func TestStreamSetMcpServersEmptyArrays(t *testing.T) {
+	stream, _, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{
+			"added":   []interface{}{},
+			"removed": []interface{}{},
+			"errors":  map[string]interface{}{},
+		}),
+	)
+
+	got, err := stream.SetMcpServers(context.Background(), map[string]MCPServerConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.NotNil(t, got.Added)
+	assert.Empty(t, got.Added)
+	assert.NotNil(t, got.Removed)
+	assert.Empty(t, got.Removed)
+	assert.NotNil(t, got.Errors)
+	assert.Empty(t, got.Errors)
+}
+
+func TestStreamReconnectMcpServerControlError(t *testing.T) {
+	stream, _, _ := newStreamControlTest(func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "error",
+				RequestID: req.RequestID,
+				Error:     "unknown server",
+			},
+		}
+	})
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.ReconnectMcpServer(ctx, "foo")
+	})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "unknown server"))
+}
+
+func TestStreamToggleMcpServerControlError(t *testing.T) {
+	stream, _, _ := newStreamControlTest(func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "error",
+				RequestID: req.RequestID,
+				Error:     "unknown server",
+			},
+		}
+	})
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.ToggleMcpServer(ctx, "foo", false)
+	})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "unknown server"))
+}

--- a/messages.go
+++ b/messages.go
@@ -259,7 +259,12 @@ type SDKControlRequestBody struct {
 	Model                  string                              `json:"model,omitempty"`                  // For set_model
 	MaxThinkingTokens      *int                                `json:"max_thinking_tokens,omitempty"`    // For set_max_thinking_tokens
 	UserMessageID          string                              `json:"user_message_id,omitempty"`        // For rewind_files
+	// mcp_message uses snake_case server_name; other MCP control subtypes use
+	// camelCase serverName, matching the CLI wire protocol.
 	ServerName             string                              `json:"server_name,omitempty"`            // For mcp_message
+	MCPServerName          string                              `json:"serverName,omitempty"`             // For MCP control subtypes that use camelCase
+	Enabled                *bool                               `json:"enabled,omitempty"`                // For mcp_toggle
+	Servers                *map[string]MCPServerConfig         `json:"servers,omitempty"`                // For mcp_set_servers
 	Message                map[string]interface{}              `json:"message,omitempty"`                // For mcp_message (JSONRPC)
 }
 

--- a/messages.go
+++ b/messages.go
@@ -259,12 +259,10 @@ type SDKControlRequestBody struct {
 	Model                  string                              `json:"model,omitempty"`                  // For set_model
 	MaxThinkingTokens      *int                                `json:"max_thinking_tokens,omitempty"`    // For set_max_thinking_tokens
 	UserMessageID          string                              `json:"user_message_id,omitempty"`        // For rewind_files
-	// mcp_message uses snake_case server_name; other MCP control subtypes use
-	// camelCase serverName, matching the CLI wire protocol.
-	ServerName             string                              `json:"server_name,omitempty"`            // For mcp_message
-	MCPServerName          string                              `json:"serverName,omitempty"`             // For MCP control subtypes that use camelCase
-	Enabled                *bool                               `json:"enabled,omitempty"`                // For mcp_toggle
-	Servers                *map[string]MCPServerConfig         `json:"servers,omitempty"`                // For mcp_set_servers
+	ServerName             string                              `json:"server_name,omitempty"`            // For mcp_message (snake_case)
+	MCPServerName          string                              `json:"serverName,omitempty"`             // For mcp_reconnect/mcp_toggle/mcp_set_servers (camelCase)
+	Enabled                *bool                               `json:"enabled,omitempty"`                // For mcp_toggle (pointer so explicit false serializes)
+	Servers                *map[string]MCPServerConfig         `json:"servers,omitempty"`                // For mcp_set_servers (pointer so nil/empty round-trips as {})
 	Message                map[string]interface{}              `json:"message,omitempty"`                // For mcp_message (JSONRPC)
 }
 

--- a/query_types.go
+++ b/query_types.go
@@ -59,6 +59,13 @@ type McpServerInfo struct {
 	Version string `json:"version"` // Server version
 }
 
+// McpSetServersResult is the response from Stream.SetMcpServers.
+type McpSetServersResult struct {
+	Added   []string          `json:"added"`
+	Removed []string          `json:"removed"`
+	Errors  map[string]string `json:"errors"`
+}
+
 // AccountInfo contains user account information.
 type AccountInfo struct {
 	Email            string `json:"email,omitempty"`            // User email


### PR DESCRIPTION
PR 19 of the v0.2.119 catchup. Adds three MCP runtime-control methods to `Stream`, matching the upstream surface in `sdk.d.ts` L2105-2141.

## Methods

| Method | Subtype | Payload |
|---|---|---|
| `ReconnectMcpServer(ctx, serverName)` | `mcp_reconnect` | `serverName` |
| `ToggleMcpServer(ctx, serverName, enabled)` | `mcp_toggle` | `serverName`, `enabled` |
| `SetMcpServers(ctx, servers) (*McpSetServersResult, error)` | `mcp_set_servers` | `servers` |

All three route through `sendSDKControlRequest` (PR 17). `Enabled` is `*bool` so an explicit `false` serializes; `Servers` is `*map[...]` so the field is omitted on unrelated subtypes but a nil/empty input still round-trips as `"servers":{}` to match the TS "remove all dynamic servers" semantics.

## Wire field divergence

`SDKControlRequestBody.ServerName` (snake_case `server_name`) is preserved for `mcp_message`. The new `MCPServerName` field (camelCase `serverName`) is added separately for the MCP control subtypes that use the camelCase form. Same Go-level concept on the wire as two different keys; documented inline.

## Tests

`client_mcp_runtime_test.go` covers, for each method:
- outbound wire shape (subtype + field names, including `enabled:false`)
- response parsing (populated and empty arrays/maps)
- error propagation through `sendSDKControlRequest`

## Out of scope

- In-process SDK MCP server hot-swap (`Options.SDKMcpServers`). TS `setMcpServers` rebuilds the client-side SDK MCP registry; Go's registry is initialized once and never mutated. Adding hot-swap means extending `MCPServerConfig` with an SDK-instance variant and exposing a `Protocol` mutator — separate PR.
- Other Stream methods (`ReadFile`, `ReloadPlugins`, `ApplyFlagSettings`, `StopTask`, `Close` semantics) — PR 20.
- Session-management free functions — PR 21.
- Other MCP subtypes (`mcp_authenticate`, `mcp_clear_auth`, `mcp_oauth_callback_url`) — out of v0.2.119 scope.