### PR TITLE
options: add ToolAliases option (with control-init mirror)

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package claudeagent
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,4 +27,14 @@ func TestNewClientAcceptsPermissionModeConstants(t *testing.T) {
 			require.Equal(t, tt.mode, client.options.PermissionMode)
 		})
 	}
+}
+
+func TestWithToolAliases(t *testing.T) {
+	opts := NewOptions()
+	require.Nil(t, opts.ToolAliases)
+
+	aliases := map[string]string{"Bash": "mcp__workspace__bash"}
+	WithToolAliases(aliases)(opts)
+
+	assert.Equal(t, aliases, opts.ToolAliases)
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -1559,3 +1559,89 @@ exec "$real_cli" "$@"
 		assert.Equal(t, want.Env, got.Env)
 	})
 }
+
+func TestIntegrationToolAliases(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	realCLI, err := DiscoverCLIPath(&Options{})
+	require.NoError(t, err)
+
+	tmp := t.TempDir()
+	initLog := filepath.Join(tmp, "initialize.json")
+	shimPath := filepath.Join(tmp, "claude-shim.py")
+	shimBody := fmt.Sprintf(`#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+import threading
+
+init_log = %q
+real_cli = %q
+
+proc = subprocess.Popen(
+    [real_cli] + sys.argv[1:],
+    stdin=subprocess.PIPE,
+    stdout=sys.stdout.buffer,
+    stderr=sys.stderr.buffer,
+)
+
+captured = False
+
+def forward_stdin():
+    global captured
+    try:
+        for line in sys.stdin.buffer:
+            if not captured:
+                try:
+                    msg = json.loads(line)
+                    request = msg.get("request", {})
+                    if (
+                        msg.get("type") == "control_request"
+                        and request.get("subtype") == "initialize"
+                    ):
+                        with open(init_log, "w", encoding="utf-8") as f:
+                            json.dump(request, f)
+                        captured = True
+                except Exception:
+                    pass
+            proc.stdin.write(line)
+            proc.stdin.flush()
+    finally:
+        proc.stdin.close()
+
+thread = threading.Thread(target=forward_stdin)
+thread.start()
+code = proc.wait()
+thread.join(timeout=1)
+sys.exit(code)
+`, initLog, realCLI)
+	require.NoError(t, os.WriteFile(shimPath, []byte(shimBody), 0o755))
+
+	opts := append(isolatedClientOptions(t),
+		WithCLIPath(shimPath),
+		WithToolAliases(map[string]string{"Bash": "Read"}),
+	)
+
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	stream, err := client.Stream(ctx)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	init, err := stream.InitializationResult()
+	require.NoError(t, err)
+	require.NotNil(t, init)
+
+	data, err := os.ReadFile(initLog)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, map[string]interface{}{"Bash": "Read"}, got["toolAliases"])
+}

