### PR TITLE
mcp: add per-server alwaysLoad + sdk-mcp instructions

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -609,6 +609,22 @@ func TestIntegrationMCPTimeout(t *testing.T) {
 	t.Skip("not directly triggerable from CLI without slow stdio MCP fixture: in-process SDK MCP servers are registered separately from MCPServerConfig timeout")
 }
 
+func TestIntegrationMCPAlwaysLoad(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// TODO: Backfill when the CLI exposes prompt tool-loading state to SDK tests.
+	t.Skip("not directly assertable from CLI: alwaysLoad affects prompt composition and tool-search gating, not anything observable on the SDK transport")
+}
+
+func TestIntegrationSDKMCPInstructions(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// TODO: Backfill when the CLI exposes consumed MCP instructions to SDK tests.
+	t.Skip("not directly assertable from CLI: MCP server instructions are consumed internally by the CLI for prompt composition")
+}
+
 // TestIntegrationStopHookBlock tests that Stop hooks can block session exit
 // and reinject a new prompt using the Decision/Reason/SystemMessage fields.
 //

--- a/mcp.go
+++ b/mcp.go
@@ -14,9 +14,10 @@ import (
 //
 // Use CreateMcpServer to create a new server and AddTool to register tools.
 type McpServer struct {
-	name    string
-	version string
-	tools   map[string]*toolEntry
+	name         string
+	version      string
+	instructions string
+	tools        map[string]*toolEntry
 }
 
 // toolEntry stores tool metadata and handler.
@@ -59,6 +60,13 @@ type McpServerOptions struct {
 	Name    string          // Server name (required).
 	Version string          // Server version (default: "1.0.0").
 	Tools   []ToolRegistrar // Tools to register (optional).
+
+	// Instructions is an MCP "instructions" block exposed by this server.
+	// When proxying a real MCP server through the SDK transport, pass the
+	// underlying server's getInstructions() here so it isn't dropped on
+	// the way through. Empty string omits the field entirely from the
+	// MCP initialize response.
+	Instructions string
 }
 
 // CreateMcpServer creates a new in-process MCP server.
@@ -80,9 +88,10 @@ func CreateMcpServer(opts McpServerOptions) *McpServer {
 	}
 
 	server := &McpServer{
-		name:    opts.Name,
-		version: version,
-		tools:   make(map[string]*toolEntry),
+		name:         opts.Name,
+		version:      version,
+		instructions: opts.Instructions,
+		tools:        make(map[string]*toolEntry),
 	}
 
 	// Register any tools from options.
@@ -339,6 +348,12 @@ func (s *McpServer) Name() string {
 // Version returns the server version.
 func (s *McpServer) Version() string {
 	return s.version
+}
+
+// Instructions returns the MCP instructions block configured for this server.
+// Empty string means no instructions block is exposed.
+func (s *McpServer) Instructions() string {
+	return s.instructions
 }
 
 // ToolNames returns the names of all registered tools.

--- a/mcp_test.go
+++ b/mcp_test.go
@@ -100,6 +100,59 @@ func TestMCPServerConfigTimeoutJSON(t *testing.T) {
 	})
 }
 
