### PR TITLE
messages: add GoalStatusMessage + WithGoal option (#62)

### DIFF
--- a/client.go
+++ b/client.go
@@ -251,6 +251,12 @@ func (c *Client) Query(ctx context.Context, prompt string) iter.Seq[Message] {
 				if _, ok := msg.(ResultMessage); ok {
 					return
 				}
+
+				// Stop on goal-met status: the CLI has decided the goal
+				// condition is satisfied and will terminate the session.
+				if goal, ok := msg.(GoalStatusMessage); ok && goal.Met {
+					return
+				}
 			}
 		}
 	}

--- a/errors.go
+++ b/errors.go
@@ -196,6 +196,19 @@ func (e *ErrQuestionTimeout) Error() string {
 	return fmt.Sprintf("question timed out: %s", e.ToolUseID)
 }
 
+// ErrGoalAchieved signals that the session terminated because the goal condition was met.
+type ErrGoalAchieved struct {
+	Condition  string
+	Iterations int
+	DurationMs int64
+	Tokens     int
+}
+
+// Error implements the error interface.
+func (e *ErrGoalAchieved) Error() string {
+	return fmt.Sprintf("goal achieved after %d iteration(s): %s", e.Iterations, e.Condition)
+}
+
 // ErrNoQuestionHandler indicates that an AskUserQuestion tool call was
 // received but no handler was configured and no Questions() iterator is active.
 //

