### PR TITLE
hooks: add SessionStart reloadSkills hook output (v0.3.168 deferred Phase I-3)

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -4,6 +4,7 @@
 - Backfill `TestIntegrationStopHookSessionCrons` when the CLI test fixture can deterministically create a session cron.
 - Backfill `TestIntegrationHookTerminalSequence` when the CLI test fixture can capture terminal-escape bytes emitted by hook `terminalSequence` returns. Currently those go straight to the controlling TTY and aren't observable on the SDK transport.
 - Backfill `TestIntegrationHookSuppressOriginalPrompt` when the CLI test fixture can assert the block-message body the CLI returns when a UserPromptSubmit hook returns `suppressOriginalPrompt: true`. The omission is a CLI rendering behavior, not surfaced on the SDK transport.
+- Backfill `TestIntegrationSessionStartReloadSkills` when the CLI test fixture can change `CLAUDE_SKILLS_DIR` between SessionStart and the first message so reload-skills behavior is observable in standard integration runs.
 - Backfill `TestIntegrationPostToolUseUpdatedToolOutput` when the CLI test fixture can deterministically run a tool whose output a PostToolUse hook rewrites, so the model receives the rewritten value rather than the original tool response.
 - Backfill `TestIntegrationAssistantMessageSubagentFields` when the CLI test fixture can deterministically run a subagent task end-to-end.
 - Backfill `TestIntegrationUserMessageSubagentFields` when the CLI test fixture can deterministically run a Task-tool subagent whose tool-result user message round-trips `subagent_type` + `task_description`.

--- a/integration_test.go
+++ b/integration_test.go
@@ -740,6 +740,13 @@ func TestIntegrationHookSuppressOriginalPrompt(t *testing.T) {
 	t.Skip("not directly assertable from CLI: suppressOriginalPrompt is a CLI block-message rendering behavior, not surfaced on the SDK transport")
 }
 
