### PR TITLE
hooks: support suppressOriginalPrompt on UserPromptSubmit hook output

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -3,6 +3,7 @@
 - Backfill `TestIntegrationStopHookBackgroundTasks` when the CLI test fixture can deterministically create a long-running background task.
 - Backfill `TestIntegrationStopHookSessionCrons` when the CLI test fixture can deterministically create a session cron.
 - Backfill `TestIntegrationHookTerminalSequence` when the CLI test fixture can capture terminal-escape bytes emitted by hook `terminalSequence` returns. Currently those go straight to the controlling TTY and aren't observable on the SDK transport.
+- Backfill `TestIntegrationHookSuppressOriginalPrompt` when the CLI test fixture can assert the block-message body the CLI returns when a UserPromptSubmit hook returns `suppressOriginalPrompt: true`. The omission is a CLI rendering behavior, not surfaced on the SDK transport.
 - Backfill `TestIntegrationPostToolUseUpdatedToolOutput` when the CLI test fixture can deterministically run a tool whose output a PostToolUse hook rewrites, so the model receives the rewritten value rather than the original tool response.
 - Backfill `TestIntegrationAssistantMessageSubagentFields` when the CLI test fixture can deterministically run a subagent task end-to-end.
 - Backfill `TestIntegrationUserMessageSubagentFields` when the CLI test fixture can deterministically run a Task-tool subagent whose tool-result user message round-trips `subagent_type` + `task_description`.

--- a/integration_test.go
+++ b/integration_test.go
@@ -729,6 +729,17 @@ func TestIntegrationHookTerminalSequence(t *testing.T) {
 	t.Skip("not directly assertable from CLI: terminalSequence bytes are written to the controlling terminal, not surfaced on the SDK transport")
 }
 
+func TestIntegrationHookSuppressOriginalPrompt(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// TODO: Backfill when the CLI test fixture can assert the
+	// block-message body the CLI returns when a UserPromptSubmit hook
+	// returns suppressOriginalPrompt: true; the omission is a CLI
+	// rendering behavior not directly observable on the SDK transport.
+	t.Skip("not directly assertable from CLI: suppressOriginalPrompt is a CLI block-message rendering behavior, not surfaced on the SDK transport")
+}
+
 func TestIntegrationPostToolUseUpdatedToolOutput(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/options.go
+++ b/options.go
@@ -1863,6 +1863,15 @@ type HookResult struct {
 	// Honored on any hook return, sync or async.
 	TerminalSequence string
 
+	// SuppressOriginalPrompt, when set on a UserPromptSubmit hook return,
+	// asks the CLI to omit the original user prompt from the block message
+	// it returns when the hook blocks. Honored only on UserPromptSubmit
+	// hooks; nil (the default) leaves the wire field unset; a pointer to
+	// false explicitly opts out. Translates into hookSpecificOutput.
+	// suppressOriginalPrompt per sdk.d.ts v0.3.150 L5808. Useful when the
+	// prompt itself was the reason for the block (PII, credentials, etc.).
+	SuppressOriginalPrompt *bool
+
 	// UpdatedToolOutput replaces the tool output sent to the model on
 	// PostToolUse hooks. The value is forwarded verbatim as
 	// hookSpecificOutput.updatedToolOutput; any JSON-encodable value is

--- a/protocol.go
+++ b/protocol.go
@@ -1605,6 +1605,17 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 		resp["hookSpecificOutput"] = hookSpecificOutput
 	}
 
+	if result.SuppressOriginalPrompt != nil && hookType == string(HookTypeUserPromptSubmit) {
+		hookSpecificOutput, _ := resp["hookSpecificOutput"].(map[string]interface{})
+		if hookSpecificOutput == nil {
+			hookSpecificOutput = map[string]interface{}{
+				"hookEventName": string(HookTypeUserPromptSubmit),
+			}
+		}
+		hookSpecificOutput["suppressOriginalPrompt"] = *result.SuppressOriginalPrompt
+		resp["hookSpecificOutput"] = hookSpecificOutput
+	}
+
 	return resp
 }
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -2801,6 +2801,77 @@ func TestBuildHookResponse_TerminalSequence(t *testing.T) {
 	})
 }
 
