### PR TITLE
client: support submit_feedback and host_auth_token_refresh control subtypes

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -10,3 +10,4 @@
 - Backfill `TestIntegrationCompactBoundaryPreservedMessages` when the CLI test fixture can deterministically trigger a partial compaction with messagesToKeep so the `compact_metadata.preserved_messages` block is populated.
 - Backfill `TestIntegrationMemoryRecallOrganizationScope` when the CLI test fixture can deterministically surface an organization-scoped memory (https URL + inline content) on a `memory_recall` system event.
 - Backfill `TestIntegrationPartialAssistantParentToolUseID` when the CLI test fixture can deterministically emit a streaming partial event nested under a Task-tool subagent so `parent_tool_use_id` carries a non-null tool_use id.
+- Backfill `TestIntegrationHostAuthTokenRefresh` when a real auth-failure path or a CLI-side fixture flag can deterministically trigger the `host_auth_token_refresh` control request. Currently not triggerable from the CLI in standard integration runs; verified via unit test.

--- a/client.go
+++ b/client.go
@@ -923,6 +923,30 @@ func (s *Stream) StopTask(ctx context.Context, taskID string) error {
 	return err
 }
 
+// SubmitFeedbackOptions configures Stream.SubmitFeedback.
+type SubmitFeedbackOptions struct {
+	// Surface identifies the UI surface that originated the feedback.
+	Surface string
+}
+
+// SubmitFeedback sends free-form session feedback to the CLI.
+//
+// Only available in streaming input mode.
+func (s *Stream) SubmitFeedback(
+	ctx context.Context, description string, opts ...SubmitFeedbackOptions,
+) error {
+	var o SubmitFeedbackOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype:     "submit_feedback",
+		Description: description,
+		Surface:     o.Surface,
+	})
+	return err
+}
+
 // BackgroundTasks backgrounds in-flight foreground tasks (Bash commands and
 // subagents). When toolUseID is non-empty, only the task started by that
 // tool_use block is backgrounded; when empty, all foreground tasks are

--- a/client_file_plugin_control_test.go
+++ b/client_file_plugin_control_test.go
@@ -439,6 +439,49 @@ func TestStreamApplyFlagSettingsMixedNullValues(t *testing.T) {
 	)
 }
 
+func TestStreamSubmitFeedbackMinimal(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.SubmitFeedback(ctx, "ship it")
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"submit_feedback","description":"ship it"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamSubmitFeedbackWithSurface(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.SubmitFeedback(ctx, "looks good",
+			SubmitFeedbackOptions{Surface: "rating-thumb"})
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"submit_feedback","description":"looks good","surface":"rating-thumb"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamSubmitFeedbackOmitsEmptySurface(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.SubmitFeedback(ctx, "hi", SubmitFeedbackOptions{})
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"submit_feedback","description":"hi"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
 func TestStreamStopTaskWireShape(t *testing.T) {
 	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -1754,6 +1754,17 @@ func TestIntegrationStreamFileAndRuntime(t *testing.T) {
 		}))
 	})
 
