### PR TITLE
messages: drop omitempty on PartialAssistantMessage.parent_tool_use_id

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -9,3 +9,4 @@
 - Backfill `TestIntegrationTaskLifecycleFields` when the CLI test fixture can deterministically run a Task-tool subagent (populates `subagent_type` on `task_started`/`task_progress`) and pause a running task (emits `task_updated` with `status:"paused"`).
 - Backfill `TestIntegrationCompactBoundaryPreservedMessages` when the CLI test fixture can deterministically trigger a partial compaction with messagesToKeep so the `compact_metadata.preserved_messages` block is populated.
 - Backfill `TestIntegrationMemoryRecallOrganizationScope` when the CLI test fixture can deterministically surface an organization-scoped memory (https URL + inline content) on a `memory_recall` system event.
+- Backfill `TestIntegrationPartialAssistantParentToolUseID` when the CLI test fixture can deterministically emit a streaming partial event nested under a Task-tool subagent so `parent_tool_use_id` carries a non-null tool_use id.

--- a/integration_test.go
+++ b/integration_test.go
@@ -2005,3 +2005,9 @@ func TestIntegrationMemoryRecallOrganizationScope(t *testing.T) {
 	skipIfNoCLI(t)
 	t.Skip("requires CLI to surface an organization-scoped memory (https URL + inline content); tracked in INTEGRATION-FOLLOWUPS.md")
 }
+
+func TestIntegrationPartialAssistantParentToolUseID(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+	t.Skip("requires CLI to deterministically emit a streaming partial event nested under a Task-tool subagent (parent_tool_use_id non-null); tracked in INTEGRATION-FOLLOWUPS.md")
+}

--- a/messages.go
+++ b/messages.go
@@ -593,11 +593,14 @@ type SystemPlugin struct {
 // These messages are only emitted when IncludePartialMessages is true in Options.
 // They contain raw streaming events for real-time display.
 type PartialAssistantMessage struct {
-	Type            string          `json:"type"`  // Always "stream_event"
-	Event           json.RawMessage `json:"event"` // Raw streaming event
-	ParentToolUseID *string         `json:"parent_tool_use_id,omitempty"`
-	UUID            string          `json:"uuid"`       // Unique message ID
-	SessionID       string          `json:"session_id"` // Session identifier
+	Type  string          `json:"type"`  // Always "stream_event"
+	Event json.RawMessage `json:"event"` // Raw streaming event
+	// ParentToolUseID is the parent tool_use ID when the partial event is
+	// nested inside a subagent invocation (Task tool); nil for top-level
+	// streaming. The wire key is always present (string or null).
+	ParentToolUseID *string `json:"parent_tool_use_id"`
+	UUID            string  `json:"uuid"`       // Unique message ID
+	SessionID       string  `json:"session_id"` // Session identifier
 }
 
 // MessageType implements Message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -670,6 +670,83 @@ func TestParseMessageStreamEvent(t *testing.T) {
 	assert.False(t, streamEvent.Timestamp.IsZero())
 }
 
+// TestParseMessagePartialAssistantParentToolUseID exercises the
+// parent_tool_use_id wire-shape contract on PartialAssistantMessage:
+// the key is always present (string or null), never omitted.
+func TestParseMessagePartialAssistantParentToolUseID(t *testing.T) {
+	t.Run("parses string value", func(t *testing.T) {
+		input := `{
+			"type": "stream_event",
+			"event": {"type":"text_delta","delta":"hi"},
+			"parent_tool_use_id": "toolu_parent",
+			"uuid": "550e8400-e29b-41d4-a716-446655440301",
+			"session_id": "sess_partial_001"
+		}`
+
+		msg, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+
+		partial, ok := msg.(PartialAssistantMessage)
+		require.True(t, ok)
+		require.NotNil(t, partial.ParentToolUseID)
+		assert.Equal(t, "toolu_parent", *partial.ParentToolUseID)
+	})
+
+	t.Run("parses null value", func(t *testing.T) {
+		input := `{
+			"type": "stream_event",
+			"event": {"type":"text_delta","delta":"hi"},
+			"parent_tool_use_id": null,
+			"uuid": "550e8400-e29b-41d4-a716-446655440302",
+			"session_id": "sess_partial_002"
+		}`
+
+		msg, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+
+		partial, ok := msg.(PartialAssistantMessage)
+		require.True(t, ok)
+		assert.Nil(t, partial.ParentToolUseID)
+	})
+
+	t.Run("nil marshals as explicit null (not omitted)", func(t *testing.T) {
+		in := PartialAssistantMessage{
+			Type:            "stream_event",
+			Event:           json.RawMessage(`{"type":"text_delta","delta":"hi"}`),
+			ParentToolUseID: nil,
+			UUID:            "550e8400-e29b-41d4-a716-446655440303",
+			SessionID:       "sess_partial_003",
+		}
+
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		assert.Contains(t, string(data), `"parent_tool_use_id":null`)
+	})
+
+	t.Run("string round-trip", func(t *testing.T) {
+		parent := "toolu_parent_roundtrip"
+		in := PartialAssistantMessage{
+			Type:            "stream_event",
+			Event:           json.RawMessage(`{"type":"text_delta","delta":"hi"}`),
+			ParentToolUseID: &parent,
+			UUID:            "550e8400-e29b-41d4-a716-446655440304",
+			SessionID:       "sess_partial_004",
+		}
+
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		parsed, err := ParseMessage(data)
+		require.NoError(t, err)
+
+		out, ok := parsed.(PartialAssistantMessage)
+		require.True(t, ok)
+		require.NotNil(t, out.ParentToolUseID)
+		assert.Equal(t, parent, *out.ParentToolUseID)
+	})
+}
+
 // TestParseMessageTodoUpdate tests parsing todo updates.
 func TestParseMessageTodoUpdate(t *testing.T) {
 	input := `{


### PR DESCRIPTION
TS SDK `SDKPartialAssistantMessage.parent_tool_use_id` is a required field
typed `string | null` — the key is always present on the wire, valued either
a string or `null`. The Go field tag was `,omitempty`, which marshals a nil
pointer to an absent key — divergent from the TS schema and breaks consumers
that parse Go-emitted partial messages against it.

Drop `,omitempty` so a nil `ParentToolUseID` serializes as
`"parent_tool_use_id": null`. Docstring refreshed to call out the wire
contract.

Tests: new `TestParseMessagePartialAssistantParentToolUseID` covers parse
(string + null), marshal-nil-emits-null-key, and string round-trip.
Integration `t.Skip`'d — requires the CLI to deterministically emit a
streaming partial event nested under a Task-tool subagent; follow-up tracked
in `INTEGRATION-FOLLOWUPS.md`.

Ref: TS SDK v0.3.150, `SDKPartialAssistantMessage` L3292–3299.