### PR TITLE
hooks: add SessionCronSummary + session_crons field on Stop/SubagentStop

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -1,3 +1,4 @@
 # Integration Followups
 
 - Backfill `TestIntegrationStopHookBackgroundTasks` when the CLI test fixture can deterministically create a long-running background task.
+- Backfill `TestIntegrationStopHookSessionCrons` when the CLI test fixture can deterministically create a session cron.

--- a/integration_test.go
+++ b/integration_test.go
@@ -725,6 +725,14 @@ func TestIntegrationStopHookBackgroundTasks(t *testing.T) {
 	t.Skip("not triggerable from CLI without a long-running background task; tracked in INTEGRATION-FOLLOWUPS.md")
 }
 
+func TestIntegrationStopHookSessionCrons(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// TODO: Backfill when a deterministic session cron fixture is available.
+	t.Skip("not triggerable from CLI without scheduling a session cron; tracked in INTEGRATION-FOLLOWUPS.md")
+}
+
 func TestIntegrationBaseHookInputEffort(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/options.go
+++ b/options.go
@@ -1353,12 +1353,22 @@ type BackgroundTaskSummary struct {
 	Name        string `json:"name,omitempty"`
 }
 
+// SessionCronSummary is a snapshot of a session-scoped cron task that will
+// wake this session later (CronCreate, ScheduleWakeup, /loop).
+type SessionCronSummary struct {
+	ID        string `json:"id"`
+	Schedule  string `json:"schedule"`
+	Recurring bool   `json:"recurring"`
+	Prompt    string `json:"prompt"`
+}
+
 // StopInput contains data for Stop hooks.
 type StopInput struct {
 	BaseHookInput
 	StopHookActive       bool                    `json:"stop_hook_active"`
 	LastAssistantMessage string                  `json:"last_assistant_message,omitempty"`
 	BackgroundTasks      []BackgroundTaskSummary `json:"background_tasks,omitempty"`
+	SessionCrons         []SessionCronSummary    `json:"session_crons,omitempty"`
 }
 
 // HookType implements HookInput.
@@ -1380,6 +1390,7 @@ type SubagentStopInput struct {
 	AgentTranscriptPath  string                  `json:"agent_transcript_path,omitempty"`
 	LastAssistantMessage string                  `json:"last_assistant_message,omitempty"`
 	BackgroundTasks      []BackgroundTaskSummary `json:"background_tasks,omitempty"`
+	SessionCrons         []SessionCronSummary    `json:"session_crons,omitempty"`
 }
 
 // HookType implements HookInput.

--- a/protocol.go
+++ b/protocol.go
@@ -386,6 +386,7 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 			StopHookActive:       getBool(inputData, "stop_hook_active"),
 			LastAssistantMessage: getString(inputData, "last_assistant_message"),
 			BackgroundTasks:      getBackgroundTaskSummaries(inputData, "background_tasks"),
+			SessionCrons:         getSessionCronSummaries(inputData, "session_crons"),
 		}
 	case HookTypeSubagentStop:
 		input = SubagentStopInput{
@@ -397,6 +398,7 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 			AgentTranscriptPath:  getString(inputData, "agent_transcript_path"),
 			LastAssistantMessage: getString(inputData, "last_assistant_message"),
 			BackgroundTasks:      getBackgroundTaskSummaries(inputData, "background_tasks"),
+			SessionCrons:         getSessionCronSummaries(inputData, "session_crons"),
 		}
 	case HookTypePreCompact:
 		input = PreCompactInput{
@@ -883,6 +885,7 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 			StopHookActive:       getBool(hookInput, "stop_hook_active"),
 			LastAssistantMessage: getString(hookInput, "last_assistant_message"),
 			BackgroundTasks:      getBackgroundTaskSummaries(hookInput, "background_tasks"),
+			SessionCrons:         getSessionCronSummaries(hookInput, "session_crons"),
 		}
 	case "SubagentStop":
 		input = SubagentStopInput{
@@ -894,6 +897,7 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 			AgentTranscriptPath:  getString(hookInput, "agent_transcript_path"),
 			LastAssistantMessage: getString(hookInput, "last_assistant_message"),
 			BackgroundTasks:      getBackgroundTaskSummaries(hookInput, "background_tasks"),
+			SessionCrons:         getSessionCronSummaries(hookInput, "session_crons"),
 		}
 	case "PreCompact":
 		input = PreCompactInput{
@@ -1442,6 +1446,27 @@ func getBackgroundTaskSummaries(m map[string]interface{}, key string) []Backgrou
 			Server:      getString(entry, "server"),
 			Tool:        getString(entry, "tool"),
 			Name:        getString(entry, "name"),
+		})
+	}
+	return out
+}
+
+func getSessionCronSummaries(m map[string]interface{}, key string) []SessionCronSummary {
+	raw, ok := m[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]SessionCronSummary, 0, len(raw))
+	for _, v := range raw {
+		entry, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		out = append(out, SessionCronSummary{
+			ID:        getString(entry, "id"),
+			Schedule:  getString(entry, "schedule"),
+			Recurring: getBool(entry, "recurring"),
+			Prompt:    getString(entry, "prompt"),
 		})
 	}
 	return out

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -1859,6 +1859,19 @@ func TestHandleHookCallback_StopInputFields(t *testing.T) {
 			Description: "planning followup",
 			AgentType:   "planner",
 		}, stopInput.BackgroundTasks[1])
