### PR TITLE
messages: add task lifecycle subagent_type + paused status

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -5,3 +5,4 @@
 - Backfill `TestIntegrationAssistantMessageSubagentFields` when the CLI test fixture can deterministically run a subagent task end-to-end.
 - Backfill `TestIntegrationAssistantMessageError` when the CLI test fixture can deterministically force an upstream API failure into an `assistant` event.
 - Backfill `TestIntegrationResultMessageOriginTTFT` when the CLI test fixture can deterministically emit `origin` and/or `ttft_ms` on a result event.
+- Backfill `TestIntegrationTaskLifecycleFields` when the CLI test fixture can deterministically run a Task-tool subagent (populates `subagent_type` on `task_started`/`task_progress`) and pause a running task (emits `task_updated` with `status:"paused"`).

--- a/integration_test.go
+++ b/integration_test.go
@@ -754,6 +754,13 @@ func TestIntegrationResultMessageOriginTTFT(t *testing.T) {
 	t.Skip("requires CLI to emit origin/ttft_ms on result events (host-side multi-actor or measured TTFT); tracked in INTEGRATION-FOLLOWUPS.md")
 }
 
+func TestIntegrationTaskLifecycleFields(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	t.Skip("requires CLI to emit a Task-tool subagent run (subagent_type) and a paused-status task_updated event; tracked in INTEGRATION-FOLLOWUPS.md")
+}
+
 func TestIntegrationBaseHookInputEffort(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/messages.go
+++ b/messages.go
@@ -703,6 +703,7 @@ const (
 	TaskRunStatusCompleted TaskRunStatus = "completed"
 	TaskRunStatusFailed    TaskRunStatus = "failed"
 	TaskRunStatusKilled    TaskRunStatus = "killed"
+	TaskRunStatusPaused    TaskRunStatus = "paused"
 )
 
 // TaskStartedMessage reports that a task has started executing.
@@ -712,6 +713,7 @@ type TaskStartedMessage struct {
 	TaskID         string `json:"task_id"`                   // Task identifier
 	ToolUseID      string `json:"tool_use_id,omitempty"`     // Related tool use ID
 	Description    string `json:"description"`               // Task description
+	SubagentType   string `json:"subagent_type,omitempty"`   // Subagent type for Task tool subagents
 	TaskType       string `json:"task_type,omitempty"`       // Task type
 	WorkflowName   string `json:"workflow_name,omitempty"`   // Workflow script metadata name
 	Prompt         string `json:"prompt,omitempty"`          // Task prompt
@@ -730,6 +732,7 @@ type TaskProgressMessage struct {
 	TaskID       string    `json:"task_id"`                  // Task identifier
 	ToolUseID    string    `json:"tool_use_id,omitempty"`    // Related tool use ID
 	Description  string    `json:"description"`              // Task description
+	SubagentType string    `json:"subagent_type,omitempty"`  // Subagent type for Task tool subagents
 	Usage        TaskUsage `json:"usage"`                    // Resource consumption
 	LastToolName string    `json:"last_tool_name,omitempty"` // Last tool used by task
 	Summary      string    `json:"summary,omitempty"`        // Task progress summary

--- a/messages_test.go
+++ b/messages_test.go
@@ -1780,6 +1780,26 @@ func TestTaskProgressSubagentTypeOmitEmpty(t *testing.T) {
 	assert.NotContains(t, got, "subagent_type")
 }
 
+func TestTaskProgressSubagentTypeRoundTrip(t *testing.T) {
+	want := TaskProgressMessage{
+		Type:         "system",
+		Subtype:      "task_progress",
+		TaskID:       "t1",
+		Description:  "d",
+		SubagentType: "explorer",
+		Usage:        TaskUsage{},
+		UUID:         "u",
+		SessionID:    "s",
+	}
+
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+
+	var got TaskProgressMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, want.SubagentType, got.SubagentType)
+}
+
 func TestParseMessageTaskUpdated(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/messages_test.go
+++ b/messages_test.go
@@ -1603,6 +1603,62 @@ func TestParseMessageTaskStarted(t *testing.T) {
 	}
 }
 
+func TestParseMessageTaskStartedSubagentType(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "task_started",
+		"task_id": "t1",
+		"description": "Review changes",
+		"subagent_type": "reviewer",
+		"uuid": "u1",
+		"session_id": "s1"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	taskMsg, ok := msg.(TaskStartedMessage)
+	require.True(t, ok, "expected TaskStartedMessage")
+	assert.Equal(t, "reviewer", taskMsg.SubagentType)
+}
+
+func TestTaskStartedSubagentTypeOmitEmpty(t *testing.T) {
+	msg := TaskStartedMessage{
+		Type:        "system",
+		Subtype:     "task_started",
+		TaskID:      "t1",
+		Description: "d",
+		UUID:        "u",
+		SessionID:   "s",
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.NotContains(t, got, "subagent_type")
+}
+
+func TestTaskStartedSubagentTypeRoundTrip(t *testing.T) {
+	want := TaskStartedMessage{
+		Type:         "system",
+		Subtype:      "task_started",
+		TaskID:       "t1",
+		Description:  "d",
+		SubagentType: "explorer",
+		UUID:         "u",
+		SessionID:    "s",
+	}
+
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+
+	var got TaskStartedMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, want.SubagentType, got.SubagentType)
+}
+
 func TestParseMessageTaskProgress(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -1679,6 +1735,49 @@ func TestParseMessageTaskProgress(t *testing.T) {
 			tt.check(t, taskMsg)
 		})
 	}
+}
+
+func TestParseMessageTaskProgressSubagentType(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "task_progress",
+		"task_id": "t1",
+		"description": "Review changes",
+		"subagent_type": "reviewer",
+		"usage": {
+			"total_tokens": 12,
+			"tool_uses": 1,
+			"duration_ms": 80
+		},
+		"uuid": "u1",
+		"session_id": "s1"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	taskMsg, ok := msg.(TaskProgressMessage)
+	require.True(t, ok, "expected TaskProgressMessage")
+	assert.Equal(t, "reviewer", taskMsg.SubagentType)
+}
+
+func TestTaskProgressSubagentTypeOmitEmpty(t *testing.T) {
+	msg := TaskProgressMessage{
+		Type:        "system",
+		Subtype:     "task_progress",
+		TaskID:      "t1",
+		Description: "d",
+		Usage:       TaskUsage{},
+		UUID:        "u",
+		SessionID:   "s",
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.NotContains(t, got, "subagent_type")
 }
 
 func TestParseMessageTaskUpdated(t *testing.T) {
@@ -1776,6 +1875,26 @@ func TestParseMessageTaskUpdated(t *testing.T) {
 			tt.check(t, taskMsg)
 		})
 	}
