### PR TITLE
stream: add BackgroundTasks runtime control

### DIFF
--- a/client.go
+++ b/client.go
@@ -908,6 +908,37 @@ func (s *Stream) StopTask(ctx context.Context, taskID string) error {
 	return err
 }
 
+// BackgroundTasks backgrounds in-flight foreground tasks (Bash commands and
+// subagents). When toolUseID is non-empty, only the task started by that
+// tool_use block is backgrounded; when empty, all foreground tasks are
+// backgrounded, equivalent to pressing Ctrl+B in the terminal.
+//
+// Each blocking tool call returns immediately with a "running in the
+// background" tool_result and the turn continues; the task keeps running
+// and emits a task_notification when it settles.
+//
+// Returns true when at least one task was backgrounded; returns false only
+// when toolUseID was non-empty and matched no foreground task.
+func (s *Stream) BackgroundTasks(
+	ctx context.Context, toolUseID string,
+) (bool, error) {
+	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype:   "background_tasks",
+		ToolUseID: toolUseID,
+	})
+	if err != nil {
+		return false, err
+	}
+
+	backgrounded := true
+	if v, ok := resp.Response.Response["backgrounded"]; ok {
+		if b, ok := v.(bool); ok {
+			backgrounded = b
+		}
+	}
+	return backgrounded, nil
+}
+
 // sendSDKControlRequest sends an SDK-format control request and waits for the
 // matching response.
 func (s *Stream) sendSDKControlRequest(

--- a/client_file_plugin_control_test.go
+++ b/client_file_plugin_control_test.go
@@ -335,3 +335,70 @@ func TestStreamStopTaskWireShape(t *testing.T) {
 		rawWrittenSDKControlRequest(t, transport),
 	)
 }