+		require.Len(t, stopInput.SessionCrons, 2)
+		assert.Equal(t, SessionCronSummary{
+			ID:        "cron_weekday",
+			Schedule:  "0 9 * * 1-5",
+			Recurring: true,
+			Prompt:    "weekday standup",
+		}, stopInput.SessionCrons[0])
+		assert.Equal(t, SessionCronSummary{
+			ID:        "cron_wakeup",
+			Schedule:  "15 14 1 6 *",
+			Recurring: false,
+			Prompt:    "resume investigation",
+		}, stopInput.SessionCrons[1])
 		return HookResult{Continue: true}, nil
 	}
 
@@ -1888,6 +1901,20 @@ func TestHandleHookCallback_StopInputFields(t *testing.T) {
 						"status":      "pending",
 						"description": "planning followup",
 						"agent_type":  "planner",
+					},
+				},
+				"session_crons": []interface{}{
+					map[string]interface{}{
+						"id":        "cron_weekday",
+						"schedule":  "0 9 * * 1-5",
+						"recurring": true,
+						"prompt":    "weekday standup",
+					},
+					map[string]interface{}{
+						"id":        "cron_wakeup",
+						"schedule":  "15 14 1 6 *",
+						"recurring": false,
+						"prompt":    "resume investigation",
 					},
 				},
 			},
@@ -1929,6 +1956,19 @@ func TestHandleSDKHookCallback_SubagentStopInputFields(t *testing.T) {
 			Description: "planning followup",
 			AgentType:   "builder",
 		}, subagentStopInput.BackgroundTasks[1])
+		require.Len(t, subagentStopInput.SessionCrons, 2)
+		assert.Equal(t, SessionCronSummary{
+			ID:        "cron_weekday",
+			Schedule:  "0 9 * * 1-5",
+			Recurring: true,
+			Prompt:    "weekday standup",
+		}, subagentStopInput.SessionCrons[0])
+		assert.Equal(t, SessionCronSummary{
+			ID:        "cron_wakeup",
+			Schedule:  "15 14 1 6 *",
+			Recurring: false,
+			Prompt:    "resume investigation",
+		}, subagentStopInput.SessionCrons[1])
 		return HookResult{Continue: true}, nil
 	}
 
@@ -1964,6 +2004,20 @@ func TestHandleSDKHookCallback_SubagentStopInputFields(t *testing.T) {
 						"agent_type":  "builder",
 					},
 				},
