### PR TITLE
settings: add hook command `args` (exec form)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -625,6 +625,14 @@ func TestIntegrationSDKMCPInstructions(t *testing.T) {
 	t.Skip("not directly assertable from CLI: MCP server instructions are consumed internally by the CLI for prompt composition")
 }
 
+func TestIntegrationHookCommandArgs(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// TODO: Backfill if the CLI exposes hook subprocess spawn details to SDK tests.
+	t.Skip("not directly assertable from CLI: hook args is a settings shape consumed by the CLI's hook spawn path, not observable on the SDK transport")
+}
+
 // TestIntegrationStopHookBlock tests that Stop hooks can block session exit
 // and reinject a new prompt using the Decision/Reason/SystemMessage fields.
 //

--- a/options.go
+++ b/options.go
@@ -426,8 +426,15 @@ type SettingsHookMatcher struct {
 }
 
 type SettingsHook struct {
-	Type           string                 `json:"type"`
-	Command        string                 `json:"command,omitempty"`
+	Type    string `json:"type"`
+	Command string `json:"command,omitempty"`
+	// Args is an argument list for hook exec form. When present, Command is
+	// resolved as an executable and spawned directly with these arguments --
+	// no shell. Path placeholders like ${CLAUDE_PLUGIN_ROOT} are substituted
+	// per-element as plain strings, so paths with quotes, $, or backticks
+	// never reach a shell parser. When absent, Command runs through a shell
+	// (bash on POSIX, PowerShell on Windows without Git Bash).
+	Args           []string               `json:"args,omitempty"`
 	Prompt         string                 `json:"prompt,omitempty"`
 	URL            string                 `json:"url,omitempty"`
 	Server         string                 `json:"server,omitempty"`
@@ -443,6 +450,26 @@ type SettingsHook struct {
 	AsyncRewake    *bool                  `json:"asyncRewake,omitempty"`
 	Headers        map[string]string      `json:"headers,omitempty"`
 	AllowedEnvVars []string               `json:"allowedEnvVars,omitempty"`
+}
+
+func (h SettingsHook) MarshalJSON() ([]byte, error) {
+	type alias SettingsHook
+
+	data, err := json.Marshal(alias(h))
+	if err != nil {
+		return nil, err
+	}
+	if h.Args == nil {
+		return data, nil
+	}
+
+	var fields map[string]interface{}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return nil, err
+	}
+	fields["args"] = h.Args
+
+	return json.Marshal(fields)
 }
 
 type SettingsWorktree struct {

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,60 @@
+package claudeagent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingsHookArgsJSON(t *testing.T) {
+	t.Run("marshal includes args", func(t *testing.T) {
+		data, err := json.Marshal(SettingsHook{
+			Type:    "command",
+			Command: "foo",
+			Args:    []string{"--flag", "value"},
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, []interface{}{"--flag", "value"}, got["args"])
+	})
+
+	t.Run("nil args omitted", func(t *testing.T) {
+		data, err := json.Marshal(SettingsHook{
+			Type:    "command",
+			Command: "foo",
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "args")
+	})
+
+	t.Run("unmarshal args", func(t *testing.T) {
+		var cfg SettingsHook
+		require.NoError(t, json.Unmarshal(
+			[]byte(`{"type":"command","command":"foo","args":["--flag","value"]}`),
+			&cfg,
+		))
+
+		assert.Equal(t, []string{"--flag", "value"}, cfg.Args)
+	})
+
+	t.Run("empty args included", func(t *testing.T) {
+		data, err := json.Marshal(SettingsHook{
+			Type:    "command",
+			Command: "foo",
+			// Non-nil empty args intentionally forces exec form with no args.
+			Args: []string{},
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, []interface{}{}, got["args"])
+	})
+}


### PR DESCRIPTION
TS SDK v0.3.150 added `args?: string[]` to the `'command'`-type hook
shape in settings. When present, the CLI resolves `command` as an
executable and spawns it directly with these arguments -- no shell.
Path placeholders like `${CLAUDE_PLUGIN_ROOT}` are substituted per-element
as plain strings, so paths with quotes, `$`, or backticks never reach
a shell parser. When absent, `command` runs through a shell (bash on
POSIX, PowerShell on Windows without Git Bash).

The Go side is pure shape passthrough -- the CLI consumes `args` to
pick between exec-form and shell-form spawn; the SDK just round-trips
the field. Adds one `Args []string` field on `SettingsHook` with
`omitempty` to keep the existing JSON shape unchanged for hooks that
don't set it.

A custom `MarshalJSON` preserves an intentional non-nil empty slice as
`"args":[]` (force-exec-form-no-args), since stdlib `omitempty` would
otherwise collapse it with nil.

Part of the v0.3.150 catchup (PR 8 of 34).

See `memory/catchup-v0.3.150/PLAN.md` §"PR 08".