+}
+
+func TestParseMessageTaskUpdatedPausedStatus(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "task_updated",
+		"task_id": "t1",
+		"patch": {
+			"status": "paused"
+		},
+		"uuid": "u",
+		"session_id": "s"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	taskMsg, ok := msg.(TaskUpdatedMessage)
+	require.True(t, ok, "expected TaskUpdatedMessage")
+	assert.Equal(t, TaskRunStatusPaused, taskMsg.Patch.Status)
 }
 
 func TestParseMessageTaskNotification(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up gap-fill against the v0.2.119 TS spec. Three additions to `messages.go`:

- `TaskStartedMessage.SubagentType` — populated by the CLI when the Task tool drives a subagent run; `omitempty` since legacy task starts don't carry it.
- `TaskProgressMessage.SubagentType` — same field on the progress event; same `omitempty`.
- `TaskRunStatusPaused` — new enum value (`"paused"`) on the `task_updated` status set.

These three were present in `sdk.d.ts` but missed when PR 14b shipped the task-lifecycle subtype skeleton. No behavior change; wire-format additions only.

## Test plan

- [x] `go test ./...` — pass
- [x] `go vet ./...` and `go vet -tags integration ./...` — clean
- [x] `gofmt -l .` — empty
- [x] New unit tests in `messages_test.go`:
  - `TestParseMessageTaskStartedSubagentType` / `TestTaskStartedSubagentTypeOmitEmpty` / `TestTaskStartedSubagentTypeRoundTrip`
  - `TestParseMessageTaskProgressSubagentType` / `TestTaskProgressSubagentTypeOmitEmpty`
  - `TestParseMessageTaskUpdatedPausedStatus`
- [x] Integration placeholder `TestIntegrationTaskLifecycleFields` added (skipped — needs a CLI fixture that runs a Task-tool subagent and pauses it); tracked in `INTEGRATION-FOLLOWUPS.md`.