### PR TITLE
options: add MCPServerConfig.Timeout for per-server tool-call timeout

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -602,6 +602,13 @@ func TestIntegrationSDKMCPServer(t *testing.T) {
 		"expected response to contain the sum 11 (7 + 4)")
 }
 
+func TestIntegrationMCPTimeout(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	t.Skip("not directly triggerable from CLI without slow stdio MCP fixture: in-process SDK MCP servers are registered separately from MCPServerConfig timeout")
+}
+
 // TestIntegrationStopHookBlock tests that Stop hooks can block session exit
 // and reinject a new prompt using the Decision/Reason/SystemMessage fields.
 //

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -46,6 +46,60 @@ func TestMCPServerConfigEnv(t *testing.T) {
 	assert.Equal(t, "true", config.Env["DEBUG"])
 }
 
+func TestMCPServerConfigTimeoutJSON(t *testing.T) {
+	ptr := func(v int) *int { return &v }
+
+	t.Run("marshal includes timeout", func(t *testing.T) {
+		data, err := json.Marshal(MCPServerConfig{
+			Type:    "stdio",
+			Command: "foo",
+			Timeout: ptr(5000),
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, float64(5000), got["timeout"])
+	})
+
+	t.Run("unmarshal timeout", func(t *testing.T) {
+		var cfg MCPServerConfig
+		require.NoError(t, json.Unmarshal(
+			[]byte(`{"type":"stdio","command":"foo","timeout":3000}`),
+			&cfg,
+		))
+
+		require.NotNil(t, cfg.Timeout)
+		assert.Equal(t, 3000, *cfg.Timeout)
+	})
+
+	t.Run("nil timeout omitted", func(t *testing.T) {
+		data, err := json.Marshal(MCPServerConfig{
+			Type:    "stdio",
+			Command: "foo",
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "timeout")
+	})
+
+	t.Run("explicit zero timeout included", func(t *testing.T) {
+		data, err := json.Marshal(MCPServerConfig{
+			Type:    "stdio",
+			Command: "foo",
+			// A zero pointee is still explicit; only nil is omitted.
+			Timeout: ptr(0),
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, float64(0), got["timeout"])
+	})
+}
+
 func TestWithMCPServers(t *testing.T) {
 	servers := map[string]MCPServerConfig{
 		"server1": {

--- a/messages.go
+++ b/messages.go
@@ -239,6 +239,7 @@ type SDKControlRequestBody struct {
 	Subtype                string                              `json:"subtype"`                          // Request subtype
 	Hooks                  map[string][]SDKHookCallbackMatcher `json:"hooks,omitempty"`                  // For initialize
 	SDKMCPServers          []string                            `json:"sdkMcpServers,omitempty"`          // For initialize
+	MCPServers             map[string]MCPServerConfig          `json:"mcpServers,omitempty"`             // For initialize
 	JSONSchema             map[string]interface{}              `json:"jsonSchema,omitempty"`             // For initialize
 	SystemPrompt           string                              `json:"systemPrompt,omitempty"`           // For initialize
 	AppendSystemPrompt     string                              `json:"appendSystemPrompt,omitempty"`     // For initialize

--- a/options.go
+++ b/options.go
@@ -1950,6 +1950,11 @@ type MCPServerConfig struct {
 	Headers map[string]string     `json:"headers,omitempty"` // Remote server headers (for sse/http)
 	Tools   []MCPServerToolPolicy `json:"tools,omitempty"`   // Remote server tool permission policies
 	Address string                `json:"address,omitempty"` // Socket address (for socket type)
+	// Timeout is the per-server tool-call timeout in milliseconds. Overrides
+	// the MCP_TOOL_TIMEOUT environment variable for this server. Hard wall-
+	// clock limit per call; progress notifications do not extend it.
+	// Server-side floor: 1000ms.
+	Timeout *int `json:"timeout,omitempty"`
 }
 
 // MCPServerToolPolicy configures a per-tool permission policy for remote MCP servers.

--- a/protocol.go
+++ b/protocol.go
@@ -109,6 +109,7 @@ func (p *Protocol) Initialize(ctx context.Context) error {
 			Subtype:                "initialize",
 			Hooks:                  hooks,
 			SDKMCPServers:          sdkMcpServers,
+			MCPServers:             p.options.MCPServers,
 			SystemPrompt:           p.options.SystemPrompt,
 			PlanModeInstructions:   p.options.PlanModeInstructions,
 			ExcludeDynamicSections: excludeDynamicSections,

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -148,6 +148,28 @@ func TestProtocolInitializeOptions(t *testing.T) {
 			unexpected: []string{"toolAliases"},
 		},
 		{
+			name: "mcp server timeout wired through",
+			configure: func(opts *Options) {
+				timeout := 5000
+				WithMCPServers(map[string]MCPServerConfig{
+					"local": {
+						Type:    "stdio",
+						Command: "foo",
+						Timeout: &timeout,
+					},
+				})(opts)
+			},
+			expected: map[string]interface{}{
+				"mcpServers": map[string]interface{}{
+					"local": map[string]interface{}{
+						"type":    "stdio",
+						"command": "foo",
+						"timeout": float64(5000),
+					},
+				},
+			},
+		},
+		{
 			name: "exclude dynamic false omitted",
 			configure: func(opts *Options) {
 				WithExcludeDynamicSystemPromptSections(false)(opts)

--- a/transport.go
+++ b/transport.go
@@ -245,6 +245,9 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		mcpConfig := map[string]interface{}{
 			"type": serverType,
 		}
+		if config.Timeout != nil {
+			mcpConfig["timeout"] = *config.Timeout
+		}
 		switch serverType {
 		case "stdio":
 			mcpConfig["command"] = config.Command

--- a/transport_test.go
+++ b/transport_test.go
@@ -1259,6 +1259,23 @@ func TestSubprocessTransportMCPConfigEncoding(t *testing.T) {
 			},
 		},
 		{
+			name:       "stdio with timeout",
+			serverName: "local",
+			config: MCPServerConfig{
+				Type:    "stdio",
+				Command: "x",
+				Timeout: func() *int {
+					v := 5000
+					return &v
+				}(),
+			},
+			want: map[string]interface{}{
+				"type":    "stdio",
+				"command": "x",
+				"timeout": float64(5000),
+			},
+		},
+		{
 			name:       "stdio implicit type",
 			serverName: "local",
 			config: MCPServerConfig{


### PR DESCRIPTION
## What

Adds `Timeout *int` (milliseconds) on `MCPServerConfig`. Overrides `MCP_TOOL_TIMEOUT` for that one server. Hard wall-clock per call - progress notifications do not extend it. Server-side floor is 1000ms.

## Wire paths

Two places encode `MCPServerConfig`, and both now carry `timeout`:

1. **`--mcp-config`** (`SubprocessTransport.Connect`) - the JSON config blob written to the CLI's `--mcp-config` flag.
2. **Control-init body** (`Protocol.Initialize` -> `SDKControlRequestBody.MCPServers`) - previously missing entirely. Added so the SDK matches the established pattern of duplicating session-shaping options through both the CLI flag and the init body (same shape as `SystemPrompt`, etc.).

`omitempty` semantics: nil timeout is dropped from the wire; explicit `0` is preserved.

## Tests

- `TestMCPServerConfigTimeoutJSON` - JSON round-trip on the struct itself (nil omitted, zero preserved, value round-trips).
- `TestSubprocessTransportMCPConfigEncoding/stdio with timeout` - subprocess `--mcp-config` path.
- `TestProtocolInitializeOptions/mcp server timeout wired through` - control-init body path.

## Followups

`TestIntegrationMCPTimeout` is a `t.Skip()` placeholder. Driving it live needs a slow stdio MCP fixture so the CLI can actually time out a tool call; opening that as separate work.