### PR TITLE
messages: add MemoryScopeOrganization variant

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -8,3 +8,4 @@
 - Backfill `TestIntegrationResultMessageOriginTTFT` when the CLI test fixture can deterministically emit `origin` and/or `ttft_ms` on a result event.
 - Backfill `TestIntegrationTaskLifecycleFields` when the CLI test fixture can deterministically run a Task-tool subagent (populates `subagent_type` on `task_started`/`task_progress`) and pause a running task (emits `task_updated` with `status:"paused"`).
 - Backfill `TestIntegrationCompactBoundaryPreservedMessages` when the CLI test fixture can deterministically trigger a partial compaction with messagesToKeep so the `compact_metadata.preserved_messages` block is populated.
+- Backfill `TestIntegrationMemoryRecallOrganizationScope` when the CLI test fixture can deterministically surface an organization-scoped memory (https URL + inline content) on a `memory_recall` system event.

--- a/integration_test.go
+++ b/integration_test.go
@@ -1999,3 +1999,9 @@ func TestIntegrationCompactBoundaryPreservedMessages(t *testing.T) {
 	skipIfNoCLI(t)
 	t.Skip("requires CLI to trigger a partial compaction that emits compact_metadata.preserved_messages (messagesToKeep populated); tracked in INTEGRATION-FOLLOWUPS.md")
 }
+
+func TestIntegrationMemoryRecallOrganizationScope(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+	t.Skip("requires CLI to surface an organization-scoped memory (https URL + inline content); tracked in INTEGRATION-FOLLOWUPS.md")
+}

--- a/messages.go
+++ b/messages.go
@@ -882,15 +882,26 @@ const (
 type MemoryScope string
 
 const (
-	MemoryScopePersonal MemoryScope = "personal"
-	MemoryScopeTeam     MemoryScope = "team"
+	MemoryScopePersonal     MemoryScope = "personal"
+	MemoryScopeTeam         MemoryScope = "team"
+	MemoryScopeOrganization MemoryScope = "organization"
 )
 
 // MemoryRecallEntry describes one recalled memory or synthesis.
 type MemoryRecallEntry struct {
-	Path    string      `json:"path"`
-	Scope   MemoryScope `json:"scope"`
-	Content string      `json:"content,omitempty"`
+	// Path is the absolute path to the memory file, a synthesis sentinel
+	// of the form "<synthesis:DIR>" when mode is "synthesize", or an
+	// https URL when scope is "organization".
+	Path string `json:"path"`
+
+	// Scope identifies the source of the memory.
+	Scope MemoryScope `json:"scope"`
+
+	// Content is the surfaced memory body. Always present for
+	// "synthesize" mode and for "organization" scope (neither has an
+	// on-disk path to lazy-load from); absent for file-backed "select"
+	// entries.
+	Content string `json:"content,omitempty"`
 }
 
 // MemoryRecallMessage reports memories surfaced into the current turn.

--- a/messages_test.go
+++ b/messages_test.go
@@ -2380,6 +2380,22 @@ func TestParseMessageMemoryRecall(t *testing.T) {
 			wantEntries:      1,
 			wantContentEntry: 0,
 		},
+		{
+			name: "select mode with organization scope",
+			input: `{
+				"type": "system",
+				"subtype": "memory_recall",
+				"mode": "select",
+				"memories": [
+					{ "path": "https://memories.example.com/org/policy.md", "scope": "organization", "content": "Org-wide policy body." }
+				],
+				"uuid": "550e8400-e29b-41d4-a716-446655440242",
+				"session_id": "sess_misc_005"
+			}`,
+			wantMode:         MemoryRecallModeSelect,
+			wantEntries:      1,
+			wantContentEntry: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -2406,6 +2422,31 @@ func TestParseMessageMemoryRecall(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMemoryRecallEntryOrganizationScopeRoundTrip(t *testing.T) {
+	in := MemoryRecallMessage{
+		Type:      "system",
+		Subtype:   "memory_recall",
+		Mode:      MemoryRecallModeSelect,
+		Memories:  []MemoryRecallEntry{{Path: "https://memories.example.com/org/policy.md", Scope: MemoryScopeOrganization, Content: "Org-wide policy body."}},
+		UUID:      "550e8400-e29b-41d4-a716-446655440243",
+		SessionID: "sess_misc_006",
+	}
+
+	data, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	parsed, err := ParseMessage(data)
+	require.NoError(t, err)
+
+	out, ok := parsed.(MemoryRecallMessage)
+	require.True(t, ok)
+	require.Len(t, out.Memories, 1)
+	assert.Equal(t, MemoryScopeOrganization, out.Memories[0].Scope)
+	assert.Equal(t, "organization", string(out.Memories[0].Scope))
+	assert.Equal(t, "https://memories.example.com/org/policy.md", out.Memories[0].Path)
+	assert.Equal(t, "Org-wide policy body.", out.Memories[0].Content)
 }
 
 func TestParseMessageMirrorError(t *testing.T) {


### PR DESCRIPTION
Mirror v0.3.150 TS SDK widening of `SDKMemoryRecallMessage.memories[].scope`:

* `MemoryScopeOrganization` constant (`"organization"`), appended after `MemoryScopeTeam`.
* `MemoryRecallEntry.Path` / `.Content` docstrings refreshed to match TS: `path` may be an `https://` URL when scope is `"organization"`; `content` is always present for `"synthesize"` mode and for `"organization"` scope (no on-disk lazy-load target).

Tests: extend `TestParseMessageMemoryRecall` with an `organization`-scope case
and add a dedicated round-trip test that asserts the new constant survives a
marshal -> `ParseMessage` cycle. Integration `t.Skip`'d - requires the CLI to
deterministically surface an org-scoped memory; follow-up tracked in
`INTEGRATION-FOLLOWUPS.md`.

Ref: TS SDK v0.3.150, `SDKMemoryRecallMessage.memories[].scope` L3231 +
docstrings L3228 / L3233.

See memory/catchup-v0.3.150/PLAN.md §"PR 21".
