### PR TITLE
messages: add `permission_denied` system subtype

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -237,6 +237,81 @@ func TestIntegrationPermissionCallback(t *testing.T) {
 	}
 }
 
+func TestIntegrationPermissionDeniedMessage(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	mcpServerPath := filepath.Join(t.TempDir(), "example-mcp-server")
+	buildCmd := exec.Command("go", "build", "-o", mcpServerPath, "./cmd/example-mcp-server")
+	buildCmd.Dir = "."
+	out, err := buildCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to build MCP server: %v\n%s", err, out)
+	}
+
+	permissionCalled := false
+	canUseTool := func(ctx context.Context,
+		req ToolPermissionRequest) PermissionResult {
+
+		permissionCalled = true
+		t.Logf("Permission requested for tool: %s", req.ToolName)
+		return PermissionDeny{Reason: "integration test denied tool use"}
+	}
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt(
+			"You are a helpful assistant. When asked to add numbers, "+
+				"you MUST use the add_numbers tool. Do not calculate manually.",
+		),
+		WithMCPServers(map[string]MCPServerConfig{
+			"example": {
+				Type:    "stdio",
+				Command: mcpServerPath,
+			},
+		}),
+		WithStrictMCPConfig(true),
+		WithPermissionMode(PermissionModeDefault),
+		WithCanUseTool(canUseTool),
+		WithMaxTurns(5),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	var deniedMessages []PermissionDeniedMessage
+	for msg := range client.Query(ctx, "Use the add_numbers tool to add 7 and 5.") {
+		switch m := msg.(type) {
+		case PermissionDeniedMessage:
+			deniedMessages = append(deniedMessages, m)
+		case AssistantMessage:
+			t.Logf("Response: %s", m.ContentText())
+		case ResultMessage:
+			t.Logf("Result: status=%s, cost=$%.4f", m.Status, m.TotalCostUSD)
+		}
+	}
+
+	require.True(t, permissionCalled, "expected permission callback to be called")
+	if len(deniedMessages) == 0 {
+		t.Skip("permission_denied emission depends on CLI build supporting v0.3.150 SDKPermissionDeniedMessage")
+	}
+
+	var found bool
+	for _, msg := range deniedMessages {
+		if msg.ToolName != "add_numbers" {
+			continue
+		}
+		found = true
+		assert.NotEmpty(t, msg.ToolUseID)
+		assert.NotEmpty(t, msg.Message)
+		assert.NotEmpty(t, msg.UUID)
+		assert.NotEmpty(t, msg.SessionID)
+	}
+	assert.True(t, found, "expected permission_denied message for add_numbers")
+}
+
 // TestIntegrationHooks tests hook callback invocation.
 func TestIntegrationHooks(t *testing.T) {
 	skipIfNoToken(t)

--- a/messages.go
+++ b/messages.go
@@ -908,6 +908,26 @@ type NotificationMessage struct {
 // MessageType implements Message.
 func (m NotificationMessage) MessageType() string { return "system" }
 
+// PermissionDeniedMessage reports a tool call denied by the permission
+// machinery. The SDK emits it for every denial path (mode, rule,
+// classifier, async-agent) so consumers can observe denials without
+// parsing the rejection text out of the assistant turn.
+type PermissionDeniedMessage struct {
+	Type               string `json:"type"`                           // Always "system"
+	Subtype            string `json:"subtype"`                        // "permission_denied"
+	ToolName           string `json:"tool_name"`                      // Denied tool name
+	ToolUseID          string `json:"tool_use_id"`                    // Denied tool_use_id
+	AgentID            string `json:"agent_id,omitempty"`             // Subagent ID when denial originated in a subagent
+	DecisionReasonType string `json:"decision_reason_type,omitempty"` // Discriminator from PermissionDecisionReason (e.g. "classifier", "asyncAgent", "mode", "rule")
+	DecisionReason     string `json:"decision_reason,omitempty"`      // Human-readable reason from the deciding component
+	Message            string `json:"message"`                        // Rejection message returned to the model in tool_result
+	UUID               string `json:"uuid"`                           // Unique message ID
+	SessionID          string `json:"session_id"`                     // Session identifier
+}
+
+// MessageType implements Message.
+func (m PermissionDeniedMessage) MessageType() string { return "system" }
+
 // PluginInstallStatus is the plugin installation progress state.
 type PluginInstallStatus string
 
@@ -1125,6 +1145,10 @@ func ParseMessage(data []byte) (Message, error) {
 			return msg, err
 		case "notification":
 			var msg NotificationMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "permission_denied":
+			var msg PermissionDeniedMessage
 			err := json.Unmarshal(data, &msg)
 			return msg, err
 		case "plugin_install":

--- a/messages_test.go
+++ b/messages_test.go
@@ -1956,6 +1956,86 @@ func TestParseMessageMirrorError(t *testing.T) {
 	}
 }
 
+func TestParseMessagePermissionDenied(t *testing.T) {
+	t.Run("all optional fields present", func(t *testing.T) {
+		input := `{
+			"type": "system",
+			"subtype": "permission_denied",
+			"tool_name": "Bash",
+			"tool_use_id": "toolu_01abc",
+			"agent_id": "agent_123",
+			"decision_reason_type": "classifier",
+			"decision_reason": "Command accesses a protected path",
+			"message": "Permission denied",
+			"uuid": "550e8400-e29b-41d4-a716-446655440252",
+			"session_id": "sess_misc_007"
+		}`
+
+		msg, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+
+		deniedMsg, ok := msg.(PermissionDeniedMessage)
+		require.True(t, ok, "expected PermissionDeniedMessage")
+
+		assert.Equal(t, "system", deniedMsg.MessageType())
+		assert.Equal(t, "permission_denied", deniedMsg.Subtype)
+		assert.Equal(t, "Bash", deniedMsg.ToolName)
+		assert.Equal(t, "toolu_01abc", deniedMsg.ToolUseID)
+		assert.Equal(t, "agent_123", deniedMsg.AgentID)
+		assert.Equal(t, "classifier", deniedMsg.DecisionReasonType)
+		assert.Equal(t, "Command accesses a protected path", deniedMsg.DecisionReason)
+		assert.Equal(t, "Permission denied", deniedMsg.Message)
+	})
+
+	t.Run("optionals omitted for top-level call", func(t *testing.T) {
+		input := `{
+			"type": "system",
+			"subtype": "permission_denied",
+			"tool_name": "Read",
+			"tool_use_id": "toolu_02def",
+			"message": "Tool use denied",
+			"uuid": "550e8400-e29b-41d4-a716-446655440253",
+			"session_id": "sess_misc_008"
+		}`
+
+		msg, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+
+		deniedMsg, ok := msg.(PermissionDeniedMessage)
+		require.True(t, ok, "expected PermissionDeniedMessage")
+
+		assert.Equal(t, "system", deniedMsg.MessageType())
+		assert.Equal(t, "permission_denied", deniedMsg.Subtype)
+		assert.Equal(t, "Read", deniedMsg.ToolName)
+		assert.Equal(t, "toolu_02def", deniedMsg.ToolUseID)
+		assert.Empty(t, deniedMsg.AgentID)
+		assert.Empty(t, deniedMsg.DecisionReasonType)
+		assert.Empty(t, deniedMsg.DecisionReason)
+		assert.Equal(t, "Tool use denied", deniedMsg.Message)
+		assert.Equal(t, "550e8400-e29b-41d4-a716-446655440253", deniedMsg.UUID)
+		assert.Equal(t, "sess_misc_008", deniedMsg.SessionID)
+	})
+
+	t.Run("marshal back omits absent optionals", func(t *testing.T) {
+		msg := PermissionDeniedMessage{
+			Type:      "system",
+			Subtype:   "permission_denied",
+			ToolName:  "Bash",
+			ToolUseID: "toolu_03ghi",
+			Message:   "Permission denied",
+			UUID:      "550e8400-e29b-41d4-a716-446655440254",
+			SessionID: "sess_misc_009",
+		}
+
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		assert.NotContains(t, string(data), `"agent_id"`)
+		assert.NotContains(t, string(data), `"decision_reason_type"`)
+		assert.NotContains(t, string(data), `"decision_reason"`)
+	})
+}
+
 func TestParseMessageNotification(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
TS SDK v0.3.150 added `SDKPermissionDeniedMessage`, a new `system`
subtype the CLI emits whenever a tool call is denied via the permission
machinery (mode, rule, classifier, async-agent). Consumers can now
observe denials off the message channel without parsing the rejection
text out of the assistant turn.

Adds `PermissionDeniedMessage` mirroring the TS shape and wires it into
the `ParseMessage` system-subtype switch in alphabetical position
(between `notification` and `plugin_install`).

Three TS-side optional string fields (`agent_id`, `decision_reason_type`,
`decision_reason`) are modeled as `string` + `omitempty`, matching the
existing pattern for unambiguous-absent-when-empty optionals in this
file (`PluginInstallMessage.Name`, `NotificationMessage.Color`). The
required `message` field has no `omitempty`.

Part of the v0.3.150 catchup (PR 11 of 34).

See memory/catchup-v0.3.150/PLAN.md §"PR 11".