+
+func TestStreamBackgroundTasksWireShape(t *testing.T) {
+	t.Run("with tool_use_id", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(
+			successSDKControlResponseWithPayload(map[string]interface{}{
+				"backgrounded": true,
+			}),
+		)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		ok, err := stream.BackgroundTasks(ctx, "tool_use_42")
+		require.NoError(t, err)
+		assert.True(t, ok)
+
+		assert.JSONEq(t,
+			`{"type":"control_request","request_id":"req_1",`+
+				`"request":{"subtype":"background_tasks",`+
+				`"tool_use_id":"tool_use_42"}}`,
+			rawWrittenSDKControlRequest(t, transport),
+		)
+	})
+
+	t.Run("without tool_use_id", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(
+			successSDKControlResponseWithPayload(map[string]interface{}{
+				"backgrounded": true,
+			}),
+		)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		ok, err := stream.BackgroundTasks(ctx, "")
+		require.NoError(t, err)
+		assert.True(t, ok)
+
+		assert.JSONEq(t,
+			`{"type":"control_request","request_id":"req_1",`+
+				`"request":{"subtype":"background_tasks"}}`,
+			rawWrittenSDKControlRequest(t, transport),
+		)
+	})
+
+	t.Run("no match returns false", func(t *testing.T) {
+		stream, _, _ := newStreamControlTest(
+			successSDKControlResponseWithPayload(map[string]interface{}{
+				"backgrounded": false,
+			}),
+		)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		ok, err := stream.BackgroundTasks(ctx, "tool_use_does_not_exist")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("absent backgrounded key defaults to true", func(t *testing.T) {
+		stream, _, _ := newStreamControlTest(successSDKControlResponse)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		ok, err := stream.BackgroundTasks(ctx, "")
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1657,6 +1657,98 @@ func TestIntegrationStreamFileAndRuntime(t *testing.T) {
 	})
 }
 
+func TestIntegrationBackgroundTasks(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	tempDir := t.TempDir()
+	opts := append(isolatedClientOptions(t),
+		WithCwd(tempDir),
+		WithSystemPrompt(
+			"You are a helpful assistant. When asked to run a shell command, "+
+				"use Bash immediately and do not describe it first.",
+		),
+		WithPermissionMode(PermissionModeBypassAll),
+		WithAllowDangerouslySkipPermissions(true),
+		WithMaxTurns(3),
+		WithStderr(func(data string) {
+			t.Logf("CLI stderr: %s", data)
+		}),
+	)
+
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	stream, err := client.Stream(ctx)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	require.NoError(t, stream.Send(ctx,
+		"Run this exact Bash command and wait for it: sleep 30",
+	))
+
+	var (
+		backgrounded   bool
+		backgroundErr  error
+		backgroundSent bool
+		gotToolUse     bool
+		toolUseID      string
+		gotResult      bool
+		gotInProgress  bool
+	)
+
+	for msg := range stream.Messages() {
+		switch m := msg.(type) {
+		case AssistantMessage:
+			for _, block := range m.Message.Content {
+				if block.Type != "tool_use" {
+					continue
+				}
+				gotToolUse = true
+				toolUseID = block.ID
+				t.Logf("Tool use: name=%s id=%s", block.Name, block.ID)
+				if !backgroundSent {
+					backgroundSent = true
+					backgrounded, backgroundErr = stream.BackgroundTasks(ctx, "")
+					if backgroundErr != nil {
+						if strings.Contains(backgroundErr.Error(), "background_tasks") {
+							t.Skip("background_tasks control subtype depends on CLI build supporting v0.3.150")
+						}
+						require.NoError(t, backgroundErr)
+					}
+					assert.True(t, backgrounded)
+				}
+			}
+		case UserMessage:
+			if m.ParentToolUseID != nil && strings.Contains(
+				strings.ToLower(fmt.Sprint(m.ToolUseResult)),
+				"background",
+			) {
+				gotInProgress = true
+			}
+		case ResultMessage:
+			gotResult = true
+			t.Logf("Result: subtype=%s status=%s", m.Subtype, m.Status)
+			return
+		case TaskNotificationMessage:
+			t.Logf("Task notification: task_id=%s tool_use_id=%s status=%s",
+				m.TaskID, m.ToolUseID, m.Status)
+		}
+	}
+
+	require.True(t, gotToolUse, "expected a Bash tool_use")
+	require.NotEmpty(t, toolUseID, "expected tool_use id")
+	require.True(t, backgroundSent, "expected BackgroundTasks call")
+	require.NoError(t, backgroundErr)
+	assert.True(t, backgrounded)
+	assert.True(t, gotInProgress, "expected background tool_result")
+	assert.True(t, gotResult, "expected final result")
+}
+
 // TestIntegrationSettingsOptions is a slot for the PR 22 settings option
 // surface. The transport unit tests assert exact --settings and
 // --managed-settings argv emission; a live assertion needs a CLI-supported

--- a/integration_test.go
+++ b/integration_test.go
@@ -1734,7 +1734,6 @@ func TestIntegrationBackgroundTasks(t *testing.T) {
 		case ResultMessage:
 			gotResult = true
 			t.Logf("Result: subtype=%s status=%s", m.Subtype, m.Status)
-			return
 		case TaskNotificationMessage:
 			t.Logf("Task notification: task_id=%s tool_use_id=%s status=%s",
 				m.TaskID, m.ToolUseID, m.Status)

--- a/integration_test.go
+++ b/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 

--- a/messages.go
+++ b/messages.go
@@ -254,7 +254,7 @@ type SDKControlRequestBody struct {
 	ToolAliases            map[string]string                   `json:"toolAliases,omitempty"`            // For initialize
 	ToolName               string                              `json:"tool_name,omitempty"`              // For can_use_tool/hook_callback
 	Input                  map[string]interface{}              `json:"input,omitempty"`                  // For can_use_tool/hook_callback
-	ToolUseID              string                              `json:"tool_use_id,omitempty"`            // For can_use_tool/hooks
+	ToolUseID              string                              `json:"tool_use_id,omitempty"`            // For can_use_tool/hooks/background_tasks
 	AgentID                string                              `json:"agent_id,omitempty"`               // For can_use_tool
 	CallbackID             string                              `json:"callback_id,omitempty"`            // For hook_callback
 	Mode                   string                              `json:"mode,omitempty"`                   // For set_permission_mode


### PR DESCRIPTION
In this PR, we add the `BackgroundTasks` control method on `Stream`, which backgrounds in-flight foreground tool calls (Bash commands and subagents). When `toolUseID` is non-empty, only the task started by that `tool_use` block is backgrounded; passing an empty string backgrounds all foreground tasks, equivalent to pressing Ctrl+B in the terminal. Each blocking tool call returns immediately with a "running in the background" `tool_result` and the turn continues, with the task emitting a `task_notification` once it eventually settles.

This is part of the v0.2.119 SDK catchup tracking PR 12 in the upstream TS sequence. The method maps to the `background_tasks` SDK control subtype landing in CLI v0.3.150.

## Method shape

```go
func (s *Stream) BackgroundTasks(ctx context.Context, toolUseID string) (bool, error)
```

We default the `backgrounded` response field to `true` when absent, mirroring the TS SDK's `?? true` fallback, and return `false` only when a specific `toolUseID` matched no foreground task. The existing `tool_use_id` field on `SDKControlRequestBody` is reused for the request payload; its inline comment picks up the new subtype.

## Tests

Unit coverage in `client_file_plugin_control_test.go` exercises four cases against the wire shape: with `tool_use_id`, without `tool_use_id`, an explicit `backgrounded: false` no-match response, and the absent-key default-true fallback.

```
=== RUN   TestStreamBackgroundTasksWireShape
--- PASS: TestStreamBackgroundTasksWireShape (0.00s)
    --- PASS: with_tool_use_id (0.00s)
    --- PASS: without_tool_use_id (0.00s)
    --- PASS: no_match_returns_false (0.00s)
    --- PASS: absent_backgrounded_key_defaults_to_true (0.00s)
```

A live integration test in `integration_test.go` sends a `Bash sleep` request, calls `BackgroundTasks("")` once a `tool_use` arrives, and asserts the turn completes with a backgrounded `tool_result`. It skips cleanly when the installed CLI rejects the `background_tasks` subtype, so the test slot is in place ahead of v0.3.150 rollout.