### PR TITLE
docs: refresh v0.2.119 parity notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ make test-race                          # Unit tests with race detector
 
 Integration tests require `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY`. Without a token, they skip (not fail). Always run `make test-integration` after changes that affect CLI communication.
 
+The SDK has been brought forward through the v0.2.119 TypeScript Agent SDK catchup. When adding new Claude Code CLI surfaces, check the installed CLI behavior and the TypeScript SDK reference before assuming an older local pattern is complete.
+
 ## Verifying Changes
 
 **All changes must pass tests and lint before committing.**
@@ -23,7 +25,7 @@ After modifying code:
 1. `go build ./...` - must pass
 2. `go test ./...` - unit tests must pass
 3. `make lint` - linter must pass (no warnings)
-4. `make test-integration` - run if touching client.go, protocol.go, transport.go, or message handling
+4. `make test-integration` - run if touching client.go, protocol.go, transport.go, settings/options, or message handling
 
 For new features, check coverage: `make coverage`
 
@@ -37,6 +39,8 @@ This SDK wraps the Claude Code CLI as a subprocess, communicating via JSON over 
 - `transport.go` - Subprocess lifecycle, stdin/stdout pipes
 - `mcp.go` - In-process MCP server with generics-based tools
 - `ask_user.go` - `QuestionMessage` for interactive Q&A
+- `sessions.go` - Local JSONL session listing, loading, and deletion helpers
+- `tasks.go` - Persistent task-list helpers shared with Claude Code task tools
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ the CLI as a subprocess. It communicates via line-delimited JSON over
 stdin/stdout, giving you access to Claude's tool use, extended thinking,
 session management, and hook system.
 
+This repository tracks the official TypeScript Agent SDK surface through the
+v0.2.119 catchup work, using Go idioms where the API shape differs.
+
 ```mermaid
 flowchart TB
     subgraph SDK[Go SDK]
@@ -116,6 +119,23 @@ client, _ := claudeagent.NewClient(
 )
 ```
 
+Settings can be supplied either as a settings file path or as inline JSON:
+
+```go
+client, _ := claudeagent.NewClient(
+    claudeagent.WithSettingsPath("/path/to/settings.json"),
+)
+
+client, _ = claudeagent.NewClient(
+    claudeagent.WithSettings(claudeagent.Settings{
+        Model: "claude-sonnet-4-5-20250929",
+        Permissions: &claudeagent.SettingsPermissions{
+            Allow: []string{"Bash(git status)"},
+        },
+    }),
+)
+```
+
 ## Custom Tools (MCP)
 
 Define tools that Claude can use during conversations:
@@ -186,6 +206,26 @@ For detailed guides and examples, see [docs/examples/](docs/examples/):
 - [Skills](docs/examples/skills.md) - Filesystem-based capability extensions
 - [Ralph Loop](docs/examples/ralph.md) - Iterative task completion pattern
 - [Task Lists](docs/TASKS.md) - Multi-agent task coordination system
+
+## TypeScript SDK Parity
+
+The v0.2.119 catchup adds coverage for recent Agent SDK and Claude Code CLI
+surfaces, including:
+
+- thinking effort, task budgets, debug files, extra CLI args, agent selection,
+  and prompt/agent progress toggles
+- programmatic subagents, richer hook inputs/outputs, permission updates, and
+  MCP HTTP/SSE configuration
+- stream control and introspection helpers, runtime MCP server updates,
+  file/read-state/plugin control, and local JSONL session helpers
+- explicit settings support via `WithSettingsPath`, `WithSettings`, and
+  `WithManagedSettings`
+
+Some areas remain intentionally limited by the CLI or integration harness:
+desktop/IDE-only settings are not modeled exhaustively, several runtime control
+paths have unit coverage plus skipped integration slots until stable live CLI
+fixtures exist, and alpha task/agent behavior should still be checked against
+the installed Claude Code CLI version.
 
 For internal architecture, see [DESIGN.md](docs/DESIGN.md). For CLI protocol
 details (how this and the official Typescript SDK actually work), see

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -10,7 +10,7 @@ The SDK prioritizes three things:
 
 **Feature parity with the TypeScript SDK.** Users switching from TypeScript
 should find equivalent functionality. The API surface differs for Go idioms,
-but capabilities match.
+but the v0.2.119 catchup covers the major current CLI and Agent SDK surfaces.
 
 **Minimal dependencies.** The core SDK depends only on the standard library.
 Testing uses testify for assertions and rapid for property-based tests, but
@@ -71,6 +71,8 @@ claudeagent/
 ├── options.go         # Configuration and hook types
 ├── mcp.go             # MCP server helpers
 ├── query_types.go     # Query response types
+├── sessions.go        # Local JSONL session helpers
+├── tasks.go           # Persistent task-list helpers
 ├── tool_inputs.go     # Tool input type definitions
 ├── skills.go          # Skills loading from filesystem
 ├── errors.go          # Error types
@@ -405,7 +407,9 @@ This pattern provides:
 - Backward compatibility: new options don't break existing code
 - Sensible defaults: `DefaultOptions()` provides safe starting values
 
-The full options struct has 30+ fields matching the TypeScript SDK's capabilities.
+The full options struct has broad coverage for the TypeScript SDK's
+configuration surface, including settings, managed settings, subagents,
+skills, MCP servers, hooks, permissions, thinking controls, and runtime flags.
 
 ## Testing Strategy
 


### PR DESCRIPTION
See memory/catchup-v0.2.119/PLAN.md §"PR 23".

- Notes the v0.2.119 TypeScript Agent SDK catchup in the README.
- Adds a settings configuration example and parity summary for newly covered surfaces.
- Updates contributor guidance in CLAUDE.md for settings/options integration checks.
- Refreshes DESIGN.md package/options notes now that sessions, tasks, and settings have landed.

Validation:
- `GOCACHE=/home/node/go/cache GOMODCACHE=/home/node/go/modcache /home/node/.local/go/bin/go test ./...`