### PR TITLE
hooks: support terminalSequence on hook response envelope

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -2,6 +2,7 @@
 
 - Backfill `TestIntegrationStopHookBackgroundTasks` when the CLI test fixture can deterministically create a long-running background task.
 - Backfill `TestIntegrationStopHookSessionCrons` when the CLI test fixture can deterministically create a session cron.
+- Backfill `TestIntegrationHookTerminalSequence` when the CLI test fixture can capture terminal-escape bytes emitted by hook `terminalSequence` returns. Currently those go straight to the controlling TTY and aren't observable on the SDK transport.
 - Backfill `TestIntegrationPostToolUseUpdatedToolOutput` when the CLI test fixture can deterministically run a tool whose output a PostToolUse hook rewrites, so the model receives the rewritten value rather than the original tool response.
 - Backfill `TestIntegrationAssistantMessageSubagentFields` when the CLI test fixture can deterministically run a subagent task end-to-end.
 - Backfill `TestIntegrationUserMessageSubagentFields` when the CLI test fixture can deterministically run a Task-tool subagent whose tool-result user message round-trips `subagent_type` + `task_description`.

--- a/integration_test.go
+++ b/integration_test.go
@@ -718,6 +718,17 @@ func TestIntegrationHookContinueOnBlock(t *testing.T) {
 	t.Skip("not directly assertable from CLI: continueOnBlock affects the CLI's turn-continuation decision after a blocking hook, not anything observable on the SDK transport")
 }
 
+func TestIntegrationHookTerminalSequence(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// TODO: Backfill when the CLI test fixture can capture
+	// terminal-escape bytes emitted by a hook return; currently those
+	// go straight to the controlling TTY and aren't observable on the
+	// SDK transport.
+	t.Skip("not directly assertable from CLI: terminalSequence bytes are written to the controlling terminal, not surfaced on the SDK transport")
+}
+
 func TestIntegrationPostToolUseUpdatedToolOutput(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/options.go
+++ b/options.go
@@ -1754,6 +1754,7 @@ type HookJSONOutput struct {
 	Decision           string                 `json:"decision,omitempty"` // "approve" or "block"
 	SystemMessage      string                 `json:"systemMessage,omitempty"`
 	Reason             string                 `json:"reason,omitempty"`
+	TerminalSequence   string                 `json:"terminalSequence,omitempty"`
 	HookSpecificOutput map[string]interface{} `json:"hookSpecificOutput,omitempty"`
 }
 
@@ -1853,6 +1854,14 @@ type HookResult struct {
 	// SystemMessage is displayed to Claude as context when blocking exit.
 	// Use this to provide iteration counts or other status information.
 	SystemMessage string
+
+	// TerminalSequence is a terminal escape sequence (e.g. OSC 9 / OSC 777
+	// desktop-notification) the CLI will emit verbatim on the SDK consumer's
+	// behalf after running the hook. Empty string omits the field on the
+	// wire. The CLI restricts the allowlist to notification/title OSCs
+	// (0, 1, 2, 9, 99, 777) and BEL; anything else is dropped CLI-side.
+	// Honored on any hook return, sync or async.
+	TerminalSequence string
 
 	// UpdatedToolOutput replaces the tool output sent to the model on
 	// PostToolUse hooks. The value is forwarded verbatim as

--- a/protocol.go
+++ b/protocol.go
@@ -1548,6 +1548,10 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 		resp["continue"] = result.Continue
 	}
 
+	if result.TerminalSequence != "" {
+		resp["terminalSequence"] = result.TerminalSequence
+	}
+
 	// If HookSpecificOutput is set explicitly, use it directly.
 	// This gives callbacks full control over the hookSpecificOutput
 	// envelope when auto-translation of Modify is insufficient.

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -2714,6 +2714,93 @@ func TestBuildHookResponse_PostToolUseUpdatedToolOutput(t *testing.T) {
 	})
 }
 