+	t.Run("submit_feedback", func(t *testing.T) {
+		stream, _ := newFileStream(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		require.NoError(t, stream.SubmitFeedback(ctx, "integration test ping"))
+		require.NoError(t, stream.SubmitFeedback(ctx,
+			"with surface", SubmitFeedbackOptions{Surface: "integration"}))
+	})
+
 	t.Run("deferred_runtime_methods", func(t *testing.T) {
 		t.Skip("not triggerable from CLI yet: RewindFiles needs file " +
 			"checkpointing setup, ReloadPlugins needs a plugin fixture, " +

--- a/messages.go
+++ b/messages.go
@@ -308,6 +308,8 @@ type SDKControlRequestBody struct {
 	Encoding               string                              `json:"encoding,omitempty"`               // For read_file ("utf-8"|"base64")
 	MTime                  *int64                              `json:"mtime,omitempty"`                  // For seed_read_state
 	Settings               *map[string]interface{}             `json:"settings,omitempty"`               // For apply_flag_settings
+	Description            string                              `json:"description,omitempty"`            // For submit_feedback
+	Surface                string                              `json:"surface,omitempty"`                // For submit_feedback
 	TaskID                 string                              `json:"task_id,omitempty"`                // For stop_task
 	ServerName             string                              `json:"server_name,omitempty"`            // For mcp_message (snake_case)
 	MCPServerName          string                              `json:"serverName,omitempty"`             // For mcp_reconnect/mcp_toggle/mcp_set_servers (camelCase)

--- a/options.go
+++ b/options.go
@@ -63,6 +63,10 @@ type Options struct {
 	// OnElicitation handles MCP server requests for user input.
 	OnElicitation OnElicitationFunc
 
+	// GetHostAuthToken handles host-auth-token refresh requests from the CLI.
+	// If unset, the SDK replies with an error response.
+	GetHostAuthToken GetHostAuthTokenFunc
+
 	// Hooks register lifecycle callbacks for events like tool use.
 	Hooks map[HookType][]HookConfig
 
@@ -881,6 +885,17 @@ func WithOnElicitation(fn OnElicitationFunc) Option {
 	}
 }
 
+// WithGetHostAuthToken registers a callback that refreshes host auth tokens on
+// CLI request.
+//
+// If unset, the SDK responds with an error to any host_auth_token_refresh
+// control request.
+func WithGetHostAuthToken(fn GetHostAuthTokenFunc) Option {
+	return func(o *Options) {
+		o.GetHostAuthToken = fn
+	}
+}
+
 // WithHooks registers lifecycle callbacks.
 //
 // Example:
@@ -1053,6 +1068,11 @@ type CanUseToolFunc func(ctx context.Context, req ToolPermissionRequest) Permiss
 //
 // Returning a non-nil error converts the response to action="cancel".
 type OnElicitationFunc func(ctx context.Context, req ElicitationRequest) (ElicitationResult, error)
+
+// GetHostAuthTokenFunc returns a fresh host auth token.
+//
+// The context is canceled when the CLI cancels the refresh request.
+type GetHostAuthTokenFunc func(ctx context.Context) (string, error)
 
 // ElicitationRequest is the input to the OnElicitation callback.
 type ElicitationRequest struct {

--- a/protocol.go
+++ b/protocol.go
@@ -195,6 +195,10 @@ func (p *Protocol) handleControlRequest(ctx context.Context, req ControlRequest)
 	case "hook_callback":
 		resp = p.handleHookCallback(ctx, req)
 
+	// Host auth token refresh from CLI.
+	case "host_auth_token_refresh":
+		resp = p.handleHostAuthTokenRefresh(ctx, req)
+
 	// MCP message from CLI (mcp_message) - routes to in-process MCP server.
 	case "mcp_message":
 		resp = p.handleMCPMessage(ctx, req)
@@ -266,6 +270,42 @@ func (p *Protocol) handlePermissionRequest(ctx context.Context, req ControlReque
 			Subtype:   "success",
 			RequestID: req.RequestID,
 			Response:  respData,
+		},
+	}
+}
+
+// handleHostAuthTokenRefresh services a host_auth_token_refresh control
+// request by invoking the configured callback.
+func (p *Protocol) handleHostAuthTokenRefresh(
+	ctx context.Context, req ControlRequest,
+) SDKControlResponse {
+	if p.options.GetHostAuthToken == nil {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "error",
+				RequestID: req.RequestID,
+				Error:     "GetHostAuthToken callback is not provided",
+			},
+		}
+	}
+	token, err := p.options.GetHostAuthToken(ctx)
+	if err != nil {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "error",
+				RequestID: req.RequestID,
+				Error:     err.Error(),
+			},
+		}
+	}
+	return SDKControlResponse{
+		Type: "control_response",
+		Response: SDKControlResponseBody{
+			Subtype:   "success",
+			RequestID: req.RequestID,
+			Response:  map[string]interface{}{"authToken": token},
 		},
 	}
 }

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -850,6 +850,62 @@ func TestProtocolHandleElicitationRequest(t *testing.T) {
 	})
 }
 
