### PR TITLE
hooks: add MessageDisplay hook (v0.3.168 deferred Phase I-1)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -740,6 +740,15 @@ func TestIntegrationHookSuppressOriginalPrompt(t *testing.T) {
 	t.Skip("not directly assertable from CLI: suppressOriginalPrompt is a CLI block-message rendering behavior, not surfaced on the SDK transport")
 }
 
+func TestIntegrationMessageDisplayHook(t *testing.T) {
+	// Registering HookTypeMessageDisplay against a streamed assistant turn
+	// (with WithMaxTurns(1) and a normal prompt) yields zero callback
+	// invocations end-to-end against the v0.3.168 CLI. The assistant message
+	// arrives on the SDK transport but no MessageDisplay hook events do.
+	// Tracked in memory/catchup-v0.3.168/INTEGRATION-FOLLOWUPS.md.
+	t.Skip("not triggerable from CLI: v0.3.168 CLI does not emit MessageDisplay hook events to SDK transports during assistant streaming")
+}
+
 func TestIntegrationPostToolUseUpdatedToolOutput(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/options.go
+++ b/options.go
@@ -1267,6 +1267,9 @@ const (
 	// HookTypeInstructionsLoaded fires when instruction files are loaded.
 	HookTypeInstructionsLoaded HookType = "InstructionsLoaded"
 
+	// HookTypeMessageDisplay fires as assistant message display lines stream.
+	HookTypeMessageDisplay HookType = "MessageDisplay"
+
 	// HookTypePreToolUse fires before tool execution.
 	HookTypePreToolUse HookType = "PreToolUse"
 
@@ -1422,6 +1425,23 @@ func (InstructionsLoadedInput) HookType() HookType { return HookTypeInstructions
 
 // Base implements HookInput.
 func (i InstructionsLoadedInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// MessageDisplayInput contains data for MessageDisplay hooks per sdk.d.ts
+// v0.3.168 L1153-L1180.
+type MessageDisplayInput struct {
+	BaseHookInput
+	TurnID    string `json:"turn_id"`
+	MessageID string `json:"message_id"`
+	Index     int    `json:"index"`
+	Final     bool   `json:"final"`
+	Delta     string `json:"delta"`
+}
+
+// HookType implements HookInput.
+func (MessageDisplayInput) HookType() HookType { return HookTypeMessageDisplay }
+
+// Base implements HookInput.
+func (i MessageDisplayInput) Base() BaseHookInput { return i.BaseHookInput }
 
 // PreToolUseInput contains data for PreToolUse hooks.
 type PreToolUseInput struct {
@@ -1974,6 +1994,13 @@ type HookResult struct {
 	// suppressOriginalPrompt per sdk.d.ts v0.3.150 L5808. Useful when the
 	// prompt itself was the reason for the block (PII, credentials, etc.).
 	SuppressOriginalPrompt *bool
+
+	// DisplayContent replaces the displayed delta for MessageDisplay hooks
+	// without changing the stored message or model-visible content. Honored
+	// only on MessageDisplay hooks and silently dropped for other hook types.
+	// Translates into hookSpecificOutput.displayContent per sdk.d.ts v0.3.168
+	// L1182-L1191.
+	DisplayContent *string
 
 	// UpdatedToolOutput replaces the tool output sent to the model on
 	// PostToolUse hooks. The value is forwarded verbatim as

--- a/protocol.go
+++ b/protocol.go
@@ -402,6 +402,15 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 			TriggerFilePath: getString(inputData, "trigger_file_path"),
 			ParentFilePath:  getString(inputData, "parent_file_path"),
 		}
+	case HookTypeMessageDisplay:
+		input = MessageDisplayInput{
+			BaseHookInput: base,
+			TurnID:        getString(inputData, "turn_id"),
+			MessageID:     getString(inputData, "message_id"),
+			Index:         getInt(inputData, "index"),
+			Final:         getBool(inputData, "final"),
+			Delta:         getString(inputData, "delta"),
+		}
 	case HookTypePreToolUse:
 		input = PreToolUseInput{
 			BaseHookInput: base,
@@ -900,6 +909,15 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 			Globs:           getStringSlice(hookInput, "globs"),
 			TriggerFilePath: getString(hookInput, "trigger_file_path"),
 			ParentFilePath:  getString(hookInput, "parent_file_path"),
+		}
+	case "MessageDisplay":
+		input = MessageDisplayInput{
+			BaseHookInput: base,
+			TurnID:        getString(hookInput, "turn_id"),
+			MessageID:     getString(hookInput, "message_id"),
+			Index:         getInt(hookInput, "index"),
+			Final:         getBool(hookInput, "final"),
+			Delta:         getString(hookInput, "delta"),
 		}
 	case "PreToolUse":
 		input = PreToolUseInput{
@@ -1613,6 +1631,17 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 			}
 		}
 		hookSpecificOutput["suppressOriginalPrompt"] = *result.SuppressOriginalPrompt
+		resp["hookSpecificOutput"] = hookSpecificOutput
+	}
+
+	if result.DisplayContent != nil && hookType == string(HookTypeMessageDisplay) {
+		hookSpecificOutput, _ := resp["hookSpecificOutput"].(map[string]interface{})
+		if hookSpecificOutput == nil {
+			hookSpecificOutput = map[string]interface{}{
+				"hookEventName": string(HookTypeMessageDisplay),
+			}
+		}
+		hookSpecificOutput["displayContent"] = *result.DisplayContent
 		resp["hookSpecificOutput"] = hookSpecificOutput
 	}
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -2872,6 +2872,74 @@ func TestBuildHookResponse_SuppressOriginalPrompt(t *testing.T) {
 	})
 }
 
+func TestGetHookInput_MessageDisplay(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+
+	protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+		ev, ok := input.(MessageDisplayInput)
+		require.True(t, ok)
+		assert.Equal(t, HookTypeMessageDisplay, ev.HookType())
+		assert.Equal(t, "turn-123", ev.TurnID)
+		assert.Equal(t, "message-456", ev.MessageID)
+		assert.Equal(t, 2, ev.Index)
+		assert.True(t, ev.Final)
+		assert.Equal(t, "newly completed line\n", ev.Delta)
+		return HookResult{Continue: true}, nil
+	}
+
+	resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+		RequestID: "r",
+		Request: SDKControlRequestBody{
+			Subtype:    "hook_callback",
+			CallbackID: "h",
+			Input: map[string]interface{}{
+				"hook_event_name": "MessageDisplay",
+				"turn_id":         "turn-123",
+				"message_id":      "message-456",
+				"index":           float64(2),
+				"final":           true,
+				"delta":           "newly completed line\n",
+			},
+		},
+	})
+	assert.Equal(t, "success", resp.Response.Subtype)
+}
+
+func TestBuildHookResponse_MessageDisplay_DisplayContentSet(t *testing.T) {
+	replacement := "replacement"
+	resp := buildHookResponse("MessageDisplay", HookResult{
+		Continue:       true,
+		DisplayContent: &replacement,
+	})
+
+	hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "MessageDisplay", hso["hookEventName"])
+	assert.Equal(t, "replacement", hso["displayContent"])
+}
+
+func TestBuildHookResponse_MessageDisplay_DisplayContentNil(t *testing.T) {
+	resp := buildHookResponse("MessageDisplay", HookResult{
+		Continue: true,
+	})
+
+	_, has := resp["hookSpecificOutput"]
+	assert.False(t, has)
+}
+
+func TestBuildHookResponse_DisplayContentIgnoredOnNonMessageDisplay(t *testing.T) {
+	replacement := "x"
+	resp := buildHookResponse("PostToolUse", HookResult{
+		Continue:       true,
+		DisplayContent: &replacement,
+	})
+
+	_, has := resp["hookSpecificOutput"]
+	assert.False(t, has)
+}
+
 func TestBuildHookResponse_WatchPaths(t *testing.T) {
 	t.Run("CwdChanged emits watchPaths", func(t *testing.T) {
 		resp := buildHookResponse("CwdChanged", HookResult{


### PR DESCRIPTION
Adds the `MessageDisplay` hook event to the Go SDK, mirroring TS SDK
v0.3.168 (sdk.d.ts L1153-L1191). Fires once per delta flush while an
assistant message streams; display-only (stored message + what the
model sees are untouched).

- `HookTypeMessageDisplay` constant
- `MessageDisplayInput { TurnID, MessageID, Index, Final, Delta }`
- `HookResult.DisplayContent *string` for the hookSpecificOutput surface
- protocol.go dispatch on both transport paths + buildHookResponse emission
- unit tests for dispatch + 3 output cases (set, nil, ignored on non-MessageDisplay)
- integration: `t.Skip` — the v0.3.168 CLI does not emit MessageDisplay
  events onto SDK transports during streaming; tracked in
  memory/catchup-v0.3.168/INTEGRATION-FOLLOWUPS.md

See memory/catchup-v0.3.168/PLAN.md §"PR-01".