### PR TITLE
stream: file checkpoint, read-state seed, plugin reload, runtime control (PR 20 of v0.2.119 catchup)

### DIFF
--- a/client.go
+++ b/client.go
@@ -759,22 +759,6 @@ func (s *Stream) Interrupt(ctx context.Context) error {
 	return err
 }
 
-// RewindFiles restores files to a checkpoint at the specified user message.
-//
-// This requires EnableFileCheckpointing to be true in Options.
-// The userMessageUUID should be the UUID of a previous user message.
-func (s *Stream) RewindFiles(ctx context.Context, userMessageUUID string) error {
-	req := SDKControlRequest{
-		Type:      "control_request",
-		RequestID: s.client.protocol.nextRequestID(),
-		Request: SDKControlRequestBody{
-			Subtype:       "rewind_files",
-			UserMessageID: userMessageUUID,
-		},
-	}
-	return s.client.transport.Write(ctx, req)
-}
-
 // SetPermissionMode dynamically changes the permission mode for this session.
 // It blocks until the CLI acknowledges the request or returns an error.
 func (s *Stream) SetPermissionMode(ctx context.Context, mode PermissionMode) error {
@@ -803,6 +787,123 @@ func (s *Stream) SetMaxThinkingTokens(ctx context.Context, tokens *int) error {
 	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
 		Subtype:           "set_max_thinking_tokens",
 		MaxThinkingTokens: tokens,
+	})
+	return err
+}
+
+// RewindFiles restores tracked files to their state at the specified user
+// message checkpoint. EnableFileCheckpointing must be true when the session is
+// started for the CLI to have checkpoint data.
+func (s *Stream) RewindFiles(
+	ctx context.Context,
+	userMessageID string,
+	opts *RewindFilesOptions,
+) (*RewindFilesResult, error) {
+	body := SDKControlRequestBody{
+		Subtype:       "rewind_files",
+		UserMessageID: userMessageID,
+	}
+	if opts != nil && opts.DryRun {
+		body.DryRun = &opts.DryRun
+	}
+	resp, err := s.sendSDKControlRequest(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := json.Marshal(resp.Response.Response)
+	if err != nil {
+		return nil, fmt.Errorf("rewind_files: marshal: %w", err)
+	}
+	var out RewindFilesResult
+	if err := json.Unmarshal(bytes, &out); err != nil {
+		return nil, fmt.Errorf("rewind_files: unmarshal: %w", err)
+	}
+	return &out, nil
+}
+
+// SeedReadState seeds the CLI read-file cache with a path and mtime observed
+// by the caller. The CLI uses the mtime to avoid seeding stale reads.
+func (s *Stream) SeedReadState(ctx context.Context, path string, mtime int64) error {
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "seed_read_state",
+		Path:    path,
+		MTime:   &mtime,
+	})
+	return err
+}
+
+// ReadFile reads a file from the session filesystem using CLI read permissions.
+// Unlike the TypeScript SDK, CLI errors are returned to the caller instead of
+// being swallowed as a nil response.
+func (s *Stream) ReadFile(
+	ctx context.Context,
+	path string,
+	opts *ReadFileOptions,
+) (*SDKControlReadFileResponse, error) {
+	body := SDKControlRequestBody{
+		Subtype: "read_file",
+		Path:    path,
+	}
+	if opts != nil && opts.MaxBytes > 0 {
+		body.MaxBytes = &opts.MaxBytes
+	}
+	resp, err := s.sendSDKControlRequest(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := json.Marshal(resp.Response.Response)
+	if err != nil {
+		return nil, fmt.Errorf("read_file: marshal: %w", err)
+	}
+	var out SDKControlReadFileResponse
+	if err := json.Unmarshal(bytes, &out); err != nil {
+		return nil, fmt.Errorf("read_file: unmarshal: %w", err)
+	}
+	return &out, nil
+}
+
+// ReloadPlugins reloads plugins from disk and returns refreshed session metadata.
+func (s *Stream) ReloadPlugins(
+	ctx context.Context,
+) (*SDKControlReloadPluginsResponse, error) {
+	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "reload_plugins",
+	})
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := json.Marshal(resp.Response.Response)
+	if err != nil {
+		return nil, fmt.Errorf("reload_plugins: marshal: %w", err)
+	}
+	var out SDKControlReloadPluginsResponse
+	if err := json.Unmarshal(bytes, &out); err != nil {
+		return nil, fmt.Errorf("reload_plugins: unmarshal: %w", err)
+	}
+	return &out, nil
+}
+
+// ApplyFlagSettings merges settings into the active flag settings layer.
+// Top-level keys are shallow-merged by the CLI across successive calls.
+func (s *Stream) ApplyFlagSettings(
+	ctx context.Context,
+	settings map[string]interface{},
+) error {
+	if settings == nil {
+		settings = map[string]interface{}{}
+	}
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype:  "apply_flag_settings",
+		Settings: &settings,
+	})
+	return err
+}
+
+// StopTask asks the CLI to stop a running task.
+func (s *Stream) StopTask(ctx context.Context, taskID string) error {
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "stop_task",
+		TaskID:  taskID,
 	})
 	return err
 }

