### PR TITLE
hooks: add BackgroundTaskSummary + background_tasks field on Stop/SubagentStop

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -1,0 +1,3 @@
+# Integration Followups
+
+- Backfill `TestIntegrationStopHookBackgroundTasks` when the CLI test fixture can deterministically create a long-running background task.

--- a/integration_test.go
+++ b/integration_test.go
@@ -717,6 +717,14 @@ func TestIntegrationHookContinueOnBlock(t *testing.T) {
 	t.Skip("not directly assertable from CLI: continueOnBlock affects the CLI's turn-continuation decision after a blocking hook, not anything observable on the SDK transport")
 }
 
+func TestIntegrationStopHookBackgroundTasks(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// TODO: Backfill when a deterministic long-running background task fixture is available.
+	t.Skip("not triggerable from CLI without a long-running background task; tracked in INTEGRATION-FOLLOWUPS.md")
+}
+
 func TestIntegrationBaseHookInputEffort(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/options.go
+++ b/options.go
@@ -1339,11 +1339,26 @@ func (UserPromptSubmitInput) HookType() HookType { return HookTypeUserPromptSubm
 // Base implements HookInput.
 func (i UserPromptSubmitInput) Base() BaseHookInput { return i.BaseHookInput }
 
+// BackgroundTaskSummary is a snapshot of an in-flight background task
+// registered in the session.
+type BackgroundTaskSummary struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	Status      string `json:"status"`
+	Description string `json:"description"`
+	Command     string `json:"command,omitempty"`
+	AgentType   string `json:"agent_type,omitempty"`
+	Server      string `json:"server,omitempty"`
+	Tool        string `json:"tool,omitempty"`
+	Name        string `json:"name,omitempty"`
+}
+
 // StopInput contains data for Stop hooks.
 type StopInput struct {
 	BaseHookInput
-	StopHookActive       bool   `json:"stop_hook_active"`
-	LastAssistantMessage string `json:"last_assistant_message,omitempty"`
+	StopHookActive       bool                    `json:"stop_hook_active"`
+	LastAssistantMessage string                  `json:"last_assistant_message,omitempty"`
+	BackgroundTasks      []BackgroundTaskSummary `json:"background_tasks,omitempty"`
 }
 
 // HookType implements HookInput.
@@ -1358,12 +1373,13 @@ func (i StopInput) Base() BaseHookInput { return i.BaseHookInput }
 // base hook fields) — read them via i.Base() or i.BaseHookInput.AgentID.
 type SubagentStopInput struct {
 	BaseHookInput
-	AgentName            string `json:"agent_name"`
-	Status               string `json:"status"`
-	Result               string `json:"result"`
-	StopHookActive       bool   `json:"stop_hook_active"`
-	AgentTranscriptPath  string `json:"agent_transcript_path,omitempty"`
-	LastAssistantMessage string `json:"last_assistant_message,omitempty"`
+	AgentName            string                  `json:"agent_name"`
+	Status               string                  `json:"status"`
+	Result               string                  `json:"result"`
+	StopHookActive       bool                    `json:"stop_hook_active"`
+	AgentTranscriptPath  string                  `json:"agent_transcript_path,omitempty"`
+	LastAssistantMessage string                  `json:"last_assistant_message,omitempty"`
+	BackgroundTasks      []BackgroundTaskSummary `json:"background_tasks,omitempty"`
 }
 
 // HookType implements HookInput.

--- a/protocol.go
+++ b/protocol.go
@@ -385,6 +385,7 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 			BaseHookInput:        base,
 			StopHookActive:       getBool(inputData, "stop_hook_active"),
 			LastAssistantMessage: getString(inputData, "last_assistant_message"),
+			BackgroundTasks:      getBackgroundTaskSummaries(inputData, "background_tasks"),
 		}
 	case HookTypeSubagentStop:
 		input = SubagentStopInput{
@@ -395,6 +396,7 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 			StopHookActive:       getBool(inputData, "stop_hook_active"),
 			AgentTranscriptPath:  getString(inputData, "agent_transcript_path"),
 			LastAssistantMessage: getString(inputData, "last_assistant_message"),
+			BackgroundTasks:      getBackgroundTaskSummaries(inputData, "background_tasks"),
 		}
 	case HookTypePreCompact:
 		input = PreCompactInput{
@@ -880,6 +882,7 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 			BaseHookInput:        base,
 			StopHookActive:       getBool(hookInput, "stop_hook_active"),
 			LastAssistantMessage: getString(hookInput, "last_assistant_message"),
+			BackgroundTasks:      getBackgroundTaskSummaries(hookInput, "background_tasks"),
 		}
 	case "SubagentStop":
 		input = SubagentStopInput{
@@ -890,6 +893,7 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 			StopHookActive:       getBool(hookInput, "stop_hook_active"),
 			AgentTranscriptPath:  getString(hookInput, "agent_transcript_path"),
 			LastAssistantMessage: getString(hookInput, "last_assistant_message"),
+			BackgroundTasks:      getBackgroundTaskSummaries(hookInput, "background_tasks"),
 		}
 	case "PreCompact":
 		input = PreCompactInput{
@@ -1413,6 +1417,32 @@ func getPostToolBatchToolCalls(m map[string]interface{}) []PostToolBatchToolCall
 			call.ToolResponse = marshalJSON(resp)
 		}
 		out = append(out, call)
