### PR TITLE
hooks: add SessionTitle to SessionStart + UserPromptSubmit hook inputs (v0.3.168 deferred Phase I-4)

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -5,6 +5,7 @@
 - Backfill `TestIntegrationHookTerminalSequence` when the CLI test fixture can capture terminal-escape bytes emitted by hook `terminalSequence` returns. Currently those go straight to the controlling TTY and aren't observable on the SDK transport.
 - Backfill `TestIntegrationHookSuppressOriginalPrompt` when the CLI test fixture can assert the block-message body the CLI returns when a UserPromptSubmit hook returns `suppressOriginalPrompt: true`. The omission is a CLI rendering behavior, not surfaced on the SDK transport.
 - Backfill `TestIntegrationSessionStartReloadSkills` when the CLI test fixture can change `CLAUDE_SKILLS_DIR` between SessionStart and the first message so reload-skills behavior is observable in standard integration runs.
+- Backfill `TestIntegrationSessionTitleField` when the CLI test fixture can explicitly rename the session so `session_title` is emitted on SessionStart and UserPromptSubmit hook inputs.
 - Backfill `TestIntegrationPostToolUseUpdatedToolOutput` when the CLI test fixture can deterministically run a tool whose output a PostToolUse hook rewrites, so the model receives the rewritten value rather than the original tool response.
 - Backfill `TestIntegrationAssistantMessageSubagentFields` when the CLI test fixture can deterministically run a subagent task end-to-end.
 - Backfill `TestIntegrationUserMessageSubagentFields` when the CLI test fixture can deterministically run a Task-tool subagent whose tool-result user message round-trips `subagent_type` + `task_description`.

--- a/integration_test.go
+++ b/integration_test.go
@@ -747,6 +747,13 @@ func TestIntegrationSessionStartReloadSkills(t *testing.T) {
 	t.Skip("not triggerable from CLI: SessionStart hook reload-skills behavior requires a CLAUDE_SKILLS_DIR change between session start and first message; not exercisable in standard integration runs")
 }
 