--- a/client_file_plugin_control_test.go
+++ b/client_file_plugin_control_test.go
@@ -1,0 +1,337 @@
+package claudeagent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func controlErrorResponse(message string) func(SDKControlRequest) SDKControlResponse {
+	return func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "error",
+				RequestID: req.RequestID,
+				Error:     message,
+			},
+		}
+	}
+}
+
+func TestStreamRewindFilesNoOpts(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(
+			successSDKControlResponseWithPayload(map[string]interface{}{
+				"canRewind":    true,
+				"filesChanged": []interface{}{"a", "b"},
+				"insertions":   float64(3),
+			}),
+		)
+
+		var got *RewindFilesResult
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			var err error
+			got, err = stream.RewindFiles(ctx, "user-msg-1", nil)
+			return err
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.True(t, got.CanRewind)
+		assert.Equal(t, []string{"a", "b"}, got.FilesChanged)
+		assert.Equal(t, 3, got.Insertions)
+
+		assert.JSONEq(t,
+			`{"type":"control_request","request_id":"req_1","request":{"subtype":"rewind_files","user_message_id":"user-msg-1"}}`,
+			rawWrittenSDKControlRequest(t, transport),
+		)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		stream, _, _ := newStreamControlTest(controlErrorResponse("checkpoint missing"))
+
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			_, err := stream.RewindFiles(ctx, "user-msg-1", nil)
+			return err
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "checkpoint missing")
+	})
+}
+
+func TestStreamRewindFilesDryRunTrue(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{}),
+	)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		_, err := stream.RewindFiles(ctx, "user-msg-1", &RewindFilesOptions{
+			DryRun: true,
+		})
+		return err
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"rewind_files","user_message_id":"user-msg-1","dry_run":true}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamRewindFilesDryRunFalseOmitted(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{}),
+	)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		_, err := stream.RewindFiles(ctx, "user-msg-1", &RewindFilesOptions{
+			DryRun: false,
+		})
+		return err
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"rewind_files","user_message_id":"user-msg-1"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamRewindFilesError(t *testing.T) {
+	stream, _, _ := newStreamControlTest(controlErrorResponse("cannot rewind"))
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		_, err := stream.RewindFiles(ctx, "user-msg-1", &RewindFilesOptions{
+			DryRun: true,
+		})
+		return err
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot rewind")
+}
+
+func TestStreamSeedReadStateWireShape(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.SeedReadState(ctx, "a.go", 1700000000000)
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"seed_read_state","path":"a.go","mtime":1700000000000}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamReadFileNoOpts(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(
+			successSDKControlResponseWithPayload(map[string]interface{}{
+				"contents":  "hello",
+				"absPath":   "/tmp/example.txt",
+				"truncated": true,
+			}),
+		)
+
+		var got *SDKControlReadFileResponse
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			var err error
+			got, err = stream.ReadFile(ctx, "example.txt", nil)
+			return err
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "hello", got.Contents)
+		assert.Equal(t, "/tmp/example.txt", got.AbsPath)
+		assert.True(t, got.Truncated)
+
+		assert.JSONEq(t,
+			`{"type":"control_request","request_id":"req_1","request":{"subtype":"read_file","path":"example.txt"}}`,
+			rawWrittenSDKControlRequest(t, transport),
+		)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		stream, _, _ := newStreamControlTest(controlErrorResponse("permission denied"))
+
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			_, err := stream.ReadFile(ctx, "example.txt", nil)
+			return err
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "permission denied")
+	})
+}
+
+func TestStreamReadFileWithMaxBytes(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{}),
+	)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		_, err := stream.ReadFile(ctx, "example.txt", &ReadFileOptions{
+			MaxBytes: 4096,
+		})
+		return err
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"read_file","path":"example.txt","max_bytes":4096}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamReadFileMaxBytesZeroOmitted(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{}),
+	)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		_, err := stream.ReadFile(ctx, "example.txt", &ReadFileOptions{
+			MaxBytes: 0,
+		})
+		return err
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"read_file","path":"example.txt"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamReloadPluginsParsesResponse(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(
+			successSDKControlResponseWithPayload(map[string]interface{}{
+				"commands": []interface{}{
+					map[string]interface{}{
+						"name":         "review",
+						"description":  "Run review",
+						"argumentHint": "[target]",
+					},
+				},
+				"agents": []interface{}{
+					map[string]interface{}{
+						"name":        "planner",
+						"description": "Plans work",
+						"model":       "sonnet",
+					},
+				},
+				"plugins": []interface{}{
+					map[string]interface{}{
+						"name":   "local",
+						"path":   "/tmp/plugin",
+						"source": "project",
+					},
+				},
+				"mcpServers": []interface{}{
+					map[string]interface{}{
+						"name":   "github",
+						"status": "connected",
+						"serverInfo": map[string]interface{}{
+							"name":    "github",
+							"version": "1.0.0",
+						},
+					},
+				},
+				"error_count": float64(2),
+			}),
+		)
+
+		var got *SDKControlReloadPluginsResponse
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			var err error
+			got, err = stream.ReloadPlugins(ctx)
+			return err
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, []SlashCommand{{
+			Name:         "review",
+			Description:  "Run review",
+			ArgumentHint: "[target]",
+		}}, got.Commands)
+		assert.Equal(t, []AgentInfo{{
+			Name:        "planner",
+			Description: "Plans work",
+			Model:       "sonnet",
+		}}, got.Agents)
+		assert.Equal(t, []PluginInfo{{
+			Name:   "local",
+			Path:   "/tmp/plugin",
+			Source: "project",
+		}}, got.Plugins)
+		require.Len(t, got.McpServers, 1)
+		assert.Equal(t, "github", got.McpServers[0].Name)
+		assert.Equal(t, McpServerStateConnected, got.McpServers[0].Status)
+		require.NotNil(t, got.McpServers[0].ServerInfo)
+		assert.Equal(t, "1.0.0", got.McpServers[0].ServerInfo.Version)
+		assert.Equal(t, 2, got.ErrorCount)
+
+		assert.JSONEq(t,
+			`{"type":"control_request","request_id":"req_1","request":{"subtype":"reload_plugins"}}`,
+			rawWrittenSDKControlRequest(t, transport),
+		)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		stream, _, _ := newStreamControlTest(controlErrorResponse("reload failed"))
+
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			_, err := stream.ReloadPlugins(ctx)
+			return err
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "reload failed")
+	})
+}
+
+func TestStreamApplyFlagSettingsNonEmpty(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.ApplyFlagSettings(ctx, map[string]interface{}{
+			"foo": "bar",
+			"n":   42,
+		})
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"apply_flag_settings","settings":{"foo":"bar","n":42}}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamApplyFlagSettingsNil(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.ApplyFlagSettings(ctx, nil)
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"apply_flag_settings","settings":{}}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamStopTaskWireShape(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, stream.StopTask(ctx, "task-123"))
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"stop_task","task_id":"task-123"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1284,3 +1284,20 @@ func TestIntegrationStreamIntrospection(t *testing.T) {
 	_, err = stream.AccountInfo(ctx)
 	require.NoError(t, err)
 }
