### PR TITLE
options: add typed APIProvider with `gateway` variant

### DIFF
--- a/client_introspection_test.go
+++ b/client_introspection_test.go
@@ -35,7 +35,7 @@ func canonicalInitResponse() *SDKControlInitializeResponse {
 			SubscriptionType: "pro",
 			TokenSource:      "oauth",
 			APIKeySource:     "user",
-			APIProvider:      "firstParty",
+			APIProvider:      APIProviderFirstParty,
 		},
 		FastModeState: "off",
 	}
@@ -52,7 +52,7 @@ func TestStreamInitializationResultClonesCachedInit(t *testing.T) {
 	assert.Equal(t, "default", got.OutputStyle)
 	require.Len(t, got.Commands, 2)
 	assert.Equal(t, "help", got.Commands[0].Name)
-	assert.Equal(t, "firstParty", got.Account.APIProvider)
+	assert.Equal(t, APIProviderFirstParty, got.Account.APIProvider)
 
 	// Mutate the returned slices/structs; second call must not see the mutation.
 	got.Commands[0].Name = "mutated"
@@ -117,7 +117,7 @@ func TestStreamAccountInfoReadsCachedInit(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, acct)
 	assert.Equal(t, "user@example.com", acct.Email)
-	assert.Equal(t, "firstParty", acct.APIProvider)
+	assert.Equal(t, APIProviderFirstParty, acct.APIProvider)
 
 	acct.Email = "mutated@example.com"
 	again, err := stream.AccountInfo(context.Background())
@@ -361,12 +361,41 @@ func TestStreamGetContextUsageApiUsageNullable(t *testing.T) {
 
 // Sanity-check that AccountInfo with apiProvider round-trips through JSON.
 func TestAccountInfoAPIProviderJSON(t *testing.T) {
-	in := AccountInfo{Email: "x@y", APIProvider: "bedrock"}
-	bytes, err := json.Marshal(in)
-	require.NoError(t, err)
-	assert.Contains(t, string(bytes), `"apiProvider":"bedrock"`)
+	tests := []struct {
+		name     string
+		provider APIProvider
+		wantJSON string
+	}{
+		{
+			name:     "bedrock",
+			provider: APIProviderBedrock,
+			wantJSON: `"apiProvider":"bedrock"`,
+		},
+		{
+			name:     "gateway",
+			provider: APIProviderGateway,
+			wantJSON: `"apiProvider":"gateway"`,
+		},
+	}
 
-	var out AccountInfo
-	require.NoError(t, json.Unmarshal(bytes, &out))
-	assert.Equal(t, "bedrock", out.APIProvider)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := AccountInfo{Email: "x@y", APIProvider: tt.provider}
+			bytes, err := json.Marshal(in)
+			require.NoError(t, err)
+			assert.Contains(t, string(bytes), tt.wantJSON)
+
+			var out AccountInfo
+			require.NoError(t, json.Unmarshal(bytes, &out))
+			assert.Equal(t, tt.provider, out.APIProvider)
+		})
+	}
+}
+
+func TestAccountInfoAPIProviderGatewayUnmarshal(t *testing.T) {
+	var acct AccountInfo
+	require.NoError(t, json.Unmarshal([]byte(`{"apiProvider":"gateway","apiKeySource":"oauth"}`), &acct))
+
+	assert.Equal(t, APIProviderGateway, acct.APIProvider)
+	assert.Equal(t, "oauth", acct.APIKeySource)
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -1357,8 +1357,19 @@ func TestIntegrationStreamIntrospection(t *testing.T) {
 	assert.NotEmpty(t, models, "expected at least one model from CLI")
 
 	// Account may be empty under OAuth-token-only auth; just ensure no error.
-	_, err = stream.AccountInfo(ctx)
+	acct, err := stream.AccountInfo(ctx)
 	require.NoError(t, err)
+	if acct.APIProvider != "" {
+		assert.Contains(t, []APIProvider{
+			APIProviderFirstParty,
+			APIProviderBedrock,
+			APIProviderVertex,
+			APIProviderFoundry,
+			APIProviderAnthropicAWS,
+			APIProviderMantle,
+			APIProviderGateway,
+		}, acct.APIProvider)
+	}
 }
 
 // TestIntegrationStreamFileAndRuntime exercises PR 20 stream file/runtime

--- a/query_types.go
+++ b/query_types.go
@@ -108,14 +108,31 @@ type PluginInfo struct {
 	Source string `json:"source,omitempty"`
 }
 
+// APIProvider names the active CLI API backend. Anthropic OAuth login only
+// applies for APIProviderFirstParty; for 3P providers the other AccountInfo
+// fields are absent and auth is external (AWS creds, gcloud ADC, etc.).
+// APIProviderGateway means the CLI is authenticated against an enterprise
+// gateway.
+type APIProvider string
+
+const (
+	APIProviderFirstParty   APIProvider = "firstParty"
+	APIProviderBedrock      APIProvider = "bedrock"
+	APIProviderVertex       APIProvider = "vertex"
+	APIProviderFoundry      APIProvider = "foundry"
+	APIProviderAnthropicAWS APIProvider = "anthropicAws"
+	APIProviderMantle       APIProvider = "mantle"
+	APIProviderGateway      APIProvider = "gateway"
+)
+
 // AccountInfo contains user account information.
 type AccountInfo struct {
-	Email            string `json:"email,omitempty"`            // User email
-	Organization     string `json:"organization,omitempty"`     // Organization name
-	SubscriptionType string `json:"subscriptionType,omitempty"` // Subscription tier
-	TokenSource      string `json:"tokenSource,omitempty"`      // How token was obtained
-	APIKeySource     string `json:"apiKeySource,omitempty"`     // API key source
-	APIProvider      string `json:"apiProvider,omitempty"`      // Active API backend
+	Email            string      `json:"email,omitempty"`            // User email
+	Organization     string      `json:"organization,omitempty"`     // Organization name
+	SubscriptionType string      `json:"subscriptionType,omitempty"` // Subscription tier
+	TokenSource      string      `json:"tokenSource,omitempty"`      // How token was obtained
+	APIKeySource     string      `json:"apiKeySource,omitempty"`     // API key source
+	APIProvider      APIProvider `json:"apiProvider,omitempty"`      // Active API backend
 }
 
 // SDKControlGetContextUsageResponse mirrors the context usage control response.


### PR DESCRIPTION
TS SDK v0.3.150 added `'gateway'` as a 7th value of `AccountInfo.apiProvider` ("the CLI is authenticated against an enterprise gateway"). The Go SDK already carried this as a bare string, so the new value round-trips today.

This PR makes the variant set explicit:
- Add an `APIProvider` string alias and constants for the 7 values (`APIProviderFirstParty` ... `APIProviderGateway`).
- Retype `AccountInfo.APIProvider` from `string` to `APIProvider`.

Behavior unchanged; existing JSON shape unchanged. Tests added for the new `gateway` variant round-trip.

Part of the v0.3.150 catchup (PR 1 of 34).