+// TestBuildHookResponse_SuppressOriginalPrompt verifies that
+// HookResult.SuppressOriginalPrompt is emitted under hookSpecificOutput
+// only for UserPromptSubmit hooks, composes with an explicit
+// HookSpecificOutput map without clobbering existing keys, distinguishes
+// nil from a pointer-to-false, and is ignored on other hook types.
+func TestBuildHookResponse_SuppressOriginalPrompt(t *testing.T) {
+	t.Run("emitted on UserPromptSubmit when true", func(t *testing.T) {
+		v := true
+		resp := buildHookResponse("UserPromptSubmit", HookResult{
+			Continue:               true,
+			SuppressOriginalPrompt: &v,
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "UserPromptSubmit", hso["hookEventName"])
+		assert.Equal(t, true, hso["suppressOriginalPrompt"])
+	})
+
+	t.Run("explicit false is emitted", func(t *testing.T) {
+		v := false
+		resp := buildHookResponse("UserPromptSubmit", HookResult{
+			Continue:               true,
+			SuppressOriginalPrompt: &v,
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, false, hso["suppressOriginalPrompt"])
+	})
+
+	t.Run("nil elides field", func(t *testing.T) {
+		resp := buildHookResponse("UserPromptSubmit", HookResult{
+			Continue: true,
+		})
+
+		_, has := resp["hookSpecificOutput"]
+		assert.False(t, has)
+	})
+
+	t.Run("composes with explicit HookSpecificOutput", func(t *testing.T) {
+		v := true
+		resp := buildHookResponse("UserPromptSubmit", HookResult{
+			Continue:               true,
+			SuppressOriginalPrompt: &v,
+			HookSpecificOutput: map[string]interface{}{
+				"hookEventName":     "UserPromptSubmit",
+				"additionalContext": "redacted",
+			},
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "UserPromptSubmit", hso["hookEventName"])
+		assert.Equal(t, "redacted", hso["additionalContext"])
+		assert.Equal(t, true, hso["suppressOriginalPrompt"])
+	})
+
+	t.Run("ignored on non-UserPromptSubmit hooks", func(t *testing.T) {
+		v := true
+		resp := buildHookResponse("PreToolUse", HookResult{
+			Continue:               true,
+			SuppressOriginalPrompt: &v,
+		})
+
+		_, has := resp["hookSpecificOutput"]
+		assert.False(t, has,
+			"suppressOriginalPrompt must not leak onto non-UserPromptSubmit hookSpecificOutput")
+	})
+}
+
 func TestBuildHookResponse_WatchPaths(t *testing.T) {
 	t.Run("CwdChanged emits watchPaths", func(t *testing.T) {
 		resp := buildHookResponse("CwdChanged", HookResult{


### PR DESCRIPTION
TS SDK v0.3.150 adds `suppressOriginalPrompt?: boolean` to `UserPromptSubmitHookSpecificOutput` (sdk.d.ts L5801-L5809). When a UserPromptSubmit hook blocks, setting the field tells the CLI to omit the original prompt from the block message it returns to the user -- useful when the prompt itself was the problem (PII, credentials, etc.).

- Adds `HookResult.SuppressOriginalPrompt *bool` and auto-translates it into `hookSpecificOutput.suppressOriginalPrompt` for UserPromptSubmit hooks via `buildHookResponse`.
- Uses a pointer type so nil stays absent while pointer-to-false explicitly emits `false`.
- Gated on `hookType == UserPromptSubmit` so the field does not leak onto unrelated hook outputs.
- Composes with explicit `HookResult.HookSpecificOutput` maps without clobbering existing keys, matching the existing late-merge pattern.
- Adds focused unit coverage, a skipped integration placeholder, and an `INTEGRATION-FOLLOWUPS.md` entry.

Refs: sdk.d.ts v0.3.150 L5801-L5809.