### PR TITLE
docs: refresh README + docstrings for v0.3.150 parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ stdin/stdout, giving you access to Claude's tool use, extended thinking,
 session management, and hook system.
 
 This repository tracks the official TypeScript Agent SDK surface through the
-v0.2.119 catchup work, using Go idioms where the API shape differs.
+v0.3.150 catchup work, using Go idioms where the API shape differs.
 
 ```mermaid
 flowchart TB
@@ -209,8 +209,10 @@ For detailed guides and examples, see [docs/examples/](docs/examples/):
 
 ## TypeScript SDK Parity
 
-The v0.2.119 catchup adds coverage for recent Agent SDK and Claude Code CLI
-surfaces, including:
+The SDK tracks the upstream TypeScript Agent SDK release cadence. Coverage
+landed across two catchup cycles.
+
+The v0.2.119 catchup added:
 
 - thinking effort, task budgets, debug files, extra CLI args, agent selection,
   and prompt/agent progress toggles
@@ -221,11 +223,60 @@ surfaces, including:
 - explicit settings support via `WithSettingsPath`, `WithSettings`, and
   `WithManagedSettings`
 
+The v0.3.150 catchup added:
+
+- per-server MCP `Timeout` and `AlwaysLoad` knobs across Stdio/HTTP/SSE/proxy
+  configurations
+- background-tasks control protocol (`Query.BackgroundTasks`) plus
+  `BackgroundTaskSummary` and `SessionCronSummary` payloads on `Stop` /
+  `SessionEnd` hooks
+- new `system/permission_denied` message subtype, `SDKAssistantMessage.Error`
+  enum (incl. `oauth_org_not_allowed`, `model_not_found`), `ResultMessage`
+  TTFT + origin metadata, and `MemoryRecallEntry` `organization` scope
+- hook output additions: `UpdatedToolOutput` on `PostToolUse`,
+  `TerminalSequence` OSC notifications, `SuppressOriginalPrompt` on
+  `UserPromptSubmit`, plus per-hook `Args` (no-shell exec form) and
+  `ContinueOnBlock`
+- managed-org / sandbox / worktree / marketplace settings batch covering
+  `PolicyHelper`, `DisableAgentView`, `IsolatePeerMachines`,
+  `Sandbox.TLSTerminate`, `Worktree.BaseRef`, `StatusLine.HideVimModeIndicator`,
+  marketplace `skills-dir` / `unsupported` source variants, and others
+- `read_file` `Encoding` (utf-8 / base64), `applyFlagSettings` per-key null
+  clearing, host-side `host_auth_token_refresh` and `submit_feedback` control
+  subtypes
+
 Some areas remain intentionally limited by the CLI or integration harness:
 desktop/IDE-only settings are not modeled exhaustively, several runtime control
 paths have unit coverage plus skipped integration slots until stable live CLI
 fixtures exist, and alpha task/agent behavior should still be checked against
 the installed Claude Code CLI version.
+
+### Porting from the TypeScript SDK - Go-side differences
+
+A short list of places the Go SDK consciously diverges from the TS shape; if
+you are translating TS code, watch for these:
+
+- **`Options.Env` merges, it does not replace.** TS `Options.env` REPLACES the
+  subprocess environment entirely; the Go `Options.Env` is overlaid on top of
+  `os.Environ()`. If you relied on the TS replace-semantics, clear inherited
+  variables yourself before spawning. There is no opt-in flag for replace mode.
+- **Cancellation is `context.Context`, not `AbortSignal`.** TS forwards a
+  derived `AbortSignal` that fires only after a stdin-EOF + grace window. In Go,
+  that grace window lives inside `SubprocessTransport.Close()`: the SDK closes
+  stdin, waits up to 5 seconds for the CLI to exit on its own, and only then
+  force-kills. Anything you hang off the same `context.Context` (HTTP
+  cancellation, in-flight tool teardown) inherits the same ordering guarantee.
+- **`'Skill'` in `AllowedTools` is deprecated upstream.** Per TS SDK v0.3.150,
+  passing `'Skill'` in `AllowedTools` or `AgentDefinition.Tools` is deprecated.
+  Use `AgentDefinition.Skills` for per-agent preload. The Go SDK does not
+  currently expose the upstream top-level user-facing `skills` option; the
+  existing `Options.Skills` mirrors the control-init system-prompt loading
+  allowlist, which is a different surface.
+- **`Effort` `"max"` / `"xhigh"` are model-gated.** `EffortMax` requires Opus
+  4.6/4.7 or Sonnet 4.6; `EffortXHigh` requires Opus 4.7. On unsupported
+  models the CLI silently downgrades per its own policy. The CLI is the
+  authority on which model accepts which level - the SDK only forwards the enum
+  value.
 
 For internal architecture, see [DESIGN.md](docs/DESIGN.md). For CLI protocol
 details (how this and the official Typescript SDK actually work), see

--- a/options.go
+++ b/options.go
@@ -44,8 +44,19 @@ type Options struct {
 	// AdditionalDirectories are additional directories Claude can access.
 	AdditionalDirectories []string
 
-	// Environment variables to pass to the CLI subprocess.
-	// ANTHROPIC_API_KEY should be set here or in the parent environment.
+	// Env is a map of environment variables to overlay onto the CLI
+	// subprocess environment. Entries are appended to os.Environ()
+	// before spawn, so parent-process variables like PATH and HOME
+	// remain visible to the subprocess by default.
+	//
+	// Note: this is the inverse of the TypeScript SDK's Options.env,
+	// which REPLACES the subprocess environment entirely (sdk.d.ts
+	// v0.3.150 L1326-L1332). Callers porting from TS that relied on
+	// the replace-semantics must clear inherited variables themselves;
+	// there is no opt-in flag for replace mode.
+	//
+	// ANTHROPIC_API_KEY should be set here or in the parent
+	// environment.
 	Env map[string]string
 
 	// PermissionMode controls tool execution permissions.
@@ -155,6 +166,13 @@ type Options struct {
 
 	// AllowedTools is a list of allowed tool names.
 	// If empty, all tools are allowed.
+	//
+	// Note: passing "Skill" here is deprecated as of TS SDK v0.3.150
+	// (sdk.d.ts L1265-L1268). Per-agent skill preloading lives on
+	// AgentDefinition.Skills; a top-level user-facing skills option
+	// is tracked separately and is not yet exposed by the Go SDK
+	// (the existing Options.Skills field mirrors the control-init
+	// loading allowlist, which is a different surface).
 	AllowedTools []string
 
 	// DisallowedTools is a list of disallowed tool names.
@@ -800,9 +818,14 @@ const (
 	EffortMedium EffortLevel = "medium"
 	// EffortHigh applies deep reasoning.
 	EffortHigh EffortLevel = "high"
-	// EffortXHigh applies deeper reasoning than high.
+	// EffortXHigh applies deeper reasoning than high. Supported only
+	// on Opus 4.7; silently falls back to "high" on other models per
+	// TS SDK v0.3.150 (sdk.d.ts L519-L522, L1511-L1512).
 	EffortXHigh EffortLevel = "xhigh"
-	// EffortMax applies maximum effort.
+	// EffortMax applies maximum effort. Supported on Opus 4.6, Opus
+	// 4.7, and Sonnet 4.6 per TS SDK v0.3.150 (sdk.d.ts L519-L522,
+	// L1511-L1512). On unsupported models the CLI falls back per its
+	// own downgrade policy.
 	EffortMax EffortLevel = "max"
 )
 
@@ -1969,9 +1992,15 @@ type HookResult struct {
 
 // AgentDefinition defines a specialized subagent.
 type AgentDefinition struct {
-	Name                               string               `json:"-"` // Agent identifier
-	Description                        string               `json:"description"`
-	Prompt                             string               `json:"prompt"`
+	Name        string `json:"-"` // Agent identifier
+	Description string `json:"description"`
+	Prompt      string `json:"prompt"`
+	// Tools is the array of allowed tool names for this agent. When
+	// omitted, the agent inherits all tools from its parent.
+	//
+	// Note: passing "Skill" here is deprecated as of TS SDK v0.3.150
+	// (sdk.d.ts L44). Use AgentDefinition.Skills for per-agent skill
+	// preload instead.
 	Tools                              []string             `json:"tools,omitempty"`
 	Model                              string               `json:"model,omitempty"`
 	DisallowedTools                    []string             `json:"disallowedTools,omitempty"`

--- a/transport.go
+++ b/transport.go
@@ -524,8 +524,17 @@ func (t *SubprocessTransport) EndInput() error {
 
 // Close terminates the CLI subprocess and cleans up resources.
 //
-// Close attempts a graceful shutdown by closing stdin, which signals the
-// CLI to exit. If the process doesn't exit within a timeout, it is killed.
+// Close performs a graceful shutdown: stdin is closed (signaling EOF to
+// the CLI), the SDK waits up to 5 seconds for the process to exit on its
+// own, and only on timeout is the process force-killed. This mirrors the
+// TS SDK's stdin-EOF + grace-window contract (sdk.d.ts v0.3.150
+// L5531-L5547): cancellation signals - in Go, the context plumbed through
+// Connect/Write/ReadMessages - only translate into a hard kill after the
+// CLI has had its graceful chance. Anything you hang off the same context
+// (HTTP cancellation, in-flight tool teardown) inherits the same ordering
+// guarantee.
+//
+// Close is idempotent. After Close, Write returns ErrTransportClosed.
 func (t *SubprocessTransport) Close() error {
 	if !t.closed.CompareAndSwap(false, true) {
 		return nil // Already closed


### PR DESCRIPTION
TS SDK v0.3.150 lands four documentation-worthy themes whose behavior is
already in place in the Go SDK from earlier PRs in this catchup cycle but
whose contract was not surfaced in docs:

1. `Options.Env` MERGES onto `os.Environ()`, inverse of TS's REPLACE
   semantics (transport.go L367-L371 vs. sdk.d.ts v0.3.150 L1326-L1332).
2. `SubprocessTransport.Close()` performs stdin-EOF + up-to-5s grace +
   force-kill (transport.go L526-L554), the Go-side analogue of TS's
   forwarded-AbortSignal ordering guarantee (sdk.d.ts L5531-L5547).
3. `'Skill'` in `AllowedTools` / `AgentDefinition.Tools` is deprecated
   upstream (sdk.d.ts L44, L1265-L1268); per-agent skills live on
   `AgentDefinition.Skills`.
4. `EffortMax` / `EffortXHigh` are model-gated (sdk.d.ts L519-L522,
   L1511-L1512).

Doc-only changes:

- `options.go`: refresh `Env`, `AllowedTools`, `AgentDefinition.Tools`,
  `EffortXHigh`, `EffortMax` doc-comments.
- `transport.go`: expand `SubprocessTransport.Close()` doc-comment with
  the 5-second grace contract and the context-as-cancellation mapping.
- `README.md`: bump the v0.2.119 cite to v0.3.150, append a v0.3.150
  surface-summary bullet list to the parity section, and add a new
  "Porting from the TypeScript SDK — Go-side differences" subsection
  covering the four divergences above.

No code changes, no test changes; `go test ./...`, `go vet ./...`, and
`gofmt -l .` remain green.

Refs: sdk.d.ts v0.3.150 L44, L519-L522, L1265-L1268, L1326-L1332,
L1511-L1512, L5531-L5547.