+// TestBuildHookResponse_TerminalSequence verifies that
+// HookResult.TerminalSequence is emitted on the wire envelope for both
+// Stop and non-Stop hook returns, that the empty string elides the
+// field, and that it composes with HookSpecificOutput and WatchPaths
+// without interference.
+func TestBuildHookResponse_TerminalSequence(t *testing.T) {
+	t.Run("emitted on non-Stop hook", func(t *testing.T) {
+		resp := buildHookResponse("PreToolUse", HookResult{
+			Continue:         true,
+			TerminalSequence: "\x1b]9;done\x07",
+		})
+
+		assert.Equal(t, true, resp["continue"])
+		assert.Equal(t, "\x1b]9;done\x07", resp["terminalSequence"])
+	})
+
+	t.Run("emitted on Stop hook alongside decision", func(t *testing.T) {
+		resp := buildHookResponse("Stop", HookResult{
+			Decision:         "block",
+			Reason:           "continue work",
+			TerminalSequence: "\x1b]777;notify;hi\x07",
+		})
+
+		assert.Equal(t, "block", resp["decision"])
+		assert.Equal(t, "continue work", resp["reason"])
+		assert.Equal(t, "\x1b]777;notify;hi\x07", resp["terminalSequence"])
+		_, hasContinue := resp["continue"]
+		assert.False(t, hasContinue, "Stop path must not emit continue")
+	})
+
+	t.Run("empty string elides field", func(t *testing.T) {
+		resp := buildHookResponse("PreToolUse", HookResult{
+			Continue: true,
+		})
+
+		_, has := resp["terminalSequence"]
+		assert.False(t, has)
+	})
+
+	t.Run("composes with HookSpecificOutput", func(t *testing.T) {
+		resp := buildHookResponse("PreToolUse", HookResult{
+			Continue:         true,
+			TerminalSequence: "\x07",
+			HookSpecificOutput: map[string]interface{}{
+				"hookEventName":      "PreToolUse",
+				"permissionDecision": "ask",
+			},
+		})
+
+		assert.Equal(t, "\x07", resp["terminalSequence"])
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "ask", hso["permissionDecision"])
+	})
+
+	t.Run("composes with WatchPaths", func(t *testing.T) {
+		resp := buildHookResponse("SessionStart", HookResult{
+			Continue:         true,
+			TerminalSequence: "\x1b]9;watching\x07",
+			WatchPaths:       []string{"/tmp/project"},
+		})
+
+		assert.Equal(t, "\x1b]9;watching\x07", resp["terminalSequence"])
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, []string{"/tmp/project"}, hso["watchPaths"])
+	})
+
+	t.Run("HookJSONOutput round-trip", func(t *testing.T) {
+		out := HookJSONOutput{
+			Continue:         true,
+			TerminalSequence: "\x1b]9;round-trip\x07",
+		}
+		data, err := json.Marshal(out)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"terminalSequence":"\u001b]9;round-trip\u0007"`)
+
+		var back HookJSONOutput
+		require.NoError(t, json.Unmarshal(data, &back))
+		assert.Equal(t, "\x1b]9;round-trip\x07", back.TerminalSequence)
+
+		emptyData, err := json.Marshal(HookJSONOutput{Continue: true})
+		require.NoError(t, err)
+		assert.NotContains(t, string(emptyData), "terminalSequence")
+	})
+}
+
 func TestBuildHookResponse_WatchPaths(t *testing.T) {
 	t.Run("CwdChanged emits watchPaths", func(t *testing.T) {
 		resp := buildHookResponse("CwdChanged", HookResult{


### PR DESCRIPTION
TS SDK v0.3.150 adds `terminalSequence?: string` to `SyncHookJSONOutput`
(sdk.d.ts L5635). The CLI emits the bytes verbatim to the controlling
terminal after running the hook — typical use is firing an OSC 9 /
OSC 777 desktop-notification when a long-running hook completes.
CLI-side allowlist: notification/title OSCs (0, 1, 2, 9, 99, 777) and
BEL; anything else is dropped.

Adds `HookResult.TerminalSequence string` (user-facing) and emits it
verbatim from `buildHookResponse`. Honored on both Stop and non-Stop
hook returns; empty string elides the field. Matching field added to
the wire-shaped `HookJSONOutput` struct.

PLAN.md row labels this as `AsyncHookJSONOutput`; the actual TS field
is on `SyncHookJSONOutput`. `AsyncHookJSONOutput` is the `{ async: true;
asyncTimeout?: number }` async-hook escape, which has no Go analogue.

Refs: sdk.d.ts v0.3.150 L5628–L5640.