### PR TITLE
messages: add oauth_org_not_allowed/model_not_found error variants + Error on AssistantMessage

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -3,3 +3,4 @@
 - Backfill `TestIntegrationStopHookBackgroundTasks` when the CLI test fixture can deterministically create a long-running background task.
 - Backfill `TestIntegrationStopHookSessionCrons` when the CLI test fixture can deterministically create a session cron.
 - Backfill `TestIntegrationAssistantMessageSubagentFields` when the CLI test fixture can deterministically run a subagent task end-to-end.
+- Backfill `TestIntegrationAssistantMessageError` when the CLI test fixture can deterministically force an upstream API failure into an `assistant` event.

--- a/integration_test.go
+++ b/integration_test.go
@@ -740,6 +740,13 @@ func TestIntegrationAssistantMessageSubagentFields(t *testing.T) {
 	t.Skip("requires running a subagent task end-to-end; tracked in INTEGRATION-FOLLOWUPS.md")
 }
 
+func TestIntegrationAssistantMessageError(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	t.Skip("requires an upstream API failure (e.g. auth/quota) to deterministically populate AssistantMessage.Error; tracked in INTEGRATION-FOLLOWUPS.md")
+}
+
 func TestIntegrationBaseHookInputEffort(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/messages.go
+++ b/messages.go
@@ -95,6 +95,11 @@ type AssistantMessage struct {
 	// TaskDescription is a short description of the subagent task that
 	// produced this message. Set alongside SubagentType.
 	TaskDescription string `json:"task_description,omitempty"`
+
+	// Error is the upstream API error code, if the assistant turn failed.
+	// Empty for a successful turn. See AssistantMessageError for known
+	// variants.
+	Error AssistantMessageError `json:"error,omitempty"`
 }
 
 // MessageType implements Message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -347,6 +347,30 @@ func TestParseMessageAssistantMessageSubagentFields(t *testing.T) {
 	assert.Equal(t, "Inspect repository state", assistantMsg.TaskDescription)
 }
 
+func TestParseMessageAssistantMessageError(t *testing.T) {
+	input := `{
+		"type": "assistant",
+		"message": {
+			"role": "assistant",
+			"content": [
+				{
+					"type": "text",
+					"text": "Authentication failed."
+				}
+			]
+		},
+		"error": "oauth_org_not_allowed"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	assistantMsg, ok := msg.(AssistantMessage)
+	require.True(t, ok, "expected AssistantMessage")
+
+	assert.Equal(t, AssistantMessageErrorOAuthOrgNotAllowed, assistantMsg.Error)
+}
+
 func TestAssistantMessageFieldsOmitEmpty(t *testing.T) {
 	msg := AssistantMessage{Type: "assistant"}
 	msg.Message.Role = "assistant"
@@ -360,6 +384,19 @@ func TestAssistantMessageFieldsOmitEmpty(t *testing.T) {
 	assert.NotContains(t, got, "request_id")
 	assert.NotContains(t, got, "subagent_type")
 	assert.NotContains(t, got, "task_description")
+}
+
+func TestAssistantMessageErrorOmitEmpty(t *testing.T) {
+	msg := AssistantMessage{Type: "assistant"}
+	msg.Message.Role = "assistant"
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.NotContains(t, got, "error")
 }
 
 func TestAssistantMessageJSONRoundTrip(t *testing.T) {
@@ -381,6 +418,23 @@ func TestAssistantMessageJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, msg.RequestID, got.RequestID)
 	assert.Equal(t, msg.SubagentType, got.SubagentType)
 	assert.Equal(t, msg.TaskDescription, got.TaskDescription)
+}
+
+func TestAssistantMessageErrorRoundTrip(t *testing.T) {
+	msg := AssistantMessage{
+		Type:  "assistant",
+		Error: AssistantMessageErrorModelNotFound,
+	}
+	msg.Message.Role = "assistant"
+	msg.Message.Content = []ContentBlock{{Type: "text", Text: "Model unavailable."}}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got AssistantMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, msg.Error, got.Error)
 }
 
 // TestParseMessageToolUseBlock tests parsing tool use requests.

--- a/options.go
+++ b/options.go
@@ -1616,9 +1616,11 @@ type AssistantMessageError string
 
 const (
 	AssistantMessageErrorAuthenticationFailed AssistantMessageError = "authentication_failed"
+	AssistantMessageErrorOAuthOrgNotAllowed   AssistantMessageError = "oauth_org_not_allowed"
 	AssistantMessageErrorBillingError         AssistantMessageError = "billing_error"
 	AssistantMessageErrorRateLimit            AssistantMessageError = "rate_limit"
 	AssistantMessageErrorInvalidRequest       AssistantMessageError = "invalid_request"
+	AssistantMessageErrorModelNotFound        AssistantMessageError = "model_not_found"
 	AssistantMessageErrorServerError          AssistantMessageError = "server_error"
 	AssistantMessageErrorUnknown              AssistantMessageError = "unknown"
 	AssistantMessageErrorMaxOutputTokens      AssistantMessageError = "max_output_tokens"


### PR DESCRIPTION
See memory/catchup-v0.3.150/PLAN.md §"PR 16".

Mirror v0.3.150 TS SDK:

* Two new `AssistantMessageError` variants: `oauth_org_not_allowed`, `model_not_found`. Constants ordered to match the TS spec for readability.
* New optional `Error` field on `AssistantMessage` (deferred from PR-15 per its brief). `,omitempty`; populated when the CLI streams a degraded `assistant` event.
* Existing `StopFailureInput.Error` and other reuse sites pick up the new variants automatically.
* Unit tests cover parse / omitempty / round-trip. Integration `t.Skip`'d because this requires an upstream API failure; followup tracked in `INTEGRATION-FOLLOWUPS.md`.

Ref: TS SDK v0.3.150, `SDKAssistantMessageError` L2574, `SDKAssistantMessage` L2556-2572.