--- a/goal_test.go
+++ b/goal_test.go
@@ -1,0 +1,150 @@
+package claudeagent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGoalStatusMessageJSONRoundTripMet covers the met=true wire form,
+// including the cumulative duration/token counters and the reason field.
+func TestGoalStatusMessageJSONRoundTripMet(t *testing.T) {
+	original := GoalStatusMessage{
+		Type:       "system",
+		Subtype:    "goal_status",
+		Met:        true,
+		Condition:  "all tests pass",
+		Reason:     "test suite reported zero failures",
+		Iterations: 5,
+		DurationMs: 12345,
+		Tokens:     6789,
+		UUID:       "550e8400-e29b-41d4-a716-446655440300",
+		SessionID:  "sess_goal_001",
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded GoalStatusMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, original, decoded)
+	assert.True(t, decoded.Met)
+	assert.Equal(t, "system", decoded.MessageType())
+}
+
+// TestGoalStatusMessageJSONRoundTripNotMet covers the met=false form and
+// asserts that the empty optional fields are omitted on the wire.
+func TestGoalStatusMessageJSONRoundTripNotMet(t *testing.T) {
+	original := GoalStatusMessage{
+		Type:      "system",
+		Subtype:   "goal_status",
+		Met:       false,
+		Condition: "all tests pass",
+		UUID:      "550e8400-e29b-41d4-a716-446655440301",
+		SessionID: "sess_goal_002",
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	// Optional fields with zero values should be omitted.
+	assert.NotContains(t, string(data), `"reason"`)
+	assert.NotContains(t, string(data), `"iterations"`)
+	assert.NotContains(t, string(data), `"durationMs"`)
+	assert.NotContains(t, string(data), `"tokens"`)
+
+	var decoded GoalStatusMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, original, decoded)
+	assert.False(t, decoded.Met)
+	assert.Empty(t, decoded.Reason)
+	assert.Zero(t, decoded.Iterations)
+	assert.Zero(t, decoded.DurationMs)
+	assert.Zero(t, decoded.Tokens)
+}
+
+// TestGoalStatusMessageType ensures the message identifies as "system" so it
+// routes through the system-message handling path on consumers.
+func TestGoalStatusMessageType(t *testing.T) {
+	var msg GoalStatusMessage
+	assert.Equal(t, "system", msg.MessageType())
+}
+
+// TestParseMessageGoalStatus drives the parser dispatch path: a system
+// envelope with subtype "goal_status" must materialize as GoalStatusMessage.
+func TestParseMessageGoalStatus(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "goal_status",
+		"met": true,
+		"condition": "all tests pass",
+		"reason": "test suite reported zero failures",
+		"iterations": 5,
+		"durationMs": 12345,
+		"tokens": 6789,
+		"uuid": "550e8400-e29b-41d4-a716-446655440302",
+		"session_id": "sess_goal_003"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	goalMsg, ok := msg.(GoalStatusMessage)
+	require.True(t, ok, "expected GoalStatusMessage")
+
+	assert.Equal(t, "system", goalMsg.MessageType())
+	assert.Equal(t, "goal_status", goalMsg.Subtype)
+	assert.True(t, goalMsg.Met)
+	assert.Equal(t, "all tests pass", goalMsg.Condition)
+	assert.Equal(t, "test suite reported zero failures", goalMsg.Reason)
+	assert.Equal(t, 5, goalMsg.Iterations)
+	assert.Equal(t, int64(12345), goalMsg.DurationMs)
+	assert.Equal(t, 6789, goalMsg.Tokens)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440302", goalMsg.UUID)
+	assert.Equal(t, "sess_goal_003", goalMsg.SessionID)
+}
+
+// TestWithGoalSetsCondition asserts WithGoal stores the condition on Options
+// verbatim when within the length cap.
+func TestWithGoalSetsCondition(t *testing.T) {
+	opts := DefaultOptions()
+	WithGoal("all tests pass")(&opts)
+	assert.Equal(t, "all tests pass", opts.Goal)
+}
+
+// TestWithGoalTruncates verifies that conditions over 1000 characters are
+// truncated to the cap so the CLI flag stays within accepted bounds.
+func TestWithGoalTruncates(t *testing.T) {
+	long := strings.Repeat("a", 1500)
+	opts := DefaultOptions()
+	WithGoal(long)(&opts)
+	assert.Len(t, opts.Goal, 1000)
+	assert.Equal(t, strings.Repeat("a", 1000), opts.Goal)
+}
+
+// TestErrGoalAchievedError exercises the error formatting so callers
+// type-switching on the error get a useful Error() string.
+func TestErrGoalAchievedError(t *testing.T) {
+	err := &ErrGoalAchieved{
+		Condition:  "all tests pass",
+		Iterations: 3,
+		DurationMs: 9999,
+		Tokens:     500,
+	}
+	assert.Contains(t, err.Error(), "all tests pass")
+	assert.Contains(t, err.Error(), "3 iteration")
+}
+
+// TestIntegrationGoal is a skeleton for end-to-end coverage of WithGoal. It
+// is permanently skipped because /goal evaluation requires a trusted
+// workspace with hooks enabled, which the standard CI sandbox does not
+// provide. Kept in place so the surface remains documented and the skeleton
+// is ready when a suitable harness is available.
+func TestIntegrationGoal(t *testing.T) {
+	t.Skip("goal requires trusted workspace + hooks enabled")
+}

