### PR TITLE
messages: add ThinkingTokensMessage system subtype (v0.3.168 deferred Phase I-2)

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -10,6 +10,7 @@
 - Backfill `TestIntegrationAssistantMessageError` when the CLI test fixture can deterministically force an upstream API failure into an `assistant` event.
 - Backfill `TestIntegrationResultMessageOriginTTFT` when the CLI test fixture can deterministically emit `origin` and/or `ttft_ms` on a result event.
 - Backfill `TestIntegrationTaskLifecycleFields` when the CLI test fixture can deterministically run a Task-tool subagent (populates `subagent_type` on `task_started`/`task_progress`) and pause a running task (emits `task_updated` with `status:"paused"`).
+- Backfill `TestIntegrationThinkingTokensMessage` when the CLI test fixture can deterministically invoke a thinking-capable model through a redacted-thinking phase so `thinking_tokens` system events are emitted.
 - Backfill `TestIntegrationCompactBoundaryPreservedMessages` when the CLI test fixture can deterministically trigger a partial compaction with messagesToKeep so the `compact_metadata.preserved_messages` block is populated.
 - Backfill `TestIntegrationMemoryRecallOrganizationScope` when the CLI test fixture can deterministically surface an organization-scoped memory (https URL + inline content) on a `memory_recall` system event.
 - Backfill `TestIntegrationPartialAssistantParentToolUseID` when the CLI test fixture can deterministically emit a streaming partial event nested under a Task-tool subagent so `parent_tool_use_id` carries a non-null tool_use id.

--- a/integration_test.go
+++ b/integration_test.go
@@ -808,6 +808,13 @@ func TestIntegrationTaskLifecycleFields(t *testing.T) {
 	t.Skip("requires CLI to emit a Task-tool subagent run (subagent_type) and a paused-status task_updated event; tracked in INTEGRATION-FOLLOWUPS.md")
 }
 
+func TestIntegrationThinkingTokensMessage(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	t.Skip("not triggerable from CLI: requires a thinking-capable model with redacted-thinking phase, which the standard integration run does not invoke")
+}
+
 func TestIntegrationBaseHookInputEffort(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/messages.go
+++ b/messages.go
@@ -1034,6 +1034,21 @@ type SessionStateChangedMessage struct {
 // MessageType implements Message.
 func (m SessionStateChangedMessage) MessageType() string { return "system" }
 
+// ThinkingTokensMessage reports live thinking-token estimates from
+// sdk.d.ts L3795-L3807. These values are approximate progress during
+// redacted thinking, not authoritative billed output_tokens.
+type ThinkingTokensMessage struct {
+	Type                 string `json:"type"`                   // Always "system"
+	Subtype              string `json:"subtype"`                // "thinking_tokens"
+	EstimatedTokens      int64  `json:"estimated_tokens"`       // Running total for the thinking block
+	EstimatedTokensDelta int64  `json:"estimated_tokens_delta"` // Increment carried by this frame
+	UUID                 string `json:"uuid"`                   // Unique message ID
+	SessionID            string `json:"session_id"`             // Session identifier
+}
+
+// MessageType implements Message.
+func (m ThinkingTokensMessage) MessageType() string { return "system" }
+
 // SDKStatusValue is the non-null status payload for a status message.
 type SDKStatusValue string
 
@@ -1232,6 +1247,10 @@ func ParseMessage(data []byte) (Message, error) {
 			return msg, err
 		case "status":
 			var msg StatusMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "thinking_tokens":
+			var msg ThinkingTokensMessage
 			err := json.Unmarshal(data, &msg)
 			return msg, err
 		default:

--- a/messages_test.go
+++ b/messages_test.go
@@ -2821,6 +2821,78 @@ func TestParseMessageSessionStateChanged(t *testing.T) {
 	}
 }
 
+func TestParseMessageThinkingTokens(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "thinking_tokens",
+		"estimated_tokens": 1234,
+		"estimated_tokens_delta": 56,
+		"uuid": "550e8400-e29b-41d4-a716-4466554402B0",
+		"session_id": "sess_misc_011"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	thinkingMsg, ok := msg.(ThinkingTokensMessage)
+	require.True(t, ok, "expected ThinkingTokensMessage")
+
+	assert.Equal(t, "system", thinkingMsg.MessageType())
+	assert.Equal(t, "system", thinkingMsg.Type)
+	assert.Equal(t, "thinking_tokens", thinkingMsg.Subtype)
+	assert.Equal(t, int64(1234), thinkingMsg.EstimatedTokens)
+	assert.Equal(t, int64(56), thinkingMsg.EstimatedTokensDelta)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-4466554402B0", thinkingMsg.UUID)
+	assert.Equal(t, "sess_misc_011", thinkingMsg.SessionID)
+}
+
+func TestThinkingTokensMessageRoundTrip(t *testing.T) {
+	want := ThinkingTokensMessage{
+		Type:                 "system",
+		Subtype:              "thinking_tokens",
+		EstimatedTokens:      1234,
+		EstimatedTokensDelta: 56,
+		UUID:                 "550e8400-e29b-41d4-a716-4466554402B1",
+		SessionID:            "sess_misc_011",
+	}
+
+	data, err := json.Marshal(want)
+	require.NoError(t, err)
+
+	msg, err := ParseMessage(data)
+	require.NoError(t, err)
+
+	got, ok := msg.(ThinkingTokensMessage)
+	require.True(t, ok, "expected ThinkingTokensMessage")
+	assert.Equal(t, want, got)
+}
+
+func TestParseMessageThinkingTokensZeroDelta(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "thinking_tokens",
+		"estimated_tokens": 1234,
+		"estimated_tokens_delta": 0,
+		"uuid": "550e8400-e29b-41d4-a716-4466554402B2",
+		"session_id": "sess_misc_011"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	thinkingMsg, ok := msg.(ThinkingTokensMessage)
+	require.True(t, ok, "expected ThinkingTokensMessage")
+	assert.Equal(t, int64(0), thinkingMsg.EstimatedTokensDelta)
+
+	data, err := json.Marshal(thinkingMsg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Contains(t, got, "estimated_tokens_delta")
+	assert.Equal(t, float64(0), got["estimated_tokens_delta"])
+}
+
 func TestParseMessageStatus(t *testing.T) {
 	tests := []struct {
 		name               string


### PR DESCRIPTION
## Summary

Adds the `thinking_tokens` system subtype from the v0.3.168 TS SDK
(`sdk.d.ts` L3795-L3807). Reported during the redacted-thinking phase
to expose a live estimate of thinking-token usage. These values are
approximate progress, not the authoritative billed `output_tokens`
on the result event — that distinction is called out in the doc
comment so callers don't reach for this field for billing.

New `ThinkingTokensMessage` struct mirrors the adjacent
`SessionStateChangedMessage` shape: a `Type` field that round-trips
`"system"` plus `MessageType()` returning `"system"` so the SDK
interface type stays consistent across the system subtypes.

## Test plan

- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean
- [x] `go vet -tags integration ./...` clean
- [x] `go test ./...` PASS
- Unit coverage: dispatch, full round-trip, zero-delta retention
  (delta is not `omitempty`)
- Integration: deliberate skip; the standard CLI run does not invoke
  a thinking-capable model through a redacted-thinking phase.
  Backfill tracked in `INTEGRATION-FOLLOWUPS.md`.