--- a/messages.go
+++ b/messages.go
@@ -250,6 +250,7 @@ type SDKControlRequestBody struct {
 	PromptSuggestions      *bool                               `json:"promptSuggestions,omitempty"`      // For initialize
 	AgentProgressSummaries *bool                               `json:"agentProgressSummaries,omitempty"` // For initialize
 	ForwardSubagentText    *bool                               `json:"forwardSubagentText,omitempty"`    // For initialize
+	ToolAliases            map[string]string                   `json:"toolAliases,omitempty"`            // For initialize
 	ToolName               string                              `json:"tool_name,omitempty"`              // For can_use_tool/hook_callback
 	Input                  map[string]interface{}              `json:"input,omitempty"`                  // For can_use_tool/hook_callback
 	ToolUseID              string                              `json:"tool_use_id,omitempty"`            // For can_use_tool/hooks

--- a/messages_test.go
+++ b/messages_test.go
@@ -22,6 +22,7 @@ func TestSDKControlRequestBodyInitializeOptions(t *testing.T) {
 		PromptSuggestions:      &falseVal,
 		AgentProgressSummaries: &trueVal,
 		ForwardSubagentText:    &falseVal,
+		ToolAliases:            map[string]string{"Bash": "mcp__workspace__bash"},
 	}
 
 	data, err := json.Marshal(body)
@@ -38,6 +39,7 @@ func TestSDKControlRequestBodyInitializeOptions(t *testing.T) {
 	assert.Equal(t, false, got["promptSuggestions"])
 	assert.Equal(t, true, got["agentProgressSummaries"])
 	assert.Equal(t, false, got["forwardSubagentText"])
+	assert.Equal(t, map[string]interface{}{"Bash": "mcp__workspace__bash"}, got["toolAliases"])
 }
 
 func TestSDKControlRequestBodyInitializeOptionsOmitUnset(t *testing.T) {
@@ -55,6 +57,7 @@ func TestSDKControlRequestBodyInitializeOptionsOmitUnset(t *testing.T) {
 		"promptSuggestions",
 		"agentProgressSummaries",
 		"forwardSubagentText",
+		"toolAliases",
 	} {
 		assert.NotContains(t, got, key)
 	}

--- a/options.go
+++ b/options.go
@@ -87,6 +87,13 @@ type Options struct {
 	// ForwardSubagentText surfaces subagent text in the main stream.
 	ForwardSubagentText *bool
 
+	// ToolAliases maps a tool name to a redirect target. When the model
+	// emits a `tool_use` whose name is a key in the map, the execution path
+	// resolves the mapped value instead. Single-hop (cycles do not loop).
+	// Complementary to DisallowedTools; alias only affects name-based
+	// lookup of model-emitted tool_use blocks.
+	ToolAliases map[string]string
+
 	// SessionOptions configure session behavior (create/resume/fork).
 	SessionOptions SessionOptions
 
@@ -766,6 +773,13 @@ func WithAgentProgressSummaries(enable bool) Option {
 func WithForwardSubagentText(enable bool) Option {
 	return func(o *Options) {
 		o.ForwardSubagentText = &enable
+	}
+}
+
+// WithToolAliases sets the tool-name alias map (see Options.ToolAliases).
+func WithToolAliases(aliases map[string]string) Option {
+	return func(o *Options) {
+		o.ToolAliases = aliases
 	}
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -118,6 +118,7 @@ func (p *Protocol) Initialize(ctx context.Context) error {
 			PromptSuggestions:      p.options.PromptSuggestions,
 			AgentProgressSummaries: p.options.AgentProgressSummaries,
 			ForwardSubagentText:    p.options.ForwardSubagentText,
+			ToolAliases:            p.options.ToolAliases,
 		},
 	}
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -119,6 +119,9 @@ func TestProtocolInitializeOptions(t *testing.T) {
 				WithPromptSuggestions(false)(opts)
 				WithAgentProgressSummaries(true)(opts)
 				WithForwardSubagentText(false)(opts)
+				WithToolAliases(map[string]string{
+					"Bash": "mcp__workspace__bash",
+				})(opts)
 				WithExcludeDynamicSystemPromptSections(true)(opts)
 			},
 			expected: map[string]interface{}{
@@ -128,8 +131,21 @@ func TestProtocolInitializeOptions(t *testing.T) {
 				"promptSuggestions":      false,
 				"agentProgressSummaries": true,
 				"forwardSubagentText":    false,
+				"toolAliases":            map[string]interface{}{"Bash": "mcp__workspace__bash"},
 				"excludeDynamicSections": true,
 			},
+		},
+		{
+			name: "empty tool aliases omitted",
+			configure: func(opts *Options) {
+				WithToolAliases(map[string]string{})(opts)
+			},
+			unexpected: []string{"toolAliases"},
+		},
+		{
+			name:       "nil tool aliases omitted",
+			configure:  func(opts *Options) {},
+			unexpected: []string{"toolAliases"},
 		},
 		{
 			name: "exclude dynamic false omitted",


### PR DESCRIPTION
TS SDK v0.3.150 added `Options.toolAliases?: Record<string, string>`,
a map of tool-name aliases applied before name resolution. When the
model emits a tool_use whose name is a key, the execution path
resolves the mapped name instead. Single-hop; complementary to
DisallowedTools.

This PR adds the Go-side parallel:
- New `Options.ToolAliases map[string]string` field + `WithToolAliases`
  builder.
- New `ToolAliases` field on `SDKControlRequestBody`, wired into the
  initialize control request in `protocol.go`.

No CLI flag — the TS SDK transports this only via the initialize
control message, and we match.

Part of the v0.3.150 catchup (PR 2 of 34).

See memory/catchup-v0.3.150/PLAN.md §"PR 02".