### PR TITLE
hooks: support PostToolUse updatedToolOutput convenience field

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -2,6 +2,7 @@
 
 - Backfill `TestIntegrationStopHookBackgroundTasks` when the CLI test fixture can deterministically create a long-running background task.
 - Backfill `TestIntegrationStopHookSessionCrons` when the CLI test fixture can deterministically create a session cron.
+- Backfill `TestIntegrationPostToolUseUpdatedToolOutput` when the CLI test fixture can deterministically run a tool whose output a PostToolUse hook rewrites, so the model receives the rewritten value rather than the original tool response.
 - Backfill `TestIntegrationAssistantMessageSubagentFields` when the CLI test fixture can deterministically run a subagent task end-to-end.
 - Backfill `TestIntegrationUserMessageSubagentFields` when the CLI test fixture can deterministically run a Task-tool subagent whose tool-result user message round-trips `subagent_type` + `task_description`.
 - Backfill `TestIntegrationAssistantMessageError` when the CLI test fixture can deterministically force an upstream API failure into an `assistant` event.

--- a/integration_test.go
+++ b/integration_test.go
@@ -718,6 +718,14 @@ func TestIntegrationHookContinueOnBlock(t *testing.T) {
 	t.Skip("not directly assertable from CLI: continueOnBlock affects the CLI's turn-continuation decision after a blocking hook, not anything observable on the SDK transport")
 }
 
