### PR TITLE
settings: add hook `continueOnBlock` field

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -633,6 +633,14 @@ func TestIntegrationHookCommandArgs(t *testing.T) {
 	t.Skip("not directly assertable from CLI: hook args is a settings shape consumed by the CLI's hook spawn path, not observable on the SDK transport")
 }
 
+func TestIntegrationHookContinueOnBlock(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// TODO: Backfill if the CLI exposes hook turn-continuation decisions to SDK tests.
+	t.Skip("not directly assertable from CLI: continueOnBlock affects the CLI's turn-continuation decision after a blocking hook, not anything observable on the SDK transport")
+}
+
 // TestIntegrationStopHookBlock tests that Stop hooks can block session exit
 // and reinject a new prompt using the Decision/Reason/SystemMessage fields.
 //

--- a/options.go
+++ b/options.go
@@ -434,22 +434,28 @@ type SettingsHook struct {
 	// per-element as plain strings, so paths with quotes, $, or backticks
 	// never reach a shell parser. When absent, Command runs through a shell
 	// (bash on POSIX, PowerShell on Windows without Git Bash).
-	Args           []string               `json:"args,omitempty"`
-	Prompt         string                 `json:"prompt,omitempty"`
-	URL            string                 `json:"url,omitempty"`
-	Server         string                 `json:"server,omitempty"`
-	Tool           string                 `json:"tool,omitempty"`
-	Input          map[string]interface{} `json:"input,omitempty"`
-	If             string                 `json:"if,omitempty"`
-	Shell          string                 `json:"shell,omitempty"`
-	Timeout        *int                   `json:"timeout,omitempty"`
-	Model          string                 `json:"model,omitempty"`
-	StatusMessage  string                 `json:"statusMessage,omitempty"`
-	Once           *bool                  `json:"once,omitempty"`
-	Async          *bool                  `json:"async,omitempty"`
-	AsyncRewake    *bool                  `json:"asyncRewake,omitempty"`
-	Headers        map[string]string      `json:"headers,omitempty"`
-	AllowedEnvVars []string               `json:"allowedEnvVars,omitempty"`
+	Args    []string               `json:"args,omitempty"`
+	Prompt  string                 `json:"prompt,omitempty"`
+	URL     string                 `json:"url,omitempty"`
+	Server  string                 `json:"server,omitempty"`
+	Tool    string                 `json:"tool,omitempty"`
+	Input   map[string]interface{} `json:"input,omitempty"`
+	If      string                 `json:"if,omitempty"`
+	Shell   string                 `json:"shell,omitempty"`
+	Timeout *int                   `json:"timeout,omitempty"`
+	Model   string                 `json:"model,omitempty"`
+	// ContinueOnBlock sets the continue value for the decision:"block" produced
+	// when the hook returns ok=false. Default false (turn ends). Whether
+	// continue=true lets the turn proceed depends on the event's decision:"block"
+	// semantics: on PostToolUse, the reason is fed back to Claude and the turn
+	// continues.
+	ContinueOnBlock *bool             `json:"continueOnBlock,omitempty"`
+	StatusMessage   string            `json:"statusMessage,omitempty"`
+	Once            *bool             `json:"once,omitempty"`
+	Async           *bool             `json:"async,omitempty"`
+	AsyncRewake     *bool             `json:"asyncRewake,omitempty"`
+	Headers         map[string]string `json:"headers,omitempty"`
+	AllowedEnvVars  []string          `json:"allowedEnvVars,omitempty"`
 }
 
 func (h SettingsHook) MarshalJSON() ([]byte, error) {

--- a/options_test.go
+++ b/options_test.go
@@ -58,3 +58,56 @@ func TestSettingsHookArgsJSON(t *testing.T) {
 		assert.Equal(t, []interface{}{}, got["args"])
 	})
 }
+
+func TestSettingsHookContinueOnBlockJSON(t *testing.T) {
+	t.Run("marshal includes true", func(t *testing.T) {
+		continueOnBlock := true
+		data, err := json.Marshal(SettingsHook{
+			Type:            "prompt",
+			Prompt:          "verify",
+			ContinueOnBlock: &continueOnBlock,
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, true, got["continueOnBlock"])
+	})
+
+	t.Run("nil omitted", func(t *testing.T) {
+		data, err := json.Marshal(SettingsHook{
+			Type:   "prompt",
+			Prompt: "verify",
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "continueOnBlock")
+	})
+
+	t.Run("marshal includes false", func(t *testing.T) {
+		continueOnBlock := false
+		data, err := json.Marshal(SettingsHook{
+			Type:            "prompt",
+			Prompt:          "verify",
+			ContinueOnBlock: &continueOnBlock,
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, false, got["continueOnBlock"])
+	})
+
+	t.Run("unmarshal", func(t *testing.T) {
+		var cfg SettingsHook
+		require.NoError(t, json.Unmarshal(
+			[]byte(`{"type":"prompt","prompt":"verify","continueOnBlock":true}`),
+			&cfg,
+		))
+
+		require.NotNil(t, cfg.ContinueOnBlock)
+		assert.True(t, *cfg.ContinueOnBlock)
+	})
+}


### PR DESCRIPTION
TS SDK v0.3.150 added `continueOnBlock?: boolean` to the `'prompt'`-type
hook shape in settings. It sets the continue value for the
decision:"block" produced when the hook returns ok=false. Default
false (turn ends). Whether continue=true lets the turn proceed depends
on the event's decision:"block" semantics: on PostToolUse, the reason
is fed back to Claude and the turn continues.

The Go-side `SettingsHook` struct is a flat union over all hook
subtypes (command / prompt / agent / etc.), so the new field lives
there. Pure shape passthrough -- the CLI consumes it; the SDK just
round-trips the JSON.

Modeled as `*bool` (not `bool`) so a settings author can explicitly
set `false` to override an organization-default policy that set
`true` -- matches the precedent of `Once`, `Async`, `AsyncRewake`, and
`MCPServerConfig.AlwaysLoad` in the same package.

Part of the v0.3.150 catchup (PR 9 of 34).

See `memory/catchup-v0.3.150/PLAN.md` §"PR 09".