### PR TITLE
messages: add request_id, subagent_type, task_description to AssistantMessage

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -2,3 +2,4 @@
 
 - Backfill `TestIntegrationStopHookBackgroundTasks` when the CLI test fixture can deterministically create a long-running background task.
 - Backfill `TestIntegrationStopHookSessionCrons` when the CLI test fixture can deterministically create a session cron.
+- Backfill `TestIntegrationAssistantMessageSubagentFields` when the CLI test fixture can deterministically run a subagent task end-to-end.

--- a/integration_test.go
+++ b/integration_test.go
@@ -733,6 +733,13 @@ func TestIntegrationStopHookSessionCrons(t *testing.T) {
 	t.Skip("not triggerable from CLI without scheduling a session cron; tracked in INTEGRATION-FOLLOWUPS.md")
 }
 
+func TestIntegrationAssistantMessageSubagentFields(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	t.Skip("requires running a subagent task end-to-end; tracked in INTEGRATION-FOLLOWUPS.md")
+}
+
 func TestIntegrationBaseHookInputEffort(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/messages.go
+++ b/messages.go
@@ -82,6 +82,19 @@ type AssistantMessage struct {
 	} `json:"message"`
 	ParentToolUseID *string `json:"parent_tool_use_id,omitempty"` // Parent tool use if in subagent
 	Usage           *Usage  `json:"usage,omitempty"`              // Token usage for this message
+
+	// RequestID is the upstream API request id that produced this message,
+	// when available. Optional.
+	RequestID string `json:"request_id,omitempty"`
+
+	// SubagentType is the subagent type that produced this message, when
+	// the message originated from a subagent task. Empty for top-level
+	// assistant turns.
+	SubagentType string `json:"subagent_type,omitempty"`
+
+	// TaskDescription is a short description of the subagent task that
+	// produced this message. Set alongside SubagentType.
+	TaskDescription string `json:"task_description,omitempty"`
 }
 
 // MessageType implements Message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -314,6 +314,75 @@ func TestParseMessageAssistantMessage(t *testing.T) {
 	assert.Equal(t, 0.0025, assistantMsg.Usage.Cost)
 }
 
+func TestParseMessageAssistantMessageSubagentFields(t *testing.T) {
+	input := `{
+		"type": "assistant",
+		"message": {
+			"role": "assistant",
+			"content": [
+				{
+					"type": "text",
+					"text": "Subagent response."
+				}
+			]
+		},
+		"usage": {
+			"input_tokens": 12,
+			"output_tokens": 8,
+			"total_tokens": 20
+		},
+		"request_id": "req_123",
+		"subagent_type": "general-purpose",
+		"task_description": "Inspect repository state"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	assistantMsg, ok := msg.(AssistantMessage)
+	require.True(t, ok, "expected AssistantMessage")
+
+	assert.Equal(t, "req_123", assistantMsg.RequestID)
+	assert.Equal(t, "general-purpose", assistantMsg.SubagentType)
+	assert.Equal(t, "Inspect repository state", assistantMsg.TaskDescription)
+}
+
+func TestAssistantMessageFieldsOmitEmpty(t *testing.T) {
+	msg := AssistantMessage{Type: "assistant"}
+	msg.Message.Role = "assistant"
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.NotContains(t, got, "request_id")
+	assert.NotContains(t, got, "subagent_type")
+	assert.NotContains(t, got, "task_description")
+}
+
+func TestAssistantMessageJSONRoundTrip(t *testing.T) {
+	msg := AssistantMessage{
+		Type:            "assistant",
+		RequestID:       "req_456",
+		SubagentType:    "code-reviewer",
+		TaskDescription: "Review assistant message fields",
+	}
+	msg.Message.Role = "assistant"
+	msg.Message.Content = []ContentBlock{{Type: "text", Text: "Done."}}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got AssistantMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, msg.RequestID, got.RequestID)
+	assert.Equal(t, msg.SubagentType, got.SubagentType)
+	assert.Equal(t, msg.TaskDescription, got.TaskDescription)
+}
+
 // TestParseMessageToolUseBlock tests parsing tool use requests.
 func TestParseMessageToolUseBlock(t *testing.T) {
 	inputJSON := `{


### PR DESCRIPTION
Mirrors three new optional fields the TS SDK added on `SDKAssistantMessage` in `@anthropic-ai/claude-agent-sdk@0.3.150` (sdk.d.ts L2556-2572):

- `request_id` — upstream API request id that produced the message.
- `subagent_type` — subagent type that produced the message; empty for top-level assistant turns.
- `task_description` — short description of the subagent task that produced the message.

All three are optional in TS, so Go uses `,omitempty`. Parsing is unchanged: `ParseMessage` already calls `json.Unmarshal` straight onto `AssistantMessage`, so the new fields are populated automatically when present on the wire.

Out of scope: the TS shape also gained an `error?: AssistantMessageError` field. That ships in PR-16 alongside the `AssistantMessageError` enum widening.

## Tests

`messages_test.go`:
- `TestParseMessageAssistantMessageSubagentFields` — round-trip via `ParseMessage`.
- `TestAssistantMessageFieldsOmitEmpty` — confirms `omitempty` keeps absent fields off the wire.
- `TestAssistantMessageJSONRoundTrip` — full marshal/unmarshal round-trip with all three populated.

`integration_test.go`:
- `TestIntegrationAssistantMessageSubagentFields` — `t.Skip` placeholder until a deterministic CLI trigger for subagent stream output lands. Tracked in `INTEGRATION-FOLLOWUPS.md`.

## Verification

- `go test ./... -count=1` — pass
- `go vet ./...` — clean
- `gofmt -l .` — empty

Part of the v0.3.150 catchup (PR 15, follow-up to #74 which landed the session-cron summary work).