--- a/messages.go
+++ b/messages.go
@@ -989,6 +989,24 @@ type PermissionDeniedMessage struct {
 // MessageType implements Message.
 func (m PermissionDeniedMessage) MessageType() string { return "system" }
 
+// GoalStatusMessage reports the outcome of a /goal evaluation after each turn.
+// When Met is true, the goal condition has been satisfied and the session terminates.
+type GoalStatusMessage struct {
+	Type       string `json:"type"`                 // Always "system"
+	Subtype    string `json:"subtype"`              // "goal_status"
+	Met        bool   `json:"met"`                  // True when the goal condition has been satisfied
+	Condition  string `json:"condition"`            // Natural-language stop condition being evaluated
+	Reason     string `json:"reason,omitempty"`     // Evaluator's justification for the verdict
+	Iterations int    `json:"iterations,omitempty"` // Number of turns evaluated so far
+	DurationMs int64  `json:"durationMs,omitempty"` // Cumulative session duration in milliseconds
+	Tokens     int    `json:"tokens,omitempty"`     // Cumulative tokens consumed by the session
+	UUID       string `json:"uuid"`                 // Unique message ID
+	SessionID  string `json:"session_id"`           // Session identifier
+}
+
+// MessageType implements Message.
+func (m GoalStatusMessage) MessageType() string { return "system" }
+
 // PluginInstallStatus is the plugin installation progress state.
 type PluginInstallStatus string
 
@@ -1220,6 +1238,10 @@ func ParseMessage(data []byte) (Message, error) {
 			return msg, err
 		case "permission_denied":
 			var msg PermissionDeniedMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "goal_status":
+			var msg GoalStatusMessage
 			err := json.Unmarshal(data, &msg)
 			return msg, err
 		case "plugin_install":

--- a/options.go
+++ b/options.go
@@ -258,6 +258,13 @@ type Options struct {
 	// enabling multiple instances to share the same task list.
 	// Tasks persist at ~/.claude/tasks/{TaskListID}/.
 	TaskListID string
+
+	// Goal is a natural-language stop condition evaluated by Claude after
+	// each turn. When the condition is met, the CLI emits a
+	// GoalStatusMessage with Met=true and the session terminates.
+	// Capped at 1000 characters; longer values are truncated by WithGoal.
+	// Requires a trusted workspace and hooks enabled.
+	Goal string
 }
 
 // SystemPromptConfig represents system prompt configuration.
@@ -2552,6 +2559,18 @@ func WithTaskListID(id string) Option {
 func WithTaskStore(store TaskStore) Option {
 	return func(o *Options) {
 		o.TaskStore = store
+	}
+}
+
+// WithGoal sets a natural-language stop condition. The session terminates when
+// Claude evaluates the condition as met, emitting a GoalStatusMessage{Met: true}.
+// Condition is capped at 1000 characters. Requires a trusted workspace and hooks enabled.
+func WithGoal(condition string) Option {
+	return func(o *Options) {
+		if len(condition) > 1000 {
+			condition = condition[:1000]
+		}
+		o.Goal = condition
 	}
 }
 

--- a/transport.go
+++ b/transport.go
@@ -341,6 +341,10 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		args = append(args, "--debug")
 	}
 
+	if t.options.Goal != "" {
+		args = append(args, "--goal", t.options.Goal)
+	}
+
 	// Move per-machine system prompt sections (cwd, env, memory, git status)
 	// into the first user message. Stabilizes the system prompt prefix for
 	// cross-invocation prompt-cache reuse. The CLI ignores this flag when


### PR DESCRIPTION
## Summary

Surfaces the CLI's `/goal` natural-language stop-condition protocol on the SDK. `WithGoal(condition)` wires `--goal` on the subprocess; the condition is capped at 1000 characters to match the upstream input bound. After each turn the CLI emits a `system`/`goal_status` event, which the parser now materializes as `GoalStatusMessage` carrying the verdict, the evaluator's reason, and cumulative iteration/duration/token counters.

When `Met` is true, the `Query` iterator yields the status to the caller and halts - the same termination contract `ResultMessage` already provides for the stream. `ErrGoalAchieved` is exported for callers that compose the SDK into longer-running flows and want to type-switch on goal completion rather than re-deriving it from the message stream.

Closes #62.

## What changed

- `messages.go`: new `GoalStatusMessage` type plus `subtype:"goal_status"` arm in `ParseMessage`.
- `options.go`: `Goal` field on `Options` and `WithGoal()` setter (1000-char cap).
- `transport.go`: `--goal` wired alongside the other string flags (after `--debug-file`).
- `errors.go`: `ErrGoalAchieved` with condition + iteration/duration/token context.
- `client.go`: `Query` iterator stops after yielding a `GoalStatusMessage` with `Met=true`.

## Test plan

`goal_test.go` covers:
- [x] JSON round-trip for both `met=true` (all fields populated) and `met=false` (zero-valued optionals omitted on the wire).
- [x] `MessageType()` returns `"system"`.
- [x] `WithGoal` writes the condition into `Options.Goal` verbatim under the cap.
- [x] `WithGoal` truncates inputs above 1000 chars.
- [x] `ParseMessage` dispatches `subtype:"goal_status"` to `GoalStatusMessage` with all fields decoded.
- [x] `ErrGoalAchieved.Error()` includes both the condition and iteration count.
- [x] Integration skeleton in place, skipped with the documented "goal requires trusted workspace + hooks enabled" reason.

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` are all clean.