+func TestIntegrationSessionTitleField(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	t.Skip("not triggerable from CLI: session_title only emits when user explicitly renames the session, which the standard integration run does not invoke")
+}
+
 func TestIntegrationMessageDisplayHook(t *testing.T) {
 	// Registering HookTypeMessageDisplay against a streamed assistant turn
 	// (with WithMaxTurns(1) and a normal prompt) yields zero callback

--- a/options.go
+++ b/options.go
@@ -1474,6 +1474,9 @@ func (i PostToolUseInput) Base() BaseHookInput { return i.BaseHookInput }
 type UserPromptSubmitInput struct {
 	BaseHookInput
 	Prompt string `json:"prompt"`
+	// SessionTitle is the optional user-facing session label from TS L6094.
+	// Nil means the field was absent on the wire.
+	SessionTitle *string `json:"session_title,omitempty"`
 }
 
 // HookType implements HookInput.
@@ -1621,6 +1624,9 @@ func (i NotificationInput) Base() BaseHookInput { return i.BaseHookInput }
 type SessionStartInput struct {
 	BaseHookInput
 	Source string `json:"source"` // "startup", "resume", "clear", or "compact"
+	// SessionTitle is the optional user-facing session label from TS L3978.
+	// Nil means the field was absent on the wire.
+	SessionTitle *string `json:"session_title,omitempty"`
 }
 
 // HookType implements HookInput.

--- a/protocol.go
+++ b/protocol.go
@@ -428,6 +428,7 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 		input = UserPromptSubmitInput{
 			BaseHookInput: base,
 			Prompt:        getString(inputData, "prompt"),
+			SessionTitle:  getOptionalString(inputData, "session_title"),
 		}
 	case HookTypeStop:
 		input = StopInput{
@@ -484,6 +485,7 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 		input = SessionStartInput{
 			BaseHookInput: base,
 			Source:        getString(inputData, "source"),
+			SessionTitle:  getOptionalString(inputData, "session_title"),
 		}
 	case HookTypeSessionEnd:
 		input = SessionEndInput{
@@ -936,6 +938,7 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 		input = UserPromptSubmitInput{
 			BaseHookInput: base,
 			Prompt:        getString(hookInput, "prompt"),
+			SessionTitle:  getOptionalString(hookInput, "session_title"),
 		}
 	case "Stop":
 		input = StopInput{
@@ -992,6 +995,7 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 		input = SessionStartInput{
 			BaseHookInput: base,
 			Source:        getString(hookInput, "source"),
+			SessionTitle:  getOptionalString(hookInput, "session_title"),
 		}
 	case "SessionEnd":
 		input = SessionEndInput{
@@ -1401,6 +1405,14 @@ func getString(m map[string]interface{}, key string) string {
 		return ""
 	}
 	return v
+}
+
+func getOptionalString(m map[string]interface{}, key string) *string {
+	v, ok := m[key].(string)
+	if !ok {
+		return nil
+	}
+	return &v
 }
 
 func getInt(m map[string]interface{}, key string) int {

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -3082,6 +3082,141 @@ func TestBuildHookResponse_WatchPaths(t *testing.T) {
 	})
 }
 
+func TestGetHookInput_SessionStart_SessionTitle(t *testing.T) {
+	title := "My Session"
+
+	assertLegacyHookInput(t, map[string]interface{}{
+		"hook_event":    "SessionStart",
+		"source":        "startup",
+		"session_title": title,
+	}, func(input HookInput) {
+		ev, ok := input.(SessionStartInput)
+		require.True(t, ok)
+		require.NotNil(t, ev.SessionTitle)
+		assert.Equal(t, title, *ev.SessionTitle)
+	})
+
+	assertSDKHookInput(t, map[string]interface{}{
+		"hook_event_name": "SessionStart",
+		"source":          "startup",
+		"session_title":   title,
+	}, func(input HookInput) {
+		ev, ok := input.(SessionStartInput)
+		require.True(t, ok)
+		require.NotNil(t, ev.SessionTitle)
+		assert.Equal(t, title, *ev.SessionTitle)
+	})
+}
+
+func TestGetHookInput_SessionStart_NoSessionTitle(t *testing.T) {
+	assertLegacyHookInput(t, map[string]interface{}{
+		"hook_event": "SessionStart",
+		"source":     "startup",
+	}, func(input HookInput) {
+		ev, ok := input.(SessionStartInput)
+		require.True(t, ok)
+		assert.Nil(t, ev.SessionTitle)
+	})
+
+	assertSDKHookInput(t, map[string]interface{}{
+		"hook_event_name": "SessionStart",
+		"source":          "startup",
+	}, func(input HookInput) {
+		ev, ok := input.(SessionStartInput)
+		require.True(t, ok)
+		assert.Nil(t, ev.SessionTitle)
+	})
+}
+
+func TestGetHookInput_UserPromptSubmit_SessionTitle(t *testing.T) {
+	title := "My Session"
+
+	assertLegacyHookInput(t, map[string]interface{}{
+		"hook_event":    "UserPromptSubmit",
+		"prompt":        "hello",
+		"session_title": title,
+	}, func(input HookInput) {
+		ev, ok := input.(UserPromptSubmitInput)
+		require.True(t, ok)
+		require.NotNil(t, ev.SessionTitle)
+		assert.Equal(t, title, *ev.SessionTitle)
+	})
+
+	assertSDKHookInput(t, map[string]interface{}{
+		"hook_event_name": "UserPromptSubmit",
+		"prompt":          "hello",
+		"session_title":   title,
+	}, func(input HookInput) {
+		ev, ok := input.(UserPromptSubmitInput)
+		require.True(t, ok)
+		require.NotNil(t, ev.SessionTitle)
+		assert.Equal(t, title, *ev.SessionTitle)
+	})
+}
+
+func TestGetHookInput_UserPromptSubmit_NoSessionTitle(t *testing.T) {
+	assertLegacyHookInput(t, map[string]interface{}{
+		"hook_event": "UserPromptSubmit",
+		"prompt":     "hello",
+	}, func(input HookInput) {
+		ev, ok := input.(UserPromptSubmitInput)
+		require.True(t, ok)
+		assert.Nil(t, ev.SessionTitle)
+	})
+
+	assertSDKHookInput(t, map[string]interface{}{
+		"hook_event_name": "UserPromptSubmit",
+		"prompt":          "hello",
+	}, func(input HookInput) {
+		ev, ok := input.(UserPromptSubmitInput)
+		require.True(t, ok)
+		assert.Nil(t, ev.SessionTitle)
+	})
+}
+
+func assertLegacyHookInput(t *testing.T, inputData map[string]interface{}, assertInput func(HookInput)) {
+	t.Helper()
+
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+	protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+		assertInput(input)
+		return HookResult{Continue: true}, nil
+	}
+
+	resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+		RequestID: "r",
+		Payload: map[string]interface{}{
+			"callback_id": "h",
+			"input":       inputData,
+		},
+	})
+	assert.Equal(t, "success", resp.Response.Subtype)
+}
+
+func assertSDKHookInput(t *testing.T, inputData map[string]interface{}, assertInput func(HookInput)) {
+	t.Helper()
+
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+	protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+		assertInput(input)
+		return HookResult{Continue: true}, nil
+	}
+
+	resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+		RequestID: "r",
+		Request: SDKControlRequestBody{
+			Subtype:    "hook_callback",
+			CallbackID: "h",
+			Input:      inputData,
+		},
+	})
+	assert.Equal(t, "success", resp.Response.Subtype)
+}
+
 // TestHandleHookCallback_ShapeCompatibleEvents covers the 12 v0.2.119 events
 // added in PR 8b. Each subtest exercises one event end-to-end through one of
 // the two dispatch paths and asserts every event-specific field on the parsed


### PR DESCRIPTION
## Summary

Surfaces the optional `session_title` field from the v0.3.168 TS SDK
on both hook inputs that carry it: `SessionStartHookInput`
(`sdk.d.ts` L3978) and `UserPromptSubmitHookInput` (`sdk.d.ts` L6094).
The CLI sets this when the user has explicitly named the session or
when an auto-titler generated one — exposing it lets hook authors
read the label without a separate session lookup.

**Scope correction note.** An earlier revision of the brief and the
PLAN row claimed `session_title` lived on `SDKResultMessage` and
`SessionEndHookInput`. TS verification (v0.3.150 / v0.3.159 /
v0.3.168) showed it has only ever been on these two hook inputs —
never on result or session-end. The brief and PLAN were corrected
before this PR was authored.

Adds a small `getOptionalString` helper alongside `getString` so all
four dispatch sites (legacy `handleHookCallback` and SDK
`handleSDKHookCallback`, each for `SessionStart` and
`UserPromptSubmit`) parse the wire field identically. Nil means the
key was absent or non-string; non-nil pointer carries the wire value
verbatim.

## Test plan

- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean
- [x] `go vet -tags integration ./...` clean
- [x] `go test ./...` PASS
- Unit coverage: four tests exercising both dispatchers (legacy +
  SDK control) for both hooks (`SessionStart` and
  `UserPromptSubmit`), present and absent.
- Integration: deliberate skip; emitting `session_title` requires
  the user to rename the session, which the standard CLI
  integration run does not invoke. Backfill tracked in
  `INTEGRATION-FOLLOWUPS.md`.