### PR TITLE
messages: add Origin/TTFTMs on ResultMessage + introduce MessageOrigin type

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -4,3 +4,4 @@
 - Backfill `TestIntegrationStopHookSessionCrons` when the CLI test fixture can deterministically create a session cron.
 - Backfill `TestIntegrationAssistantMessageSubagentFields` when the CLI test fixture can deterministically run a subagent task end-to-end.
 - Backfill `TestIntegrationAssistantMessageError` when the CLI test fixture can deterministically force an upstream API failure into an `assistant` event.
+- Backfill `TestIntegrationResultMessageOriginTTFT` when the CLI test fixture can deterministically emit `origin` and/or `ttft_ms` on a result event.

--- a/integration_test.go
+++ b/integration_test.go
@@ -747,6 +747,13 @@ func TestIntegrationAssistantMessageError(t *testing.T) {
 	t.Skip("requires an upstream API failure (e.g. auth/quota) to deterministically populate AssistantMessage.Error; tracked in INTEGRATION-FOLLOWUPS.md")
 }
 
+func TestIntegrationResultMessageOriginTTFT(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	t.Skip("requires CLI to emit origin/ttft_ms on result events (host-side multi-actor or measured TTFT); tracked in INTEGRATION-FOLLOWUPS.md")
+}
+
 func TestIntegrationBaseHookInputEffort(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/messages.go
+++ b/messages.go
@@ -157,6 +157,7 @@ type ResultMessage struct {
 
 	DurationMs    int64 `json:"duration_ms,omitempty"`     // Total duration in milliseconds
 	DurationAPIMs int64 `json:"duration_api_ms,omitempty"` // API call duration in milliseconds
+	TTFTMs        int64 `json:"ttft_ms,omitempty"`         // Time-to-first-token in milliseconds
 	IsError       bool  `json:"is_error,omitempty"`        // Whether this is an error result
 	NumTurns      int   `json:"num_turns,omitempty"`       // Number of conversation turns
 
@@ -169,11 +170,31 @@ type ResultMessage struct {
 	StructuredOutput  interface{}        `json:"structured_output,omitempty"`  // Structured output (if OutputFormat set)
 	StopReason        *string            `json:"stop_reason"`                  // Stop reason, explicitly null when absent
 	TerminalReason    *TerminalReason    `json:"terminal_reason,omitempty"`    // Terminal completion reason
+	Origin            *MessageOrigin     `json:"origin,omitempty"`             // Originating actor for this result
 	FastModeState     *FastModeState     `json:"fast_mode_state,omitempty"`    // Fast mode state at completion
 }
 
 // MessageType implements Message.
 func (m ResultMessage) MessageType() string { return "result" }
+
+// MessageOriginKind discriminates a MessageOrigin.
+type MessageOriginKind string
+
+const (
+	MessageOriginKindHuman            MessageOriginKind = "human"
+	MessageOriginKindChannel          MessageOriginKind = "channel"
+	MessageOriginKindPeer             MessageOriginKind = "peer"
+	MessageOriginKindTaskNotification MessageOriginKind = "task-notification"
+	MessageOriginKindCoordinator      MessageOriginKind = "coordinator"
+)
+
+// MessageOrigin describes the originating actor for a message.
+type MessageOrigin struct {
+	Kind   MessageOriginKind `json:"kind"`
+	Server string            `json:"server,omitempty"`
+	From   string            `json:"from,omitempty"`
+	Name   string            `json:"name,omitempty"`
+}
 
 // StreamEvent represents a progressive delta update during streaming.
 //

--- a/messages_test.go
+++ b/messages_test.go
@@ -524,6 +524,70 @@ func TestParseMessageResultMessage(t *testing.T) {
 	}
 }
 
+func TestParseMessageResultMessageOriginPeer(t *testing.T) {
+	input := []byte(`{
+		"type": "result",
+		"status": "success",
+		"subtype": "success",
+		"result": "done",
+		"origin": {
+			"kind": "peer",
+			"from": "agent-42",
+			"name": "reviewer"
+		}
+	}`)
+
+	msg, err := ParseMessage(input)
+	require.NoError(t, err)
+
+	resultMsg, ok := msg.(ResultMessage)
+	require.True(t, ok)
+	require.NotNil(t, resultMsg.Origin)
+	assert.Equal(t, MessageOriginKindPeer, resultMsg.Origin.Kind)
+	assert.Equal(t, "agent-42", resultMsg.Origin.From)
+	assert.Equal(t, "reviewer", resultMsg.Origin.Name)
+}
+
+func TestParseMessageResultMessageOriginHuman(t *testing.T) {
+	input := []byte(`{
+		"type": "result",
+		"status": "success",
+		"subtype": "success",
+		"result": "done",
+		"origin": {
+			"kind": "human"
+		}
+	}`)
+
+	msg, err := ParseMessage(input)
+	require.NoError(t, err)
+
+	resultMsg, ok := msg.(ResultMessage)
+	require.True(t, ok)
+	require.NotNil(t, resultMsg.Origin)
+	assert.Equal(t, MessageOriginKindHuman, resultMsg.Origin.Kind)
+	assert.Empty(t, resultMsg.Origin.From)
+	assert.Empty(t, resultMsg.Origin.Server)
+	assert.Empty(t, resultMsg.Origin.Name)
+}
+
+func TestParseMessageResultMessageTTFT(t *testing.T) {
+	input := []byte(`{
+		"type": "result",
+		"status": "success",
+		"subtype": "success",
+		"result": "done",
+		"ttft_ms": 137
+	}`)
+
+	msg, err := ParseMessage(input)
+	require.NoError(t, err)
+
+	resultMsg, ok := msg.(ResultMessage)
+	require.True(t, ok)
+	assert.Equal(t, int64(137), resultMsg.TTFTMs)
+}
+
 // TestParseMessageStreamEvent tests parsing stream events.
 func TestParseMessageStreamEvent(t *testing.T) {
 	input := `{
@@ -903,6 +967,43 @@ func TestResultMessageStopReasonNullRoundTrip(t *testing.T) {
 	var decoded ResultMessage
 	require.NoError(t, json.Unmarshal(data, &decoded))
 	assert.Nil(t, decoded.StopReason)
+}
+
+func TestResultMessageOriginTTFTOmitEmpty(t *testing.T) {
+	msg := ResultMessage{
+		Type:    "result",
+		Subtype: "success",
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.NotContains(t, got, "origin")
+	assert.NotContains(t, got, "ttft_ms")
+}
+
+func TestResultMessageOriginRoundTrip(t *testing.T) {
+	msg := ResultMessage{
+		Type:    "result",
+		Subtype: "success",
+		Origin: &MessageOrigin{
+			Kind:   MessageOriginKindChannel,
+			Server: "gateway-prod",
+		},
+		TTFTMs: 250,
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Origin)
+	assert.Equal(t, MessageOriginKindChannel, decoded.Origin.Kind)
+	assert.Equal(t, "gateway-prod", decoded.Origin.Server)
+	assert.Equal(t, int64(250), decoded.TTFTMs)
 }
 
 func TestResultMessageFieldAdditionsBackwardCompat(t *testing.T) {


### PR DESCRIPTION
Mirror v0.3.150 TS SDK:

* New `MessageOrigin` discriminated-union type (`human` / `channel` /
  `peer` / `task-notification` / `coordinator`) — first appearance in the
  Go SDK. Flat struct with a `Kind` discriminator and per-variant fields
  (`Server`, `From`, `Name`) using `,omitempty`. Reused by later PRs.
* `ResultMessage.Origin *MessageOrigin` (`,omitempty`) — present when the
  host tracks multi-actor sessions.
* `ResultMessage.TTFTMs int64` (`,omitempty`) — time-to-first-token in ms.
  TS spec puts it on the success variant only; the unified Go struct
  receives it the same way (absent on error subtypes).

Unit tests cover parse / omitempty / round-trip for both `Origin` (peer
and human variants) and `TTFTMs`. Integration `t.Skip`'d — requires
deterministic emission from the CLI; followup tracked in
`INTEGRATION-FOLLOWUPS.md`.

See memory/catchup-v0.3.150/PLAN.md §"PR 17".
Ref: TS SDK v0.3.150, `SDKMessageOrigin` L3246, `SDKResultSuccess` L3298/3415, `SDKResultError` L3441.