+	}
+	return out
+}
+
+func getBackgroundTaskSummaries(m map[string]interface{}, key string) []BackgroundTaskSummary {
+	raw, ok := m[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]BackgroundTaskSummary, 0, len(raw))
+	for _, v := range raw {
+		entry, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		out = append(out, BackgroundTaskSummary{
+			ID:          getString(entry, "id"),
+			Type:        getString(entry, "type"),
+			Status:      getString(entry, "status"),
+			Description: getString(entry, "description"),
+			Command:     getString(entry, "command"),
+			AgentType:   getString(entry, "agent_type"),
+			Server:      getString(entry, "server"),
+			Tool:        getString(entry, "tool"),
+			Name:        getString(entry, "name"),
+		})
 	}
 	return out
 }

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1844,6 +1844,21 @@ func TestHandleHookCallback_StopInputFields(t *testing.T) {
 		assert.Equal(t, "final answer", stopInput.LastAssistantMessage)
 		assert.Equal(t, "agent_stop", stopInput.Base().AgentID)
 		assert.Equal(t, "planner", stopInput.Base().AgentType)
+		require.Len(t, stopInput.BackgroundTasks, 2)
+		assert.Equal(t, BackgroundTaskSummary{
+			ID:          "task_shell",
+			Type:        "shell",
+			Status:      "running",
+			Description: "running make test",
+			Command:     "make test",
+		}, stopInput.BackgroundTasks[0])
+		assert.Equal(t, BackgroundTaskSummary{
+			ID:          "task_agent",
+			Type:        "subagent",
+			Status:      "pending",
+			Description: "planning followup",
+			AgentType:   "planner",
+		}, stopInput.BackgroundTasks[1])
 		return HookResult{Continue: true}, nil
 	}
 
@@ -1859,6 +1874,22 @@ func TestHandleHookCallback_StopInputFields(t *testing.T) {
 				"last_assistant_message": "final answer",
 				"agent_id":               "agent_stop",
 				"agent_type":             "planner",
+				"background_tasks": []interface{}{
+					map[string]interface{}{
+						"id":          "task_shell",
+						"type":        "shell",
+						"status":      "running",
+						"description": "running make test",
+						"command":     "make test",
+					},
+					map[string]interface{}{
+						"id":          "task_agent",
+						"type":        "subagent",
+						"status":      "pending",
+						"description": "planning followup",
+						"agent_type":  "planner",
+					},
+				},
 			},
 		},
 	})
@@ -1883,6 +1914,21 @@ func TestHandleSDKHookCallback_SubagentStopInputFields(t *testing.T) {
 		assert.Equal(t, "legacy result", subagentStopInput.Result)
 		assert.Equal(t, "agent_sdk", subagentStopInput.Base().AgentID)
 		assert.Equal(t, "builder", subagentStopInput.Base().AgentType)
+		require.Len(t, subagentStopInput.BackgroundTasks, 2)
+		assert.Equal(t, BackgroundTaskSummary{
+			ID:          "task_shell",
+			Type:        "shell",
+			Status:      "running",
+			Description: "running make test",
+			Command:     "make test",
+		}, subagentStopInput.BackgroundTasks[0])
+		assert.Equal(t, BackgroundTaskSummary{
+			ID:          "task_agent",
+			Type:        "subagent",
+			Status:      "pending",
+			Description: "planning followup",
+			AgentType:   "builder",
+		}, subagentStopInput.BackgroundTasks[1])
 		return HookResult{Continue: true}, nil
 	}
 