+func TestIntegrationSessionStartReloadSkills(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	t.Skip("not triggerable from CLI: SessionStart hook reload-skills behavior requires a CLAUDE_SKILLS_DIR change between session start and first message; not exercisable in standard integration runs")
+}
+
 func TestIntegrationMessageDisplayHook(t *testing.T) {
 	// Registering HookTypeMessageDisplay against a streamed assistant turn
 	// (with WithMaxTurns(1) and a normal prompt) yields zero callback

--- a/options.go
+++ b/options.go
@@ -1995,6 +1995,14 @@ type HookResult struct {
 	// prompt itself was the reason for the block (PII, credentials, etc.).
 	SuppressOriginalPrompt *bool
 
+	// ReloadSkills, when set on a SessionStart hook return, asks the CLI to
+	// re-scan skill and command directories after SessionStart hooks complete.
+	// Honored only on SessionStart hooks and silently dropped for other hook
+	// types; nil leaves the wire field unset and a pointer to false explicitly
+	// opts out. Translates into hookSpecificOutput.reloadSkills per sdk.d.ts
+	// v0.3.168 L3990.
+	ReloadSkills *bool `json:"reloadSkills,omitempty"`
+
 	// DisplayContent replaces the displayed delta for MessageDisplay hooks
 	// without changing the stored message or model-visible content. Honored
 	// only on MessageDisplay hooks and silently dropped for other hook types.

--- a/protocol.go
+++ b/protocol.go
@@ -1634,6 +1634,17 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 		resp["hookSpecificOutput"] = hookSpecificOutput
 	}
 
+	if result.ReloadSkills != nil && hookType == string(HookTypeSessionStart) {
+		hookSpecificOutput, _ := resp["hookSpecificOutput"].(map[string]interface{})
+		if hookSpecificOutput == nil {
+			hookSpecificOutput = map[string]interface{}{
+				"hookEventName": string(HookTypeSessionStart),
+			}
+		}
+		hookSpecificOutput["reloadSkills"] = *result.ReloadSkills
+		resp["hookSpecificOutput"] = hookSpecificOutput
+	}
+
 	if result.DisplayContent != nil && hookType == string(HookTypeMessageDisplay) {
 		hookSpecificOutput, _ := resp["hookSpecificOutput"].(map[string]interface{})
 		if hookSpecificOutput == nil {

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -2872,6 +2872,74 @@ func TestBuildHookResponse_SuppressOriginalPrompt(t *testing.T) {
 	})
 }
 
+func TestBuildHookResponse_ReloadSkills_True(t *testing.T) {
+	v := true
+	resp := buildHookResponse("SessionStart", HookResult{
+		Continue:     true,
+		ReloadSkills: &v,
+	})
+
+	hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "SessionStart", hso["hookEventName"])
+	assert.Equal(t, true, hso["reloadSkills"])
+}
+
+func TestBuildHookResponse_ReloadSkills_False(t *testing.T) {
+	v := false
+	resp := buildHookResponse("SessionStart", HookResult{
+		Continue:     true,
+		ReloadSkills: &v,
+	})
+
+	hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, false, hso["reloadSkills"])
+}
+
+func TestBuildHookResponse_ReloadSkills_Nil(t *testing.T) {
+	resp := buildHookResponse("SessionStart", HookResult{
+		Continue: true,
+	})
+
+	_, has := resp["hookSpecificOutput"]
+	assert.False(t, has)
+}
+
+func TestBuildHookResponse_ReloadSkills_IgnoredOnPreToolUse(t *testing.T) {
+	v := true
+	resp := buildHookResponse("PreToolUse", HookResult{
+		Continue:     true,
+		ReloadSkills: &v,
+	})
+
+	_, has := resp["hookSpecificOutput"]
+	assert.False(t, has)
+}
+
+func TestBuildHookResponse_ReloadSkills_ComposesWithAdditionalContext(t *testing.T) {
+	v := true
+	result := HookResult{
+		Continue:     true,
+		ReloadSkills: &v,
+		HookSpecificOutput: map[string]interface{}{
+			"hookEventName":     "SessionStart",
+			"additionalContext": "skills installed",
+		},
+	}
+
+	resp := buildHookResponse("SessionStart", result)
+
+	hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "SessionStart", hso["hookEventName"])
+	assert.Equal(t, "skills installed", hso["additionalContext"])
+	assert.Equal(t, true, hso["reloadSkills"])
+
+	_, mutated := result.HookSpecificOutput["reloadSkills"]
+	assert.False(t, mutated)
+}
+
 func TestGetHookInput_MessageDisplay(t *testing.T) {
 	runner := NewMockSubprocessRunner()
 	opts := NewOptions()


### PR DESCRIPTION
## Summary

Adds `reloadSkills` to the SessionStart hook-specific output from the
v0.3.168 TS SDK (`sdk.d.ts` L3990). When a SessionStart hook returns
`reloadSkills: true` the CLI re-scans skill and command directories
before continuing the session — the natural pairing for a hook that
just installed new skills on disk.

`HookResult.ReloadSkills *bool` follows the same pointer pattern as
`SuppressOriginalPrompt` and `DisplayContent`: nil leaves the wire
field unset and `&false` explicitly opts out. Gated to `SessionStart`
in `buildHookResponse`; silently dropped on other hook types. The
late-merge into `hookSpecificOutput` uses the compose pattern from
the v0.3.150 PR-28 work so caller-provided maps aren't clobbered and
the input `HookResult.HookSpecificOutput` isn't mutated.

## Test plan

- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean
- [x] `go vet -tags integration ./...` clean
- [x] `go test ./...` PASS
- Unit coverage: true / false / nil dispatch on SessionStart, silent
  drop on PreToolUse, composition with caller-provided
  `additionalContext` plus a non-mutation assertion on the input map.
- Integration: deliberate skip; reload-skills requires changing
  `CLAUDE_SKILLS_DIR` between SessionStart and the first message,
  which the standard CLI integration run does not do. Backfill
  tracked in `INTEGRATION-FOLLOWUPS.md`.