### PR TITLE
options: add workflows + ultracode + pluginSuggestionMarketplaces settings (v0.3.168 deferred Phase I-5/6/7)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2041,6 +2041,17 @@ func TestIntegrationSettingsManagedOrgFields(t *testing.T) {
 	t.Skip("not directly assertable from CLI: managed-org settings are honored only from admin-controlled policy sources, not surfaced on user CLI flag entry points")
 }
 
+func TestIntegrationSettingsWorkflowsFields(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// TODO: Backfill when the CLI test fixture can deterministically inject
+	// workflows + ultracode + pluginSuggestionMarketplaces through managed or
+	// session settings so the SDK can observe resolved workflow policy state.
+	// Tracked in memory/catchup-v0.3.168/INTEGRATION-FOLLOWUPS.md.
+	t.Skip("not triggerable from CLI: workflows + ultracode + pluginSuggestionMarketplaces are admin-policy-tier toggles not surfaced via standard CLI flags")
+}
+
 func TestIntegrationSettingsSandboxFields(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/options.go
+++ b/options.go
@@ -289,87 +289,91 @@ type Settings struct {
 	AWSAuthRefresh      string `json:"awsAuthRefresh,omitempty"`
 	GCPAuthRefresh      string `json:"gcpAuthRefresh,omitempty"`
 	// PolicyHelper configures the admin-controlled policy executable invoked at startup to compute managed settings. Honored only from policy sources. Mirrors sdk.d.ts v0.3.150 L3993.
-	PolicyHelper                      *SettingsPolicyHelper            `json:"policyHelper,omitempty"`
-	FileSuggestion                    *SettingsFileSuggestion          `json:"fileSuggestion,omitempty"`
-	RespectGitignore                  *bool                            `json:"respectGitignore,omitempty"`
-	CleanupPeriodDays                 *int                             `json:"cleanupPeriodDays,omitempty"`
-	SkillListingMaxDescChars          *int                             `json:"skillListingMaxDescChars,omitempty"`
-	SkillListingBudgetFraction        *float64                         `json:"skillListingBudgetFraction,omitempty"`
-	WSLInheritsWindowsSettings        *bool                            `json:"wslInheritsWindowsSettings,omitempty"`
-	Env                               map[string]string                `json:"env,omitempty"`
-	Attribution                       *SettingsAttribution             `json:"attribution,omitempty"`
-	IncludeCoAuthoredBy               *bool                            `json:"includeCoAuthoredBy,omitempty"`
-	IncludeGitInstructions            *bool                            `json:"includeGitInstructions,omitempty"`
-	Permissions                       *SettingsPermissions             `json:"permissions,omitempty"`
-	Model                             string                           `json:"model,omitempty"`
-	AvailableModels                   []string                         `json:"availableModels,omitempty"`
-	ModelOverrides                    map[string]string                `json:"modelOverrides,omitempty"`
-	EnableAllProjectMCPServers        *bool                            `json:"enableAllProjectMcpServers,omitempty"`
-	EnabledMCPJSONServers             []string                         `json:"enabledMcpjsonServers,omitempty"`
-	DisabledMCPJSONServers            []string                         `json:"disabledMcpjsonServers,omitempty"`
-	SkillOverrides                    map[string]SettingsSkillOverride `json:"skillOverrides,omitempty"`
-	AllowedMCPServers                 []SettingsMCPServerMatcher       `json:"allowedMcpServers,omitempty"`
-	DeniedMCPServers                  []SettingsMCPServerMatcher       `json:"deniedMcpServers,omitempty"`
-	Hooks                             map[string][]SettingsHookMatcher `json:"hooks,omitempty"`
-	Worktree                          *SettingsWorktree                `json:"worktree,omitempty"`
-	DisableAllHooks                   *bool                            `json:"disableAllHooks,omitempty"`
-	DisableSkillShellExecution        *bool                            `json:"disableSkillShellExecution,omitempty"`
-	DefaultShell                      string                           `json:"defaultShell,omitempty"`
-	AllowManagedHooksOnly             *bool                            `json:"allowManagedHooksOnly,omitempty"`
-	AllowedHTTPHookURLs               []string                         `json:"allowedHttpHookUrls,omitempty"`
-	HTTPHookAllowedEnvVars            []string                         `json:"httpHookAllowedEnvVars,omitempty"`
-	AllowManagedPermissionRulesOnly   *bool                            `json:"allowManagedPermissionRulesOnly,omitempty"`
-	AllowManagedMCPServersOnly        *bool                            `json:"allowManagedMcpServersOnly,omitempty"`
-	StrictPluginOnlyCustomization     interface{}                      `json:"strictPluginOnlyCustomization,omitempty"`
-	StatusLine                        *SettingsCommand                 `json:"statusLine,omitempty"`
-	PRURLTemplate                     string                           `json:"prUrlTemplate,omitempty"`
-	SubagentStatusLine                *SettingsCommand                 `json:"subagentStatusLine,omitempty"`
-	EnabledPlugins                    map[string]interface{}           `json:"enabledPlugins,omitempty"`
-	ExtraKnownMarketplaces            map[string]SettingsMarketplace   `json:"extraKnownMarketplaces,omitempty"`
-	StrictKnownMarketplaces           []SettingsMarketplaceSource      `json:"strictKnownMarketplaces,omitempty"`
-	BlockedMarketplaces               []SettingsMarketplaceSource      `json:"blockedMarketplaces,omitempty"`
-	ForceLoginMethod                  string                           `json:"forceLoginMethod,omitempty"`
-	ForceLoginOrgUUID                 interface{}                      `json:"forceLoginOrgUUID,omitempty"`
-	ForceRemoteSettingsRefresh        *bool                            `json:"forceRemoteSettingsRefresh,omitempty"`
-	OtelHeadersHelper                 string                           `json:"otelHeadersHelper,omitempty"`
-	OutputStyle                       string                           `json:"outputStyle,omitempty"`
-	ViewMode                          string                           `json:"viewMode,omitempty"`
-	Language                          string                           `json:"language,omitempty"`
-	SkipWebFetchPreflight             *bool                            `json:"skipWebFetchPreflight,omitempty"`
-	Sandbox                           *SettingsSandbox                 `json:"sandbox,omitempty"`
-	FeedbackSurveyRate                *float64                         `json:"feedbackSurveyRate,omitempty"`
-	SpinnerTipsEnabled                *bool                            `json:"spinnerTipsEnabled,omitempty"`
-	SpinnerVerbs                      *SettingsSpinnerVerbs            `json:"spinnerVerbs,omitempty"`
-	SpinnerTipsOverride               *SettingsSpinnerTipsOverride     `json:"spinnerTipsOverride,omitempty"`
-	SyntaxHighlightingDisabled        *bool                            `json:"syntaxHighlightingDisabled,omitempty"`
-	TerminalTitleFromRename           *bool                            `json:"terminalTitleFromRename,omitempty"`
-	AlwaysThinkingEnabled             *bool                            `json:"alwaysThinkingEnabled,omitempty"`
-	EffortLevel                       EffortLevel                      `json:"effortLevel,omitempty"`
-	AutoCompactWindow                 *int                             `json:"autoCompactWindow,omitempty"`
-	AdvisorModel                      string                           `json:"advisorModel,omitempty"`
-	FastMode                          *bool                            `json:"fastMode,omitempty"`
-	FastModePerSessionOptIn           *bool                            `json:"fastModePerSessionOptIn,omitempty"`
-	PromptSuggestionEnabled           *bool                            `json:"promptSuggestionEnabled,omitempty"`
-	ShowClearContextOnPlanAccept      *bool                            `json:"showClearContextOnPlanAccept,omitempty"`
-	Agent                             string                           `json:"agent,omitempty"`
-	CompanyAnnouncements              []string                         `json:"companyAnnouncements,omitempty"`
-	PluginConfigs                     map[string]SettingsPluginConfig  `json:"pluginConfigs,omitempty"`
-	Remote                            *SettingsRemote                  `json:"remote,omitempty"`
-	AutoUpdatesChannel                string                           `json:"autoUpdatesChannel,omitempty"`
-	MinimumVersion                    string                           `json:"minimumVersion,omitempty"`
-	PlansDirectory                    string                           `json:"plansDirectory,omitempty"`
-	TUI                               string                           `json:"tui,omitempty"`
-	Voice                             *SettingsVoice                   `json:"voice,omitempty"`
-	ChannelsEnabled                   *bool                            `json:"channelsEnabled,omitempty"`
-	AllowedChannelPlugins             []SettingsChannelPlugin          `json:"allowedChannelPlugins,omitempty"`
-	PrefersReducedMotion              *bool                            `json:"prefersReducedMotion,omitempty"`
-	AutoMemoryEnabled                 *bool                            `json:"autoMemoryEnabled,omitempty"`
-	AutoMemoryDirectory               string                           `json:"autoMemoryDirectory,omitempty"`
-	AutoDreamEnabled                  *bool                            `json:"autoDreamEnabled,omitempty"`
-	ShowThinkingSummaries             *bool                            `json:"showThinkingSummaries,omitempty"`
-	SkipDangerousModePermissionPrompt *bool                            `json:"skipDangerousModePermissionPrompt,omitempty"`
-	DisableAutoMode                   string                           `json:"disableAutoMode,omitempty"`
-	SSHConfigs                        []SettingsSSHConfig              `json:"sshConfigs,omitempty"`
+	PolicyHelper                    *SettingsPolicyHelper            `json:"policyHelper,omitempty"`
+	FileSuggestion                  *SettingsFileSuggestion          `json:"fileSuggestion,omitempty"`
+	RespectGitignore                *bool                            `json:"respectGitignore,omitempty"`
+	CleanupPeriodDays               *int                             `json:"cleanupPeriodDays,omitempty"`
+	SkillListingMaxDescChars        *int                             `json:"skillListingMaxDescChars,omitempty"`
+	SkillListingBudgetFraction      *float64                         `json:"skillListingBudgetFraction,omitempty"`
+	WSLInheritsWindowsSettings      *bool                            `json:"wslInheritsWindowsSettings,omitempty"`
+	Env                             map[string]string                `json:"env,omitempty"`
+	Attribution                     *SettingsAttribution             `json:"attribution,omitempty"`
+	IncludeCoAuthoredBy             *bool                            `json:"includeCoAuthoredBy,omitempty"`
+	IncludeGitInstructions          *bool                            `json:"includeGitInstructions,omitempty"`
+	Permissions                     *SettingsPermissions             `json:"permissions,omitempty"`
+	Model                           string                           `json:"model,omitempty"`
+	AvailableModels                 []string                         `json:"availableModels,omitempty"`
+	ModelOverrides                  map[string]string                `json:"modelOverrides,omitempty"`
+	EnableAllProjectMCPServers      *bool                            `json:"enableAllProjectMcpServers,omitempty"`
+	EnabledMCPJSONServers           []string                         `json:"enabledMcpjsonServers,omitempty"`
+	DisabledMCPJSONServers          []string                         `json:"disabledMcpjsonServers,omitempty"`
+	SkillOverrides                  map[string]SettingsSkillOverride `json:"skillOverrides,omitempty"`
+	AllowedMCPServers               []SettingsMCPServerMatcher       `json:"allowedMcpServers,omitempty"`
+	DeniedMCPServers                []SettingsMCPServerMatcher       `json:"deniedMcpServers,omitempty"`
+	Hooks                           map[string][]SettingsHookMatcher `json:"hooks,omitempty"`
+	Worktree                        *SettingsWorktree                `json:"worktree,omitempty"`
+	DisableAllHooks                 *bool                            `json:"disableAllHooks,omitempty"`
+	DisableSkillShellExecution      *bool                            `json:"disableSkillShellExecution,omitempty"`
+	DefaultShell                    string                           `json:"defaultShell,omitempty"`
+	AllowManagedHooksOnly           *bool                            `json:"allowManagedHooksOnly,omitempty"`
+	AllowedHTTPHookURLs             []string                         `json:"allowedHttpHookUrls,omitempty"`
+	HTTPHookAllowedEnvVars          []string                         `json:"httpHookAllowedEnvVars,omitempty"`
+	AllowManagedPermissionRulesOnly *bool                            `json:"allowManagedPermissionRulesOnly,omitempty"`
+	AllowManagedMCPServersOnly      *bool                            `json:"allowManagedMcpServersOnly,omitempty"`
+	StrictPluginOnlyCustomization   interface{}                      `json:"strictPluginOnlyCustomization,omitempty"`
+	StatusLine                      *SettingsCommand                 `json:"statusLine,omitempty"`
+	PRURLTemplate                   string                           `json:"prUrlTemplate,omitempty"`
+	SubagentStatusLine              *SettingsCommand                 `json:"subagentStatusLine,omitempty"`
+	EnabledPlugins                  map[string]interface{}           `json:"enabledPlugins,omitempty"`
+	ExtraKnownMarketplaces          map[string]SettingsMarketplace   `json:"extraKnownMarketplaces,omitempty"`
+	StrictKnownMarketplaces         []SettingsMarketplaceSource      `json:"strictKnownMarketplaces,omitempty"`
+	BlockedMarketplaces             []SettingsMarketplaceSource      `json:"blockedMarketplaces,omitempty"`
+	// PluginSuggestionMarketplaces names managed marketplaces whose plugins may surface as contextual install suggestions. Honored only from managed settings. Mirrors sdk.d.ts v0.3.168 L5242.
+	PluginSuggestionMarketplaces []string                     `json:"pluginSuggestionMarketplaces,omitempty"`
+	ForceLoginMethod             string                       `json:"forceLoginMethod,omitempty"`
+	ForceLoginOrgUUID            interface{}                  `json:"forceLoginOrgUUID,omitempty"`
+	ForceRemoteSettingsRefresh   *bool                        `json:"forceRemoteSettingsRefresh,omitempty"`
+	OtelHeadersHelper            string                       `json:"otelHeadersHelper,omitempty"`
+	OutputStyle                  string                       `json:"outputStyle,omitempty"`
+	ViewMode                     string                       `json:"viewMode,omitempty"`
+	Language                     string                       `json:"language,omitempty"`
+	SkipWebFetchPreflight        *bool                        `json:"skipWebFetchPreflight,omitempty"`
+	Sandbox                      *SettingsSandbox             `json:"sandbox,omitempty"`
+	FeedbackSurveyRate           *float64                     `json:"feedbackSurveyRate,omitempty"`
+	SpinnerTipsEnabled           *bool                        `json:"spinnerTipsEnabled,omitempty"`
+	SpinnerVerbs                 *SettingsSpinnerVerbs        `json:"spinnerVerbs,omitempty"`
+	SpinnerTipsOverride          *SettingsSpinnerTipsOverride `json:"spinnerTipsOverride,omitempty"`
+	SyntaxHighlightingDisabled   *bool                        `json:"syntaxHighlightingDisabled,omitempty"`
+	TerminalTitleFromRename      *bool                        `json:"terminalTitleFromRename,omitempty"`
+	AlwaysThinkingEnabled        *bool                        `json:"alwaysThinkingEnabled,omitempty"`
+	EffortLevel                  EffortLevel                  `json:"effortLevel,omitempty"`
+	// Ultracode enables session-scoped workflow orchestration, typically via --settings or apply_flag_settings. Mirrors sdk.d.ts v0.3.168 L5413.
+	Ultracode                         *bool                           `json:"ultracode,omitempty"`
+	AutoCompactWindow                 *int                            `json:"autoCompactWindow,omitempty"`
+	AdvisorModel                      string                          `json:"advisorModel,omitempty"`
+	FastMode                          *bool                           `json:"fastMode,omitempty"`
+	FastModePerSessionOptIn           *bool                           `json:"fastModePerSessionOptIn,omitempty"`
+	PromptSuggestionEnabled           *bool                           `json:"promptSuggestionEnabled,omitempty"`
+	ShowClearContextOnPlanAccept      *bool                           `json:"showClearContextOnPlanAccept,omitempty"`
+	Agent                             string                          `json:"agent,omitempty"`
+	CompanyAnnouncements              []string                        `json:"companyAnnouncements,omitempty"`
+	PluginConfigs                     map[string]SettingsPluginConfig `json:"pluginConfigs,omitempty"`
+	Remote                            *SettingsRemote                 `json:"remote,omitempty"`
+	AutoUpdatesChannel                string                          `json:"autoUpdatesChannel,omitempty"`
+	MinimumVersion                    string                          `json:"minimumVersion,omitempty"`
+	PlansDirectory                    string                          `json:"plansDirectory,omitempty"`
+	TUI                               string                          `json:"tui,omitempty"`
+	Voice                             *SettingsVoice                  `json:"voice,omitempty"`
+	ChannelsEnabled                   *bool                           `json:"channelsEnabled,omitempty"`
+	AllowedChannelPlugins             []SettingsChannelPlugin         `json:"allowedChannelPlugins,omitempty"`
+	PrefersReducedMotion              *bool                           `json:"prefersReducedMotion,omitempty"`
+	AutoMemoryEnabled                 *bool                           `json:"autoMemoryEnabled,omitempty"`
+	AutoMemoryDirectory               string                          `json:"autoMemoryDirectory,omitempty"`
+	AutoDreamEnabled                  *bool                           `json:"autoDreamEnabled,omitempty"`
+	ShowThinkingSummaries             *bool                           `json:"showThinkingSummaries,omitempty"`
+	SkipDangerousModePermissionPrompt *bool                           `json:"skipDangerousModePermissionPrompt,omitempty"`
+	DisableAutoMode                   string                          `json:"disableAutoMode,omitempty"`
+	SSHConfigs                        []SettingsSSHConfig             `json:"sshConfigs,omitempty"`
 	// ClaudeMD is CLAUDE.md-style instructions injected as organization-managed memory. Honored only from managed / policy settings. Mirrors sdk.d.ts v0.3.150 L5343.
 	ClaudeMD                   string   `json:"claudeMd,omitempty"`
 	ClaudeMDExcludes           []string `json:"claudeMdExcludes,omitempty"`
@@ -395,6 +399,12 @@ type Settings struct {
 	DisableAgentView *bool `json:"disableAgentView,omitempty"`
 	// DisableRemoteControl disables Remote Control. Typically set in managed settings. Mirrors sdk.d.ts v0.3.150 L4379.
 	DisableRemoteControl *bool `json:"disableRemoteControl,omitempty"`
+	// DisableWorkflows disables the Workflows feature, also via CLAUDE_CODE_DISABLE_WORKFLOWS. Mirrors sdk.d.ts v0.3.168 L4573.
+	DisableWorkflows *bool `json:"disableWorkflows,omitempty"`
+	// EnableWorkflows enables or disables Workflows for this user. Unset leaves the plan default. Mirrors sdk.d.ts v0.3.168 L4577.
+	EnableWorkflows *bool `json:"enableWorkflows,omitempty"`
+	// WorkflowKeywordTriggerEnabled enables the "ultracode" keyword trigger for the Workflow tool. Mirrors sdk.d.ts v0.3.168 L4582.
+	WorkflowKeywordTriggerEnabled *bool `json:"workflowKeywordTriggerEnabled,omitempty"`
 	// AllowAllClaudeAiMcps lets claude.ai cloud MCP connectors load alongside managed-mcp.json. Mirrors sdk.d.ts v0.3.150 L4411.
 	AllowAllClaudeAiMcps *bool `json:"allowAllClaudeAiMcps,omitempty"`
 	// ParentSettingsBehavior controls whether the SDK parent tier layers under the admin tier. Mirrors sdk.d.ts v0.3.150 L5019.

--- a/options_test.go
+++ b/options_test.go
@@ -309,6 +309,128 @@ func TestSettingsManagedOrgFieldsJSON(t *testing.T) {
 	})
 }
 
+func TestSettingsWorkflowsFieldsJSON(t *testing.T) {
+	t.Run("nil and empty fields omitted", func(t *testing.T) {
+		data, err := json.Marshal(Settings{
+			PluginSuggestionMarketplaces: []string{},
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		for _, k := range []string{
+			"disableWorkflows",
+			"enableWorkflows",
+			"workflowKeywordTriggerEnabled",
+			"pluginSuggestionMarketplaces",
+			"ultracode",
+		} {
+			assert.NotContains(t, got, k, "key %q must be omitted when nil or empty", k)
+		}
+	})
+
+	t.Run("disableWorkflows true round-trips", func(t *testing.T) {
+		v := true
+		data, err := json.Marshal(Settings{DisableWorkflows: &v})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, true, got["disableWorkflows"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.NotNil(t, out.DisableWorkflows)
+		assert.True(t, *out.DisableWorkflows)
+	})
+
+	t.Run("enableWorkflows false round-trips", func(t *testing.T) {
+		v := false
+		data, err := json.Marshal(Settings{EnableWorkflows: &v})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, false, got["enableWorkflows"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.NotNil(t, out.EnableWorkflows)
+		assert.False(t, *out.EnableWorkflows)
+	})
+
+	t.Run("workflowKeywordTriggerEnabled true round-trips", func(t *testing.T) {
+		v := true
+		data, err := json.Marshal(Settings{WorkflowKeywordTriggerEnabled: &v})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, true, got["workflowKeywordTriggerEnabled"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.NotNil(t, out.WorkflowKeywordTriggerEnabled)
+		assert.True(t, *out.WorkflowKeywordTriggerEnabled)
+	})
+
+	t.Run("pluginSuggestionMarketplaces round-trips", func(t *testing.T) {
+		data, err := json.Marshal(Settings{
+			PluginSuggestionMarketplaces: []string{"a", "b"},
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, []interface{}{"a", "b"}, got["pluginSuggestionMarketplaces"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, []string{"a", "b"}, out.PluginSuggestionMarketplaces)
+	})
+
+	t.Run("ultracode true round-trips", func(t *testing.T) {
+		v := true
+		data, err := json.Marshal(Settings{Ultracode: &v})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, true, got["ultracode"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.NotNil(t, out.Ultracode)
+		assert.True(t, *out.Ultracode)
+	})
+
+	t.Run("all fields round-trip together", func(t *testing.T) {
+		enabled := true
+		disabled := false
+		in := Settings{
+			DisableWorkflows:              &enabled,
+			EnableWorkflows:               &disabled,
+			WorkflowKeywordTriggerEnabled: &enabled,
+			PluginSuggestionMarketplaces:  []string{"internal", "partner"},
+			Ultracode:                     &enabled,
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.NotNil(t, out.DisableWorkflows)
+		assert.True(t, *out.DisableWorkflows)
+		require.NotNil(t, out.EnableWorkflows)
+		assert.False(t, *out.EnableWorkflows)
+		require.NotNil(t, out.WorkflowKeywordTriggerEnabled)
+		assert.True(t, *out.WorkflowKeywordTriggerEnabled)
+		assert.Equal(t, []string{"internal", "partner"}, out.PluginSuggestionMarketplaces)
+		require.NotNil(t, out.Ultracode)
+		assert.True(t, *out.Ultracode)
+	})
+}
+
 func TestSettingsSandboxFieldsJSON(t *testing.T) {
 	t.Run("tlsTerminate round-trips with both paths", func(t *testing.T) {
 		in := Settings{


### PR DESCRIPTION
## Summary

Surfaces five new optional `Settings` fields from the v0.3.168 TS SDK:

| Field | Type | sdk.d.ts | Notes |
|-------|------|----------|-------|
| `disableWorkflows` | `*bool` | L4573 | Also honors `CLAUDE_CODE_DISABLE_WORKFLOWS` env on the CLI side. |
| `enableWorkflows` | `*bool` | L4577 | Unset leaves the plan default. |
| `workflowKeywordTriggerEnabled` | `*bool` | L4582 | Enables the `ultracode` keyword trigger for the Workflow tool. |
| `pluginSuggestionMarketplaces` | `[]string` | L5242 | Managed-org marketplace gate. |
| `ultracode` | `*bool` | L5413 | Session-scoped (via `--settings` or `apply_flag_settings`). |

All `omitempty`. `*bool` everywhere except `pluginSuggestionMarketplaces` so an explicit `false` round-trips distinctly from the absent case.

## Placement

- `DisableWorkflows` / `EnableWorkflows` / `WorkflowKeywordTriggerEnabled` cluster together in spec order.
- `PluginSuggestionMarketplaces` sits in the managed-org policy cluster alongside `BlockedMarketplaces` and `StrictKnownMarketplaces`.
- `Ultracode` sits adjacent to `EffortLevel` and `AlwaysThinkingEnabled` in the session/runtime-toggle cluster.

Struct column alignment falls out of gofmt as a side effect of the longer field names landing in the upper block.

## Testing

- `TestSettingsWorkflowsFieldsJSON` (`options_test.go`): nil/empty omission, per-field round-trip for all five fields, and a combined round-trip.
- `TestIntegrationSettingsWorkflowsFields` (`integration_test.go`): deliberate `t.Skip` — admin-policy-tier toggles not triggerable from standard CLI flags, mirroring the v0.3.150 managed-org cluster pattern. Tracked in `memory/catchup-v0.3.168/INTEGRATION-FOLLOWUPS.md`.

## Test plan

- [x] `go vet ./...`
- [x] `go vet -tags integration ./...`
- [x] `go test ./...`
- [x] `gofmt -l options.go options_test.go integration_test.go` empty