+
+// TestIntegrationStreamFileAndRuntime is a slot for the PR 20 surface
+// (RewindFiles, SeedReadState, ReadFile, ReloadPlugins, ApplyFlagSettings,
+// StopTask). Each path needs setup the integration harness does not yet
+// produce: file checkpointing must be enabled at session start with a tracked
+// edit before RewindFiles will return a usable result; ReadFile and
+// SeedReadState need a file the CLI considers in-scope; ReloadPlugins needs
+// plugins configured; StopTask needs a running task identifier surfaced over
+// the wire. Once the harness can stage one of those preconditions, drop the
+// t.Skip and assert the wire round-trip end-to-end.
+func TestIntegrationStreamFileAndRuntime(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+	t.Skip("not triggerable from CLI yet: file checkpoint / read-state / " +
+		"plugin / runtime surface needs harness fixtures that don't exist; " +
+		"unit coverage in client_file_plugin_control_test.go")
+}

--- a/messages.go
+++ b/messages.go
@@ -259,6 +259,12 @@ type SDKControlRequestBody struct {
 	Model                  string                              `json:"model,omitempty"`                  // For set_model
 	MaxThinkingTokens      *int                                `json:"max_thinking_tokens,omitempty"`    // For set_max_thinking_tokens
 	UserMessageID          string                              `json:"user_message_id,omitempty"`        // For rewind_files
+	DryRun                 *bool                               `json:"dry_run,omitempty"`                // For rewind_files
+	Path                   string                              `json:"path,omitempty"`                   // For read_file/seed_read_state
+	MaxBytes               *int                                `json:"max_bytes,omitempty"`              // For read_file
+	MTime                  *int64                              `json:"mtime,omitempty"`                  // For seed_read_state
+	Settings               *map[string]interface{}             `json:"settings,omitempty"`               // For apply_flag_settings
+	TaskID                 string                              `json:"task_id,omitempty"`                // For stop_task
 	ServerName             string                              `json:"server_name,omitempty"`            // For mcp_message (snake_case)
 	MCPServerName          string                              `json:"serverName,omitempty"`             // For mcp_reconnect/mcp_toggle/mcp_set_servers (camelCase)
 	Enabled                *bool                               `json:"enabled,omitempty"`                // For mcp_toggle (pointer so explicit false serializes)

--- a/query_types.go
+++ b/query_types.go
@@ -66,6 +66,48 @@ type McpSetServersResult struct {
 	Errors  map[string]string `json:"errors"`
 }
 
+// RewindFilesOptions controls a file checkpoint rewind.
+type RewindFilesOptions struct {
+	DryRun bool `json:"dryRun,omitempty"`
+}
+
+// RewindFilesResult is the response from Stream.RewindFiles.
+type RewindFilesResult struct {
+	CanRewind    bool     `json:"canRewind"`
+	Error        string   `json:"error,omitempty"`
+	FilesChanged []string `json:"filesChanged,omitempty"`
+	Insertions   int      `json:"insertions,omitempty"`
+	Deletions    int      `json:"deletions,omitempty"`
+}
+
+// ReadFileOptions controls Stream.ReadFile.
+type ReadFileOptions struct {
+	MaxBytes int `json:"maxBytes,omitempty"`
+}
+
+// SDKControlReadFileResponse contains file contents from Stream.ReadFile.
+type SDKControlReadFileResponse struct {
+	Contents  string `json:"contents"`
+	AbsPath   string `json:"absPath"`
+	Truncated bool   `json:"truncated,omitempty"`
+}
+
+// SDKControlReloadPluginsResponse reports refreshed session components.
+type SDKControlReloadPluginsResponse struct {
+	Commands   []SlashCommand    `json:"commands"`
+	Agents     []AgentInfo       `json:"agents"`
+	Plugins    []PluginInfo      `json:"plugins"`
+	McpServers []McpServerStatus `json:"mcpServers"`
+	ErrorCount int               `json:"error_count"`
+}
+
+// PluginInfo describes a plugin loaded by the CLI.
+type PluginInfo struct {
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	Source string `json:"source,omitempty"`
+}
+
 // AccountInfo contains user account information.
 type AccountInfo struct {
 	Email            string `json:"email,omitempty"`            // User email


### PR DESCRIPTION
Catches the Go SDK Stream surface up to most of the v0.2.119 TS `Query` interface.

## New methods on `*Stream`

- `RewindFiles(ctx, userMessageID, opts *RewindFilesOptions) (*RewindFilesResult, error)` — replaces the prior fire-and-forget signature. **Breaking change** (pre-1.0; explicitly aligning with TS).
- `SeedReadState(ctx, path, mtime int64) error` — seeds the CLI read-file cache.
- `ReadFile(ctx, path, opts *ReadFileOptions) (*SDKControlReadFileResponse, error)` — TS deviation: returns the CLI error rather than swallowing it as `nil`.
- `ReloadPlugins(ctx) (*SDKControlReloadPluginsResponse, error)` — returns refreshed commands / agents / plugins / mcpServers / error_count.
- `ApplyFlagSettings(ctx, settings map[string]interface{}) error` — wire payload sends `settings: {}` when caller passes nil (matches the TS required-field shape).
- `StopTask(ctx, taskID) error` — asks the CLI to stop a running task.

## Wire shape

`SDKControlRequestBody` gains `dry_run`, `path`, `max_bytes`, `mtime`, `settings`, `task_id`. `Settings` is pointer-to-map so an empty `{}` round-trips while nil omits.

## Out of scope

- `Stream.Close()` — TS `close()` forcefully terminates the subprocess; current Go behavior only closes a local channel. Wider blast radius — left for a focused follow-up.
- `cancelAsyncMessage` — internal in TS, not on the Stream interface.

## Tests

`client_file_plugin_control_test.go` covers the 12 cases enumerated in the per-PR brief: dry-run-true / dry-run-false-omitted / nil-opts variants for `RewindFiles`; max-bytes-set / max-bytes-zero-omitted / nil-opts variants for `ReadFile`; nil-vs-non-empty for `ApplyFlagSettings`; wire-shape coverage for `SeedReadState` and `StopTask`; full payload parsing for `ReloadPlugins`; error-propagation subtests for the three response-parsing methods.

`go vet ./...` and `go test -race ./...` both pass.