+func TestIntegrationPostToolUseUpdatedToolOutput(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// TODO: Backfill when a deterministic PostToolUse rewrite fixture is available.
+	t.Skip("not triggerable from CLI without a deterministic tool call whose output a PostToolUse hook rewrites; tracked in INTEGRATION-FOLLOWUPS.md")
+}
+
 func TestIntegrationStopHookBackgroundTasks(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/options.go
+++ b/options.go
@@ -1827,8 +1827,10 @@ const (
 // the session exits or continues with a new prompt (Ralph Wiggum pattern).
 //
 // For PreToolUse hooks, Modify is automatically translated into the
-// hookSpecificOutput.updatedInput format expected by the CLI. Set
-// HookSpecificOutput directly for finer control over the response.
+// hookSpecificOutput.updatedInput format expected by the CLI. For
+// PostToolUse hooks, UpdatedToolOutput is automatically translated
+// into hookSpecificOutput.updatedToolOutput. Set HookSpecificOutput
+// directly for finer control over the response.
 type HookResult struct {
 	Continue bool                   // Continue execution (false = abort)
 	Modify   map[string]interface{} // Modifications to apply
@@ -1851,6 +1853,14 @@ type HookResult struct {
 	// SystemMessage is displayed to Claude as context when blocking exit.
 	// Use this to provide iteration counts or other status information.
 	SystemMessage string
+
+	// UpdatedToolOutput replaces the tool output sent to the model on
+	// PostToolUse hooks. The value is forwarded verbatim as
+	// hookSpecificOutput.updatedToolOutput; any JSON-encodable value is
+	// accepted. Ignored for non-PostToolUse hooks. Set HookSpecificOutput
+	// directly for finer control or to address the deprecated MCP-only
+	// updatedMCPToolOutput field.
+	UpdatedToolOutput interface{}
 
 	// HookSpecificOutput provides raw hookSpecificOutput for the CLI
 	// response. When set, this takes precedence over auto-translation

--- a/protocol.go
+++ b/protocol.go
@@ -1557,6 +1557,11 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 			hookSpecificOutput[key] = value
 		}
 		resp["hookSpecificOutput"] = hookSpecificOutput
+	} else if result.UpdatedToolOutput != nil {
+		resp["hookSpecificOutput"] = map[string]interface{}{
+			"hookEventName":     "PostToolUse",
+			"updatedToolOutput": result.UpdatedToolOutput,
+		}
 	} else if len(result.Modify) > 0 {
 		// Auto-translate Modify into the hookSpecificOutput format
 		// expected by the CLI. PreToolUse and PermissionRequest hooks

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -2591,7 +2591,7 @@ func TestBuildHookResponse_PreToolUseUpdatedInput(t *testing.T) {
 		assert.Equal(t, "ls /tmp", updatedInput["command"])
 	})
 
-	t.Run("PostToolUse falls through to legacy modify", func(t *testing.T) {
+	t.Run("PostToolUse without UpdatedToolOutput falls through to legacy modify", func(t *testing.T) {
 		result := HookResult{
 			Continue: true,
 			Modify: map[string]interface{}{
@@ -2640,6 +2640,77 @@ func TestBuildHookResponse_PreToolUseUpdatedInput(t *testing.T) {
 		// Legacy modify should NOT be present.
 		_, hasModify := resp["modify"]
 		assert.False(t, hasModify)
+	})
+}
+
+// TestBuildHookResponse_PostToolUseUpdatedToolOutput verifies that
+// HookResult.UpdatedToolOutput auto-translates into
+// hookSpecificOutput.updatedToolOutput for PostToolUse hooks.
+func TestBuildHookResponse_PostToolUseUpdatedToolOutput(t *testing.T) {
+	t.Run("string output translates", func(t *testing.T) {
+		result := HookResult{
+			Continue:          true,
+			UpdatedToolOutput: "rewritten output",
+		}
+
+		resp := buildHookResponse("PostToolUse", result)
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok, "PostToolUse should emit hookSpecificOutput")
+		assert.Equal(t, "PostToolUse", hso["hookEventName"])
+		assert.Equal(t, "rewritten output", hso["updatedToolOutput"])
+		_, hasModify := resp["modify"]
+		assert.False(t, hasModify, "modify key should not be present")
+	})
+
+	t.Run("structured output translates", func(t *testing.T) {
+		result := HookResult{
+			Continue: true,
+			UpdatedToolOutput: map[string]interface{}{
+				"status": "ok",
+				"lines":  3,
+			},
+		}
+
+		resp := buildHookResponse("PostToolUse", result)
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		out, ok := hso["updatedToolOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "ok", out["status"])
+		assert.Equal(t, 3, out["lines"])
+	})
+
+	t.Run("nil UpdatedToolOutput falls through to legacy modify", func(t *testing.T) {
+		result := HookResult{
+			Continue: true,
+			Modify:   map[string]interface{}{"key": "value"},
+		}
+
+		resp := buildHookResponse("PostToolUse", result)
+
+		modify, ok := resp["modify"].(map[string]interface{})
+		require.True(t, ok, "should fall through to legacy modify when UpdatedToolOutput is nil")
+		assert.Equal(t, "value", modify["key"])
+		_, hasHSO := resp["hookSpecificOutput"]
+		assert.False(t, hasHSO)
+	})
+
+	t.Run("UpdatedToolOutput wins over Modify", func(t *testing.T) {
+		result := HookResult{
+			Continue:          true,
+			UpdatedToolOutput: "winner",
+			Modify:            map[string]interface{}{"loser": true},
+		}
+
+		resp := buildHookResponse("PostToolUse", result)
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "winner", hso["updatedToolOutput"])
+		_, hasModify := resp["modify"]
+		assert.False(t, hasModify, "Modify should be ignored when UpdatedToolOutput is set")
 	})
 }
 


### PR DESCRIPTION
TS SDK v0.3.150 promoted the MCP-only `updatedMCPToolOutput` to a
general `updatedToolOutput?: unknown` on `PostToolUseHookSpecificOutput`
(sdk.d.ts L2068). The Go SDK already supports arbitrary
`hookSpecificOutput.*` keys via `HookResult.HookSpecificOutput`, but
that requires hand-building a map.

Adds a typed convenience field `HookResult.UpdatedToolOutput interface{}`
mirroring the existing `Modify` → `hookSpecificOutput.updatedInput`
auto-translation for PreToolUse. When a PostToolUse callback returns
a non-nil `UpdatedToolOutput`, `buildHookResponse` emits:

    "hookSpecificOutput": {
        "hookEventName":     "PostToolUse",
        "updatedToolOutput": <any JSON value>
    }

`UpdatedToolOutput` takes precedence over `Modify` when both are set;
`HookSpecificOutput` still wins over both for raw control.

Deprecated `updatedMCPToolOutput` and `additionalContext` remain
accessible via the `HookSpecificOutput` passthrough map; not promoted
to typed fields here.

Refs: sdk.d.ts v0.3.150 L2068–L2079.