### PR TITLE
client: document apply_flag_settings null-value clear semantics

### DIFF
--- a/client.go
+++ b/client.go
@@ -889,8 +889,17 @@ func (s *Stream) ReloadPlugins(
 	return &out, nil
 }
 
-// ApplyFlagSettings merges settings into the active flag settings layer.
-// Top-level keys are shallow-merged by the CLI across successive calls.
+// ApplyFlagSettings merges the provided settings into the flag settings layer,
+// updating the active configuration. Top-level keys are shallow-merged by the
+// CLI across successive calls and fall back to lower-precedence sources when
+// absent (an omitted key is a no-op).
+//
+// To clear a previously-set top-level key from the flag layer, pass it
+// explicitly with a nil value - this marshals to JSON null on the wire, which
+// the CLI treats as a clear-this-key signal. Passing nil as the whole settings
+// map sends an empty object (no-op for all keys).
+//
+// Only available in streaming input mode.
 func (s *Stream) ApplyFlagSettings(
 	ctx context.Context,
 	settings map[string]interface{},

--- a/client_file_plugin_control_test.go
+++ b/client_file_plugin_control_test.go
@@ -399,6 +399,46 @@ func TestStreamApplyFlagSettingsNil(t *testing.T) {
 	)
 }
 
+// TestStreamApplyFlagSettingsNullValue asserts that a nil interface{} value for
+// a top-level key marshals to JSON null on the wire - the v0.3.150 contract
+// for clearing a key from the flag layer.
+func TestStreamApplyFlagSettingsNullValue(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.ApplyFlagSettings(ctx, map[string]interface{}{
+			"clearMe": nil,
+		})
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"apply_flag_settings","settings":{"clearMe":null}}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+// TestStreamApplyFlagSettingsMixedNullValues asserts a mixed map with both
+// concrete values and explicit nils round-trips with each key preserved and
+// nil values rendered as JSON null.
+func TestStreamApplyFlagSettingsMixedNullValues(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.ApplyFlagSettings(ctx, map[string]interface{}{
+			"keep":  "value",
+			"clear": nil,
+			"num":   7,
+		})
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"apply_flag_settings","settings":{"keep":"value","clear":null,"num":7}}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
 func TestStreamStopTaskWireShape(t *testing.T) {
 	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -1741,7 +1741,17 @@ func TestIntegrationStreamFileAndRuntime(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 
+		// Empty-map call: baseline (was the original assertion).
 		require.NoError(t, stream.ApplyFlagSettings(ctx, map[string]interface{}{}))
+
+		// Set a flag key, then clear it with an explicit nil value. The CLI is
+		// the authority on flag-key validation; there is no read-back API yet.
+		require.NoError(t, stream.ApplyFlagSettings(ctx, map[string]interface{}{
+			"verbose": true,
+		}))
+		require.NoError(t, stream.ApplyFlagSettings(ctx, map[string]interface{}{
+			"verbose": nil,
+		}))
 	})
 
 	t.Run("deferred_runtime_methods", func(t *testing.T) {


### PR DESCRIPTION
TS SDK v0.3.150 narrows `Stream.applyFlagSettings` to `[K in keyof Settings]?: Settings[K] | null` and documents that a `null` value clears that top-level key from the flag layer while `undefined` / a missing key is a no-op (sdk.d.ts L2170–2180).

The Go SDK is already wire-compatible — `map[string]interface{}{"k": nil}` marshals to `{"k": null}` via the stdlib. This PR refreshes the `Stream.ApplyFlagSettings` docstring to make the contract explicit and pins the wire shape with two new unit tests:

- `TestStreamApplyFlagSettingsNullValue` — single nil-valued key → JSON null.
- `TestStreamApplyFlagSettingsMixedNullValues` — mixed concrete + nil round-trip.

The `apply_flag_settings` integration sub-test inside `TestIntegrationStreamFileAndRuntime` is extended to set a flag key, then clear it with a follow-up null-valued call, both via live CLI round-trip.

Refs: TS SDK v0.3.150, `applyFlagSettings` signature L2170–2180, `SDKControlApplyFlagSettingsRequest` L2617–2622 (wire-shape unchanged).