### PR TITLE
messages: add CompactMetadata.PreservedMessages

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -7,3 +7,4 @@
 - Backfill `TestIntegrationAssistantMessageError` when the CLI test fixture can deterministically force an upstream API failure into an `assistant` event.
 - Backfill `TestIntegrationResultMessageOriginTTFT` when the CLI test fixture can deterministically emit `origin` and/or `ttft_ms` on a result event.
 - Backfill `TestIntegrationTaskLifecycleFields` when the CLI test fixture can deterministically run a Task-tool subagent (populates `subagent_type` on `task_started`/`task_progress`) and pause a running task (emits `task_updated` with `status:"paused"`).
+- Backfill `TestIntegrationCompactBoundaryPreservedMessages` when the CLI test fixture can deterministically trigger a partial compaction with messagesToKeep so the `compact_metadata.preserved_messages` block is populated.

--- a/integration_test.go
+++ b/integration_test.go
@@ -1993,3 +1993,9 @@ sys.exit(code)
 	require.NoError(t, json.Unmarshal(data, &got))
 	assert.Equal(t, map[string]interface{}{"Bash": "Read"}, got["toolAliases"])
 }
+
+func TestIntegrationCompactBoundaryPreservedMessages(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+	t.Skip("requires CLI to trigger a partial compaction that emits compact_metadata.preserved_messages (messagesToKeep populated); tracked in INTEGRATION-FOLLOWUPS.md")
+}

--- a/messages.go
+++ b/messages.go
@@ -1048,10 +1048,20 @@ type StatusMessage struct {
 // MessageType implements Message.
 func (m StatusMessage) MessageType() string { return "system" }
 
+// PreservedMessages identifies the ordered list of messagesToKeep UUIDs
+// that survived a compaction.
+//
+// Supersedes preserved_segment when present.
+type PreservedMessages struct {
+	AnchorUUID string   `json:"anchor_uuid"` // Anchor message UUID
+	UUIDs      []string `json:"uuids"`       // Ordered messagesToKeep UUIDs
+}
+
 // CompactMetadata contains details about a compaction event.
 type CompactMetadata struct {
-	Trigger   string `json:"trigger"`    // "manual" or "auto"
-	PreTokens int    `json:"pre_tokens"` // Token count before compaction
+	Trigger           string             `json:"trigger"`                      // "manual" or "auto"
+	PreTokens         int                `json:"pre_tokens"`                   // Token count before compaction
+	PreservedMessages *PreservedMessages `json:"preserved_messages,omitempty"` // Ordered messagesToKeep UUIDs
 }
 
 // PermissionDenial tracks a denied permission request.

--- a/messages_test.go
+++ b/messages_test.go
@@ -1440,6 +1440,90 @@ func TestParseMessageCompactBoundary(t *testing.T) {
 	assert.Equal(t, 198732, compactMsg.CompactMetadata.PreTokens)
 }
 
+func TestParseMessageCompactBoundaryPreservedMessages(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "compact_boundary",
+		"uuid": "550e8400-e29b-41d4-a716-446655440010",
+		"session_id": "sess_compact_123",
+		"compact_metadata": {
+			"trigger": "auto",
+			"pre_tokens": 198732,
+			"preserved_messages": {
+				"anchor_uuid": "550e8400-e29b-41d4-a716-446655440100",
+				"uuids": [
+					"550e8400-e29b-41d4-a716-446655440101",
+					"550e8400-e29b-41d4-a716-446655440102"
+				]
+			}
+		}
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	compactMsg, ok := msg.(CompactBoundaryMessage)
+	require.True(t, ok, "expected CompactBoundaryMessage")
+
+	require.NotNil(t, compactMsg.CompactMetadata.PreservedMessages)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440100", compactMsg.CompactMetadata.PreservedMessages.AnchorUUID)
+	require.Len(t, compactMsg.CompactMetadata.PreservedMessages.UUIDs, 2)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440101", compactMsg.CompactMetadata.PreservedMessages.UUIDs[0])
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440102", compactMsg.CompactMetadata.PreservedMessages.UUIDs[1])
+}
+
+func TestCompactBoundaryPreservedMessagesOmitEmpty(t *testing.T) {
+	compactMsg := CompactBoundaryMessage{
+		Type:      "system",
+		Subtype:   "compact_boundary",
+		UUID:      "550e8400-e29b-41d4-a716-446655440010",
+		SessionID: "sess_compact_123",
+		CompactMetadata: CompactMetadata{
+			Trigger:   "auto",
+			PreTokens: 100,
+		},
+	}
+
+	data, err := json.Marshal(compactMsg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	metadata, ok := got["compact_metadata"].(map[string]interface{})
+	require.True(t, ok, "expected compact_metadata object")
+	assert.NotContains(t, metadata, "preserved_messages")
+}
+
+func TestCompactBoundaryPreservedMessagesRoundTrip(t *testing.T) {
+	compactMsg := CompactBoundaryMessage{
+		Type:      "system",
+		Subtype:   "compact_boundary",
+		UUID:      "550e8400-e29b-41d4-a716-446655440010",
+		SessionID: "sess_compact_123",
+		CompactMetadata: CompactMetadata{
+			Trigger:   "manual",
+			PreTokens: 100,
+			PreservedMessages: &PreservedMessages{
+				AnchorUUID: "anchor-uuid-1",
+				UUIDs:      []string{"u-1", "u-2", "u-3"},
+			},
+		},
+	}
+
+	data, err := json.Marshal(compactMsg)
+	require.NoError(t, err)
+
+	msg, err := ParseMessage(data)
+	require.NoError(t, err)
+
+	got, ok := msg.(CompactBoundaryMessage)
+	require.True(t, ok, "expected CompactBoundaryMessage")
+	require.NotNil(t, got.CompactMetadata.PreservedMessages)
+	assert.Equal(t, compactMsg.CompactMetadata.PreservedMessages.AnchorUUID, got.CompactMetadata.PreservedMessages.AnchorUUID)
+	assert.Equal(t, compactMsg.CompactMetadata.PreservedMessages.UUIDs, got.CompactMetadata.PreservedMessages.UUIDs)
+}
+
 func TestParseMessageHookStarted(t *testing.T) {
 	input := `{
 		"type": "system",


### PR DESCRIPTION
Mirror v0.3.150 TS SDK addition to `SDKCompactBoundaryMessage.compact_metadata`:

* `PreservedMessages` struct — `AnchorUUID string`, `UUIDs []string`.
* `CompactMetadata.PreservedMessages *PreservedMessages` (`preserved_messages`, `,omitempty`).

Per the TS docstring: ordered messagesToKeep UUIDs. Supersedes
`preserved_segment` — loaders look up each UUID directly and relink
`uuids[i]` to `uuids[i-1]` (`uuids[0]` to `anchor_uuid`) instead of
walking the parentUuid chain. Unset when compaction summarizes
everything.

Unit tests cover parse / omitempty / round-trip. Integration `t.Skip`'d
— requires the CLI to deterministically trigger a partial compaction
that populates `messagesToKeep`; follow-up tracked in
`INTEGRATION-FOLLOWUPS.md`.

Ref: TS SDK v0.3.150, `SDKCompactBoundaryMessage.compact_metadata.preserved_messages` L2606–2609.