### PR TITLE
client: add encoding option to read_file control request

### DIFF
--- a/client.go
+++ b/client.go
@@ -833,6 +833,7 @@ func (s *Stream) SeedReadState(ctx context.Context, path string, mtime int64) er
 }
 
 // ReadFile reads a file from the session filesystem using CLI read permissions.
+// Use ReadFileOptions.Encoding="base64" when reading binary content.
 // Unlike the TypeScript SDK, CLI errors are returned to the caller instead of
 // being swallowed as a nil response.
 func (s *Stream) ReadFile(
@@ -844,8 +845,13 @@ func (s *Stream) ReadFile(
 		Subtype: "read_file",
 		Path:    path,
 	}
-	if opts != nil && opts.MaxBytes > 0 {
-		body.MaxBytes = &opts.MaxBytes
+	if opts != nil {
+		if opts.MaxBytes > 0 {
+			body.MaxBytes = &opts.MaxBytes
+		}
+		if opts.Encoding != "" {
+			body.Encoding = opts.Encoding
+		}
 	}
 	resp, err := s.sendSDKControlRequest(ctx, body)
 	if err != nil {

--- a/client_file_plugin_control_test.go
+++ b/client_file_plugin_control_test.go
@@ -205,6 +205,82 @@ func TestStreamReadFileMaxBytesZeroOmitted(t *testing.T) {
 	)
 }
 
+// TestStreamReadFileWithEncoding asserts the encoding option threads into the
+// wire request and that a base64 response is parsed back onto the struct.
+func TestStreamReadFileWithEncoding(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{
+			"contents": "aGVsbG8=",
+			"absPath":  "/tmp/example.bin",
+			"encoding": "base64",
+		}),
+	)
+
+	var got *SDKControlReadFileResponse
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		var err error
+		got, err = stream.ReadFile(ctx, "example.bin", &ReadFileOptions{
+			Encoding: "base64",
+		})
+		return err
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "aGVsbG8=", got.Contents)
+	assert.Equal(t, "/tmp/example.bin", got.AbsPath)
+	assert.Equal(t, "base64", got.Encoding)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"read_file","path":"example.bin","encoding":"base64"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+// TestStreamReadFileEncodingEmptyOmitted asserts an empty Encoding string
+// elides the key on the wire.
+func TestStreamReadFileEncodingEmptyOmitted(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{}),
+	)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		_, err := stream.ReadFile(ctx, "example.txt", &ReadFileOptions{
+			Encoding: "",
+		})
+		return err
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"read_file","path":"example.txt"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+// TestStreamReadFileResponseEncodingDefaultsUTF8 asserts a response missing the
+// encoding field unmarshals to an empty Encoding string.
+func TestStreamReadFileResponseEncodingDefaultsUTF8(t *testing.T) {
+	stream, _, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{
+			"contents": "hello",
+			"absPath":  "/tmp/example.txt",
+		}),
+	)
+
+	var got *SDKControlReadFileResponse
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		var err error
+		got, err = stream.ReadFile(ctx, "example.txt", &ReadFileOptions{
+			Encoding: "utf-8",
+		})
+		return err
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "hello", got.Contents)
+	assert.Empty(t, got.Encoding)
+}
+
 func TestStreamReloadPluginsParsesResponse(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		stream, transport, _ := newStreamControlTest(

--- a/integration_test.go
+++ b/integration_test.go
@@ -4,6 +4,7 @@ package claudeagent
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -1680,6 +1681,47 @@ func TestIntegrationStreamFileAndRuntime(t *testing.T) {
 		assert.Equal(t, markerContent, got.Contents)
 		assert.Equal(t, filepath.Clean(markerPath), filepath.Clean(got.AbsPath))
 		assert.False(t, got.Truncated)
+	})
+
+	t.Run("read_file_base64", func(t *testing.T) {
+		tempDir := t.TempDir()
+		binaryPath := filepath.Join(tempDir, "marker.bin")
+		binaryBytes := []byte{0x00, 0x01, 0x02, 0xFF, 0xFE, 'h', 'i'}
+		require.NoError(t, os.WriteFile(binaryPath, binaryBytes, 0o644))
+
+		opts := append(isolatedClientOptions(t),
+			WithCwd(tempDir),
+			WithSystemPrompt("You are a helpful assistant."),
+			WithPermissionMode(PermissionModeBypassAll),
+			WithAllowDangerouslySkipPermissions(true),
+		)
+		client, err := NewClient(opts...)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, client.Close())
+		})
+
+		ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer cancel()
+
+		stream, err := client.Stream(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, stream.Close())
+		})
+
+		got, err := stream.ReadFile(ctx, "marker.bin", &ReadFileOptions{
+			Encoding: "base64",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, "base64", got.Encoding,
+			"CLI should echo encoding=base64 when honored")
+
+		decoded, err := base64.StdEncoding.DecodeString(got.Contents)
+		require.NoError(t, err)
+		assert.Equal(t, binaryBytes, decoded)
+		assert.Equal(t, filepath.Clean(binaryPath), filepath.Clean(got.AbsPath))
 	})
 
 	t.Run("seed_read_state", func(t *testing.T) {

--- a/messages.go
+++ b/messages.go
@@ -305,6 +305,7 @@ type SDKControlRequestBody struct {
 	DryRun                 *bool                               `json:"dry_run,omitempty"`                // For rewind_files
 	Path                   string                              `json:"path,omitempty"`                   // For read_file/seed_read_state
 	MaxBytes               *int                                `json:"max_bytes,omitempty"`              // For read_file
+	Encoding               string                              `json:"encoding,omitempty"`               // For read_file ("utf-8"|"base64")
 	MTime                  *int64                              `json:"mtime,omitempty"`                  // For seed_read_state
 	Settings               *map[string]interface{}             `json:"settings,omitempty"`               // For apply_flag_settings
 	TaskID                 string                              `json:"task_id,omitempty"`                // For stop_task

--- a/query_types.go
+++ b/query_types.go
@@ -83,6 +83,11 @@ type RewindFilesResult struct {
 // ReadFileOptions controls Stream.ReadFile.
 type ReadFileOptions struct {
 	MaxBytes int `json:"maxBytes,omitempty"`
+	// Encoding selects how the CLI encodes file bytes in the response.
+	// Valid values are "utf-8" (default; lossy for binary) and "base64"
+	// (required for arbitrary binary). Empty string lets the CLI pick its
+	// default.
+	Encoding string `json:"encoding,omitempty"`
 }
 
 // SDKControlReadFileResponse contains file contents from Stream.ReadFile.
@@ -90,6 +95,9 @@ type SDKControlReadFileResponse struct {
 	Contents  string `json:"contents"`
 	AbsPath   string `json:"absPath"`
 	Truncated bool   `json:"truncated,omitempty"`
+	// Encoding is set to "base64" when the CLI honored a base64 request.
+	// Empty string means utf-8, including when older CLIs ignore the request.
+	Encoding string `json:"encoding,omitempty"`
 }
 
 // SDKControlReloadPluginsResponse reports refreshed session components.


### PR DESCRIPTION
TS SDK v0.3.150 adds `encoding?: 'utf-8' | 'base64'` to the `read_file` control
request and a matching `encoding?: 'base64'` field on the response (set only
when the CLI honored a base64 request; absent means utf-8, including for older
CLIs that ignored the request field).

Thread the new field through `SDKControlRequestBody`, `ReadFileOptions`, and
`SDKControlReadFileResponse`. `Stream.ReadFile` now passes the option through
when non-empty; an empty string preserves the current default (utf-8) and elides
the key on the wire for older-CLI compatibility.

Tests:
- New unit tests assert the encoding wires into the request, an empty Encoding
  elides the key, and a response missing `encoding` parses as the utf-8 default.
- The `TestIntegrationStreamFileAndRuntime` group gains a `read_file_base64`
  sub-test that writes a binary marker (incl. bytes > 0x7F), reads it back with
  `encoding=base64`, and asserts a byte-for-byte round-trip after base64 decode.

Refs: TS SDK v0.3.150, `SDKControlReadFileRequest` L2949–2957,
`SDKControlReadFileResponse` L2962–2970.