+func TestProtocolHandleHostAuthTokenRefresh(t *testing.T) {
+	t.Run("callback returns token", func(t *testing.T) {
+		opts := NewOptions()
+		opts.GetHostAuthToken = func(ctx context.Context) (string, error) {
+			return "abc", nil
+		}
+		protocol := NewProtocol(nil, opts)
+
+		resp := protocol.handleHostAuthTokenRefresh(context.Background(), ControlRequest{
+			Type:      "control",
+			Subtype:   "host_auth_token_refresh",
+			RequestID: "req_host_auth",
+		})
+
+		assert.Equal(t, "control_response", resp.Type)
+		assert.Equal(t, "success", resp.Response.Subtype)
+		assert.Equal(t, "req_host_auth", resp.Response.RequestID)
+		assert.Equal(t, map[string]interface{}{"authToken": "abc"}, resp.Response.Response)
+	})
+
+	t.Run("callback absent errors", func(t *testing.T) {
+		opts := NewOptions()
+		protocol := NewProtocol(nil, opts)
+
+		resp := protocol.handleHostAuthTokenRefresh(context.Background(), ControlRequest{
+			Type:      "control",
+			Subtype:   "host_auth_token_refresh",
+			RequestID: "req_host_auth",
+		})
+
+		assert.Equal(t, "control_response", resp.Type)
+		assert.Equal(t, "error", resp.Response.Subtype)
+		assert.Equal(t, "req_host_auth", resp.Response.RequestID)
+		assert.Contains(t, resp.Response.Error, "GetHostAuthToken")
+	})
+
+	t.Run("callback returns error", func(t *testing.T) {
+		opts := NewOptions()
+		opts.GetHostAuthToken = func(ctx context.Context) (string, error) {
+			return "", errors.New("refresh failed")
+		}
+		protocol := NewProtocol(nil, opts)
+
+		resp := protocol.handleHostAuthTokenRefresh(context.Background(), ControlRequest{
+			Type:      "control",
+			Subtype:   "host_auth_token_refresh",
+			RequestID: "req_host_auth",
+		})
+
+		assert.Equal(t, "control_response", resp.Type)
+		assert.Equal(t, "error", resp.Response.Subtype)
+		assert.Equal(t, "req_host_auth", resp.Response.RequestID)
+		assert.Equal(t, "refresh failed", resp.Response.Error)
+	})
+}
+
 // TestProtocolHookCallback tests hook invocation.
 func TestProtocolHookCallback(t *testing.T) {
 	t.Run("PreToolUse hook", func(t *testing.T) {


### PR DESCRIPTION
TS SDK v0.3.150 extends `SDKControlRequestInner` with two new control subtypes (sdk.d.ts L3008):

- `submit_feedback` — client→server. The SDK consumer records textual feedback against the active session. Adds `Stream.SubmitFeedback` with an optional `SubmitFeedbackOptions.Surface`, mirroring the existing `Stream.StopTask` / `Stream.ApplyFlagSettings` shape.
- `host_auth_token_refresh` — server→client. The CLI asks the SDK consumer for a fresh host auth token. Adds `Options.GetHostAuthToken` callback + `WithGetHostAuthToken` builder + a dispatch case in `Protocol.handleControlRequest`, mirroring the existing `OnElicitation` and `CanUseTool` wiring.

Wire shapes are recovered from `sdk.mjs` — the published `.d.ts` declares both subtypes only via the union member name and omits the interface bodies. Unit tests pin the on-wire JSON for both surfaces (`TestStreamSubmitFeedback*` in `client_file_plugin_control_test.go` + `TestProtocolHandleHostAuthTokenRefresh` in `protocol_test.go`), and the `submit_feedback` integration sub-test inside `TestIntegrationStreamFileAndRuntime` exercises the live CLI round-trip. `host_auth_token_refresh` is not triggerable from the CLI without a real auth-failure path; tracked in `INTEGRATION-FOLLOWUPS.md`.

`oauth_token_refresh` and `message_rated` (sibling additions to the same union) are deferred per `PLAN.md` PR-25 scope.

Refs: TS SDK v0.3.150 `sdk.d.ts` L3008 (union add), `sdk.mjs` wire shapes for both subtypes.