@@ -1902,12 +1948,93 @@ func TestHandleSDKHookCallback_SubagentStopInputFields(t *testing.T) {
 				"agent_name":             "legacy-name",
 				"status":                 "done",
 				"result":                 "legacy result",
+				"background_tasks": []interface{}{
+					map[string]interface{}{
+						"id":          "task_shell",
+						"type":        "shell",
+						"status":      "running",
+						"description": "running make test",
+						"command":     "make test",
+					},
+					map[string]interface{}{
+						"id":          "task_agent",
+						"type":        "subagent",
+						"status":      "pending",
+						"description": "planning followup",
+						"agent_type":  "builder",
+					},
+				},
 			},
 		},
 	})
 
 	assert.Equal(t, "success", resp.Response.Subtype)
 	assert.Equal(t, "sdk_subagent_stop", resp.Response.RequestID)
+}
+
+func TestHandleHookCallback_StopInputBackgroundTasksAbsent(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+
+	protocol.hookCallbacks["hook_stop_absent"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+		stopInput, ok := input.(StopInput)
+		require.True(t, ok)
+		assert.Nil(t, stopInput.BackgroundTasks)
+		return HookResult{Continue: true}, nil
+	}
+
+	resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+		Type:      "control",
+		Subtype:   "hook_callback",
+		RequestID: "req_stop_absent",
+		Payload: map[string]interface{}{
+			"callback_id": "hook_stop_absent",
+			"input": map[string]interface{}{
+				"hook_event":       "Stop",
+				"stop_hook_active": false,
+			},
+		},
+	})
+
+	assert.Equal(t, "success", resp.Response.Subtype)
+	assert.Equal(t, "req_stop_absent", resp.Response.RequestID)
+}
+
+func TestStopInputBackgroundTasksJSONRoundTrip(t *testing.T) {
+	input := StopInput{
+		BaseHookInput: BaseHookInput{
+			SessionID: "session_123",
+		},
+		StopHookActive:       true,
+		LastAssistantMessage: "done",
+		BackgroundTasks: []BackgroundTaskSummary{
+			{
+				ID:          "task_shell",
+				Type:        "shell",
+				Status:      "running",
+				Description: "running make test",
+				Command:     "make test",
+			},
+			{
+				ID:          "task_agent",
+				Type:        "subagent",
+				Status:      "pending",
+				Description: "planning followup",
+				AgentType:   "planner",
+			},
+		},
+	}
+
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"background_tasks"`)
+	assert.NotContains(t, string(data), `"agent_type":""`)
+	assert.NotContains(t, string(data), `"command":""`)
+
+	var got StopInput
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, input, got)
 }
 
 func TestHandleSDKHookCallback_MissingHookAuditFields(t *testing.T) {


### PR DESCRIPTION
Mirror v0.3.150 TS SDK: `Options.background_tasks?: BackgroundTaskSummary[]`
on `StopHookInput` and `SubagentStopHookInput`. Lets Stop hooks distinguish
"session is done" from "paused waiting for background work".

* New `BackgroundTaskSummary` type in `options.go` (10 fields, 5 task-class
  specific with `,omitempty` so the absent-vs-empty distinction round-trips).
* New `BackgroundTasks []BackgroundTaskSummary` field on `StopInput` and
  `SubagentStopInput`.
* Wire parsing in `protocol.go` updated at both Stop/SubagentStop hook
  parse sites; new `getBackgroundTaskSummaries` helper next to
  `getPostToolBatchToolCalls`.
* Unit tests cover present / absent / round-trip. Integration test
  `t.Skip`'d — not triggerable from CLI without a long-running task
  (followup tracked in `INTEGRATION-FOLLOWUPS.md`).

Pairs with PR-12 (`Stream.BackgroundTasks` control method) and precedes
PR-14 (`SessionCronSummary` + `session_crons` field on the same hooks).
Ref: TS SDK v0.3.150.