+func TestMCPServerConfigAlwaysLoadJSON(t *testing.T) {
+	ptr := func(v bool) *bool { return &v }
+
+	t.Run("marshal includes alwaysLoad true", func(t *testing.T) {
+		data, err := json.Marshal(MCPServerConfig{
+			Type:       "stdio",
+			Command:    "foo",
+			AlwaysLoad: ptr(true),
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, true, got["alwaysLoad"])
+	})
+
+	t.Run("unmarshal alwaysLoad", func(t *testing.T) {
+		var cfg MCPServerConfig
+		require.NoError(t, json.Unmarshal(
+			[]byte(`{"type":"stdio","command":"foo","alwaysLoad":true}`),
+			&cfg,
+		))
+
+		require.NotNil(t, cfg.AlwaysLoad)
+		assert.True(t, *cfg.AlwaysLoad)
+	})
+
+	t.Run("nil alwaysLoad omitted", func(t *testing.T) {
+		data, err := json.Marshal(MCPServerConfig{
+			Type:    "stdio",
+			Command: "foo",
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "alwaysLoad")
+	})
+
+	t.Run("explicit false alwaysLoad included", func(t *testing.T) {
+		data, err := json.Marshal(MCPServerConfig{
+			Type:       "stdio",
+			Command:    "foo",
+			AlwaysLoad: ptr(false),
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, false, got["alwaysLoad"])
+	})
+}
+
 func TestWithMCPServers(t *testing.T) {
 	servers := map[string]MCPServerConfig{
 		"server1": {
@@ -139,6 +192,18 @@ func TestCreateMcpServerDefaultVersion(t *testing.T) {
 	})
 
 	assert.Equal(t, "1.0.0", server.Version())
+}
+
+func TestCreateMcpServerInstructions(t *testing.T) {
+	server := CreateMcpServer(McpServerOptions{
+		Name:         "test-server",
+		Instructions: "use this server for math",
+	})
+
+	assert.Equal(t, "use this server for math", server.Instructions())
+
+	defaultServer := CreateMcpServer(McpServerOptions{Name: "default"})
+	assert.Empty(t, defaultServer.Instructions())
 }
 
 // AddNumbersArgs is a test type for generics tests.

--- a/options.go
+++ b/options.go
@@ -1955,6 +1955,14 @@ type MCPServerConfig struct {
 	// clock limit per call; progress notifications do not extend it.
 	// Server-side floor: 1000ms.
 	Timeout *int `json:"timeout,omitempty"`
+	// AlwaysLoad, when true, forces every tool from this server to be included
+	// in the prompt instead of deferred behind tool search. Equivalent to
+	// setting defer_loading: false on the API. Default: tools are deferred
+	// when tool search is enabled. Side effect: setting this blocks startup
+	// until the server is connected (capped at the standard 5s connect
+	// timeout), even though MCP startup is otherwise non-blocking; the tools
+	// must be present when the turn-1 prompt is built.
+	AlwaysLoad *bool `json:"alwaysLoad,omitempty"`
 }
 
 // MCPServerToolPolicy configures a per-tool permission policy for remote MCP servers.

--- a/protocol.go
+++ b/protocol.go
@@ -1110,21 +1110,25 @@ func (p *Protocol) handleSDKMCPMessage(ctx context.Context, req SDKControlReques
 	case "initialize":
 		// MCP protocol handshake - respond with server info and capabilities.
 		// Return the full JSONRPC response envelope.
+		result := map[string]interface{}{
+			"protocolVersion": "2025-11-25",
+			"capabilities": map[string]interface{}{
+				"tools": map[string]interface{}{
+					"listChanged": false,
+				},
+			},
+			"serverInfo": map[string]interface{}{
+				"name":    server.Name(),
+				"version": server.Version(),
+			},
+		}
+		if instr := server.Instructions(); instr != "" {
+			result["instructions"] = instr
+		}
 		responseData = map[string]interface{}{
 			"jsonrpc": "2.0",
 			"id":      messageID,
-			"result": map[string]interface{}{
-				"protocolVersion": "2025-11-25",
-				"capabilities": map[string]interface{}{
-					"tools": map[string]interface{}{
-						"listChanged": false,
-					},
-				},
-				"serverInfo": map[string]interface{}{
-					"name":    server.Name(),
-					"version": server.Version(),
-				},
-			},
+			"result":  result,
 		}
 
 	case "notifications/initialized", "notifications/cancelled": //nolint:misspell // MCP protocol uses British spelling

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -170,6 +170,28 @@ func TestProtocolInitializeOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "mcp server alwaysLoad wired through",
+			configure: func(opts *Options) {
+				alwaysLoad := true
+				WithMCPServers(map[string]MCPServerConfig{
+					"local": {
+						Type:       "stdio",
+						Command:    "foo",
+						AlwaysLoad: &alwaysLoad,
+					},
+				})(opts)
+			},
+			expected: map[string]interface{}{
+				"mcpServers": map[string]interface{}{
+					"local": map[string]interface{}{
+						"type":       "stdio",
+						"command":    "foo",
+						"alwaysLoad": true,
+					},
+				},
+			},
+		},
+		{
 			name: "exclude dynamic false omitted",
 			configure: func(opts *Options) {
 				WithExcludeDynamicSystemPromptSections(false)(opts)
@@ -1327,6 +1349,70 @@ func TestProtocolMCPMessage(t *testing.T) {
 // TestProtocolSDKMCPMessage tests in-process MCP tool routing via SDK control format.
 // This tests the actual format the CLI sends (SDKControlRequest, not legacy ControlRequest).
 func TestProtocolSDKMCPMessage(t *testing.T) {
+	t.Run("initialize instructions", func(t *testing.T) {
+		server := CreateMcpServer(McpServerOptions{
+			Name:         "docs",
+			Version:      "2.0.0",
+			Instructions: "use this server for docs",
+		})
+		opts := NewOptions()
+		opts.SDKMcpServers = map[string]*McpServer{
+			"docs": server,
+		}
+		protocol := NewProtocol(nil, opts)
+
+		resp := protocol.handleSDKMCPMessage(context.Background(), SDKControlRequest{
+			Type:      "control_request",
+			RequestID: "sdk_mcp_init",
+			Request: SDKControlRequestBody{
+				Subtype:    "mcp_message",
+				ServerName: "docs",
+				Message: map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      "msg_init",
+					"method":  "initialize",
+				},
+			},
+		})
+
+		require.Equal(t, "success", resp.Response.Subtype)
+		mcpResponse, ok := resp.Response.Response["mcp_response"].(map[string]interface{})
+		require.True(t, ok, "mcp_response should be a map")
+		result, ok := mcpResponse["result"].(map[string]interface{})
+		require.True(t, ok, "result should be a map")
+		assert.Equal(t, "use this server for docs", result["instructions"])
+	})
+
+	t.Run("initialize omits empty instructions", func(t *testing.T) {
+		server := CreateMcpServer(McpServerOptions{Name: "docs"})
+		opts := NewOptions()
+		opts.SDKMcpServers = map[string]*McpServer{
+			"docs": server,
+		}
+		protocol := NewProtocol(nil, opts)
+
+		resp := protocol.handleSDKMCPMessage(context.Background(), SDKControlRequest{
+			Type:      "control_request",
+			RequestID: "sdk_mcp_init",
+			Request: SDKControlRequestBody{
+				Subtype:    "mcp_message",
+				ServerName: "docs",
+				Message: map[string]interface{}{
+					"jsonrpc": "2.0",
+					"id":      "msg_init",
+					"method":  "initialize",
+				},
+			},
+		})
+
+		require.Equal(t, "success", resp.Response.Subtype)
+		mcpResponse, ok := resp.Response.Response["mcp_response"].(map[string]interface{})
+		require.True(t, ok, "mcp_response should be a map")
+		result, ok := mcpResponse["result"].(map[string]interface{})
+		require.True(t, ok, "result should be a map")
+		assert.NotContains(t, result, "instructions")
+	})
+
 	t.Run("tools/call via SDK format", func(t *testing.T) {
 		runner := NewMockSubprocessRunner()
 		opts := NewOptions()

--- a/transport.go
+++ b/transport.go
@@ -248,6 +248,9 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		if config.Timeout != nil {
 			mcpConfig["timeout"] = *config.Timeout
 		}
+		if config.AlwaysLoad != nil {
+			mcpConfig["alwaysLoad"] = *config.AlwaysLoad
+		}
 		switch serverType {
 		case "stdio":
 			mcpConfig["command"] = config.Command

--- a/transport_test.go
+++ b/transport_test.go
@@ -1276,6 +1276,23 @@ func TestSubprocessTransportMCPConfigEncoding(t *testing.T) {
 			},
 		},
 		{
+			name:       "stdio with alwaysLoad",
+			serverName: "local",
+			config: MCPServerConfig{
+				Type:    "stdio",
+				Command: "x",
+				AlwaysLoad: func() *bool {
+					v := true
+					return &v
+				}(),
+			},
+			want: map[string]interface{}{
+				"type":       "stdio",
+				"command":    "x",
+				"alwaysLoad": true,
+			},
+		},
+		{
 			name:       "stdio implicit type",
 			serverName: "local",
 			config: MCPServerConfig{


### PR DESCRIPTION
In this PR, we wire up two related MCP-startup-time knobs from TS SDK
v0.3.150 (Phase B, PR-07 in the catchup plan). Both fields ship together
because they're MCP-startup-time concerns that touch the same control-init
body shape, and the brief at `memory/catchup-v0.3.150/pr-07-mcp-always-load/BRIEF.md`
intentionally bundles them.

## `MCPServerConfig.AlwaysLoad`

A new `*bool` field on `MCPServerConfig` (`options.go`) that mirrors TS SDK
`McpStdioServerConfig.alwaysLoad`, `McpHttpServerConfig.alwaysLoad`,
`McpSSEServerConfig.alwaysLoad`, and `McpClaudeAIProxyServerConfig.alwaysLoad`.
When true, every tool from this server is included in the prompt instead of
deferred behind tool search, equivalent to setting `defer_loading: false` on
the API. Side effect: setting it blocks startup until the server is connected
(capped at the standard 5s connect timeout) even though MCP startup is
otherwise non-blocking, since the tools must be present when the turn-1 prompt
is built.

`*bool` (not `bool`) so we can distinguish unset (default-defer) from explicit
`false` (reaffirming the default). Same rationale as `Timeout *int` from PR-06.
`omitempty` keeps the existing JSON shape unchanged for configs that don't set
it.

In `transport.go`, we encode `alwaysLoad` into the `--mcp-config` payload
alongside `timeout`, before the type-specific fields, so it applies uniformly
across stdio/http/sse/socket. Same flat-collapse pattern PR-06 used.

## `McpServerOptions.Instructions`

A new `string` field on `McpServerOptions` (`mcp.go`) that mirrors TS SDK
`SdkMcpServerConfig.instructions`. Used when proxying a real MCP server
through the SDK transport so the underlying server's `getInstructions()`
block isn't dropped on the way through.

`CreateMcpServer` stashes it on a new `McpServer.instructions` private field;
we expose it via a new `Instructions()` getter. In `protocol.go`'s
`handleSDKMCPMessage` initialize case, we extract the `result` map out of the
JSONRPC envelope and conditionally set `result["instructions"]` when the
server's instructions string is non-empty. Empty string keeps the existing
JSON shape for the common no-instructions case.

## Tests

- `mcp_test.go`: round-trip JSON marshaling for `MCPServerConfig.AlwaysLoad`
  (true, false, nil-omitted) and unmarshaling.
- `protocol_test.go`: control-init body wires `alwaysLoad` through the
  `McpServerConfigs()` snapshot; SDK-MCP `initialize` response includes
  `instructions` when set and omits it when empty.
- `transport_test.go`: `--mcp-config` encoding for stdio config with
  `alwaysLoad: true`.
- `integration_test.go`: `TestIntegrationMCPAlwaysLoad` and
  `TestIntegrationMCPSDKServerInstructions` are placeholders with explicit
  `t.Skip` reasons (the CLI shape these affect isn't directly assertable from
  the SDK transport, similar to existing patterns in this file).

Out of scope: per-tool `alwaysLoad` (TS `tool({ alwaysLoad })` at
`sdk.d.ts` L5721). Brief defers it to a follow-up if needed.