+				"session_crons": []interface{}{
+					map[string]interface{}{
+						"id":        "cron_weekday",
+						"schedule":  "0 9 * * 1-5",
+						"recurring": true,
+						"prompt":    "weekday standup",
+					},
+					map[string]interface{}{
+						"id":        "cron_wakeup",
+						"schedule":  "15 14 1 6 *",
+						"recurring": false,
+						"prompt":    "resume investigation",
+					},
+				},
 			},
 		},
 	})
@@ -1981,6 +2035,35 @@ func TestHandleHookCallback_StopInputBackgroundTasksAbsent(t *testing.T) {
 		stopInput, ok := input.(StopInput)
 		require.True(t, ok)
 		assert.Nil(t, stopInput.BackgroundTasks)
+		return HookResult{Continue: true}, nil
+	}
+
+	resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+		Type:      "control",
+		Subtype:   "hook_callback",
+		RequestID: "req_stop_absent",
+		Payload: map[string]interface{}{
+			"callback_id": "hook_stop_absent",
+			"input": map[string]interface{}{
+				"hook_event":       "Stop",
+				"stop_hook_active": false,
+			},
+		},
+	})
+
+	assert.Equal(t, "success", resp.Response.Subtype)
+	assert.Equal(t, "req_stop_absent", resp.Response.RequestID)
+}
+
+func TestHandleHookCallback_StopInputSessionCronsAbsent(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+
+	protocol.hookCallbacks["hook_stop_absent"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+		stopInput, ok := input.(StopInput)
+		require.True(t, ok)
+		assert.Nil(t, stopInput.SessionCrons)
 		return HookResult{Continue: true}, nil
 	}
 
@@ -2031,6 +2114,38 @@ func TestStopInputBackgroundTasksJSONRoundTrip(t *testing.T) {
 	assert.Contains(t, string(data), `"background_tasks"`)
 	assert.NotContains(t, string(data), `"agent_type":""`)
 	assert.NotContains(t, string(data), `"command":""`)
+
+	var got StopInput
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, input, got)
+}
+
+func TestStopInputSessionCronsJSONRoundTrip(t *testing.T) {
+	input := StopInput{
+		BaseHookInput: BaseHookInput{
+			SessionID: "session_123",
+		},
+		StopHookActive:       true,
+		LastAssistantMessage: "done",
+		SessionCrons: []SessionCronSummary{
+			{
+				ID:        "cron_weekday",
+				Schedule:  "0 9 * * 1-5",
+				Recurring: true,
+				Prompt:    "weekday standup",
+			},
+			{
+				ID:        "cron_wakeup",
+				Schedule:  "15 14 1 6 *",
+				Recurring: false,
+				Prompt:    "resume investigation",
+			},
+		},
+	}
+
+	data, err := json.Marshal(input)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"session_crons"`)
 
 	var got StopInput
 	require.NoError(t, json.Unmarshal(data, &got))


### PR DESCRIPTION
Mirror v0.3.150 TS SDK: `Options.session_crons?: SessionCronSummary[]` on `StopHookInput` and `SubagentStopHookInput`. Lets Stop hooks see what session-scoped cron tasks (`CronCreate`, `ScheduleWakeup`, `/loop`) are scheduled to wake the session later.

* New `SessionCronSummary` type in `options.go` (4 required fields: `id`, `schedule`, `recurring`, `prompt`).
* New `SessionCrons []SessionCronSummary` field on `StopInput` and `SubagentStopInput`, immediately after `BackgroundTasks` (PR-13).
* Wire parsing in `protocol.go` updated at both Stop/SubagentStop hook parse sites; new `getSessionCronSummaries` helper next to `getBackgroundTaskSummaries`.
* Unit tests cover present / absent / round-trip. Integration test `t.Skip`'d — not triggerable from CLI without scheduling a session cron (followup tracked in `INTEGRATION-FOLLOWUPS.md`).

Pairs with PR-13 (#73, `background_tasks` field on the same two hooks). Ref: TS SDK v0.3.150.