### PR TITLE
messages: add subagent_type + task_description on UserMessage

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -3,6 +3,7 @@
 - Backfill `TestIntegrationStopHookBackgroundTasks` when the CLI test fixture can deterministically create a long-running background task.
 - Backfill `TestIntegrationStopHookSessionCrons` when the CLI test fixture can deterministically create a session cron.
 - Backfill `TestIntegrationAssistantMessageSubagentFields` when the CLI test fixture can deterministically run a subagent task end-to-end.
+- Backfill `TestIntegrationUserMessageSubagentFields` when the CLI test fixture can deterministically run a Task-tool subagent whose tool-result user message round-trips `subagent_type` + `task_description`.
 - Backfill `TestIntegrationAssistantMessageError` when the CLI test fixture can deterministically force an upstream API failure into an `assistant` event.
 - Backfill `TestIntegrationResultMessageOriginTTFT` when the CLI test fixture can deterministically emit `origin` and/or `ttft_ms` on a result event.
 - Backfill `TestIntegrationTaskLifecycleFields` when the CLI test fixture can deterministically run a Task-tool subagent (populates `subagent_type` on `task_started`/`task_progress`) and pause a running task (emits `task_updated` with `status:"paused"`).

--- a/integration_test.go
+++ b/integration_test.go
@@ -740,6 +740,13 @@ func TestIntegrationAssistantMessageSubagentFields(t *testing.T) {
 	t.Skip("requires running a subagent task end-to-end; tracked in INTEGRATION-FOLLOWUPS.md")
 }
 
+func TestIntegrationUserMessageSubagentFields(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	t.Skip("requires CLI to emit a user-side tool-result message from a Task-tool subagent (populates user message subagent_type/task_description); tracked in INTEGRATION-FOLLOWUPS.md")
+}
+
 func TestIntegrationAssistantMessageError(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/messages.go
+++ b/messages.go
@@ -19,14 +19,16 @@ type Message interface {
 // This message type initiates or continues a conversation. The ParentToolUseID
 // field links this message to a specific tool call when providing tool results.
 type UserMessage struct {
-	Type            string               `json:"type"`                      // Always "user"
-	UUID            string               `json:"uuid,omitempty"`            // Unique message ID
-	SessionID       string               `json:"session_id"`                // Session identifier
-	Message         APIUserMessage       `json:"message"`                   // Message content
-	ParentToolUseID *string              `json:"parent_tool_use_id"`        // For tool results (null if not tool result)
-	IsSynthetic     bool                 `json:"isSynthetic,omitempty"`     // True for system-generated messages
-	ToolUseResult   interface{}          `json:"tool_use_result,omitempty"` // Tool result JSON if applicable
-	Priority        *UserMessagePriority `json:"priority,omitempty"`        // Scheduling priority
+	Type            string               `json:"type"`                       // Always "user"
+	UUID            string               `json:"uuid,omitempty"`             // Unique message ID
+	SessionID       string               `json:"session_id"`                 // Session identifier
+	Message         APIUserMessage       `json:"message"`                    // Message content
+	ParentToolUseID *string              `json:"parent_tool_use_id"`         // For tool results (null if not tool result)
+	IsSynthetic     bool                 `json:"isSynthetic,omitempty"`      // True for system-generated messages
+	ToolUseResult   interface{}          `json:"tool_use_result,omitempty"`  // Tool result JSON if applicable
+	Priority        *UserMessagePriority `json:"priority,omitempty"`         // Scheduling priority
+	SubagentType    string               `json:"subagent_type,omitempty"`    // Subagent type that produced this message
+	TaskDescription string               `json:"task_description,omitempty"` // Description of the subagent task that produced this message
 }
 
 // APIUserMessage represents the message content in Anthropic API format.

--- a/messages_test.go
+++ b/messages_test.go
@@ -261,6 +261,67 @@ func TestParseMessageUserMessage(t *testing.T) {
 	assert.Equal(t, "sess_123", userMsg.SessionID)
 }
 
+func TestParseMessageUserMessageSubagentFields(t *testing.T) {
+	input := `{
+		"type": "user",
+		"session_id": "s1",
+		"message": {
+			"role": "user",
+			"content": [{"type": "text", "text": "Tool result"}]
+		},
+		"parent_tool_use_id": null,
+		"subagent_type": "general-purpose",
+		"task_description": "Inspect repo"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	userMsg, ok := msg.(UserMessage)
+	require.True(t, ok, "expected UserMessage")
+
+	assert.Equal(t, "general-purpose", userMsg.SubagentType)
+	assert.Equal(t, "Inspect repo", userMsg.TaskDescription)
+}
+
+func TestUserMessageSubagentFieldsOmitEmpty(t *testing.T) {
+	msg := UserMessage{Type: "user", SessionID: "s1"}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.NotContains(t, got, "subagent_type")
+	assert.NotContains(t, got, "task_description")
+}
+
+func TestUserMessageSubagentFieldsRoundTrip(t *testing.T) {
+	msg := UserMessage{
+		Type:            "user",
+		SessionID:       "s1",
+		SubagentType:    "code-reviewer",
+		TaskDescription: "Review changes",
+		Message: APIUserMessage{
+			Role:    "user",
+			Content: []UserContentBlock{{Type: "text", Text: "Tool result"}},
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	parsed, err := ParseMessage(data)
+	require.NoError(t, err)
+
+	got, ok := parsed.(UserMessage)
+	require.True(t, ok, "expected UserMessage")
+
+	assert.Equal(t, msg.SubagentType, got.SubagentType)
+	assert.Equal(t, msg.TaskDescription, got.TaskDescription)
+}
+
 // TestParseMessageAssistantMessage tests parsing assistant messages.
 func TestParseMessageAssistantMessage(t *testing.T) {
 	input := `{


### PR DESCRIPTION
Mirror v0.3.150 TS SDK user-message additions:

* `UserMessage.SubagentType` (`subagent_type`, `,omitempty`) — subagent
  type that produced this message.
* `UserMessage.TaskDescription` (`task_description`, `,omitempty`) —
  description of the subagent task that produced this message.

These are the user-side companions to the assistant-side fields added in
PR #75 — a Task-tool subagent emits both user (tool-result) and
assistant messages back to the parent, and both sides now carry the
subagent labeling.

`UserMessageReplay` is intentionally untouched — the TS spec does not
add these fields to the replay variant.

Unit tests cover parse / omitempty / round-trip. Integration `t.Skip`'d
— requires the CLI to deterministically emit a Task-tool subagent's
tool-result user message; followup tracked in
`INTEGRATION-FOLLOWUPS.md`.

Ref: TS SDK v0.3.150, `SDKUserMessage` L3694 (`subagent_type`), L3698
(`task_description`).

See memory/catchup-v0.3.150/PLAN.md §"PR 19".

Verification:
* `/home/node/.openclaw/local/go/bin/go test ./...`
* `/home/node/.openclaw/local/go/bin/go vet ./...`
* `/home/node/.openclaw/local/go/bin/gofmt -l .`
* `/home/node/.openclaw/local/go/bin/go vet -tags integration ./...`
