### PR TITLE
options: document marketplace skipLfs key (v0.3.168 deferred Phase I-8)

### DIFF
--- a/options.go
+++ b/options.go
@@ -562,6 +562,10 @@ type SettingsMarketplace struct {
 	AutoUpdate      *bool                     `json:"autoUpdate,omitempty"`
 }
 
+// SettingsMarketplaceSource is the opaque marketplace source descriptor. Required key "source"
+// selects the variant; remaining keys depend on the variant (e.g. "repo", "url", "package",
+// "path", "ref", "sparsePaths", "skipLfs"). Per sdk.d.ts v0.3.168 L4695/L4717 (github) and
+// L4895/L4917 (git), the optional "skipLfs": boolean key sets GIT_LFS_SKIP_SMUDGE=1 on clone/update.
 type SettingsMarketplaceSource map[string]interface{}
 
 // SettingsMarketplaceSourceKind is the discriminator value stored in a SettingsMarketplaceSource "source" entry.
@@ -569,8 +573,10 @@ type SettingsMarketplaceSourceKind string
 
 const (
 	// SettingsMarketplaceSourceGithub identifies a GitHub marketplace source. Mirrors sdk.d.ts v0.3.150 L4459.
+	// Honors optional "skipLfs": boolean per sdk.d.ts v0.3.168 L4695.
 	SettingsMarketplaceSourceGithub SettingsMarketplaceSourceKind = "github"
 	// SettingsMarketplaceSourceGit identifies a Git marketplace source. Mirrors sdk.d.ts v0.3.150 L4466.
+	// Honors optional "skipLfs": boolean per sdk.d.ts v0.3.168 L4717.
 	SettingsMarketplaceSourceGit SettingsMarketplaceSourceKind = "git"
 	// SettingsMarketplaceSourceNPM identifies an npm marketplace source. Mirrors sdk.d.ts v0.3.150 L4484.
 	SettingsMarketplaceSourceNPM SettingsMarketplaceSourceKind = "npm"

--- a/options_test.go
+++ b/options_test.go
@@ -768,6 +768,52 @@ func TestSettingsMarketplaceSourceVariants(t *testing.T) {
 		assert.Equal(t, "skills-dir", string(SettingsMarketplaceSourceSkillsDir))
 		assert.Equal(t, "unsupported", string(SettingsMarketplaceSourceUnsupported))
 	})
+
+	t.Run("github source with skipLfs true round-trips", func(t *testing.T) {
+		in := Settings{
+			ExtraKnownMarketplaces: map[string]SettingsMarketplace{
+				"upstream": {
+					Source: SettingsMarketplaceSource{
+						"source":  string(SettingsMarketplaceSourceGithub),
+						"repo":    "anthropics/skills",
+						"skipLfs": true,
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		got := out.ExtraKnownMarketplaces["upstream"].Source
+		assert.Equal(t, "github", got["source"])
+		assert.Equal(t, "anthropics/skills", got["repo"])
+		assert.Equal(t, true, got["skipLfs"])
+	})
+
+	t.Run("git source with skipLfs false round-trips", func(t *testing.T) {
+		in := Settings{
+			ExtraKnownMarketplaces: map[string]SettingsMarketplace{
+				"mirror": {
+					Source: SettingsMarketplaceSource{
+						"source":  string(SettingsMarketplaceSourceGit),
+						"url":     "https://example.invalid/marketplace.git",
+						"skipLfs": false,
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		got := out.ExtraKnownMarketplaces["mirror"].Source
+		assert.Equal(t, "git", got["source"])
+		assert.Equal(t, "https://example.invalid/marketplace.git", got["url"])
+		assert.Equal(t, false, got["skipLfs"])
+	})
 }
 
 func TestBaseHookInputEffortJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

The TS SDK adds an optional `skipLfs?: boolean` key to both `github` and `git` marketplace source variants in v0.3.168. When set, the CLI runs git clone/update with `GIT_LFS_SKIP_SMUDGE=1` so LFS pointer files stay as pointers — useful for marketplaces hosted in repos with large LFS objects.

| Source variant | sdk.d.ts v0.3.168 |
|----------------|-------------------|
| `github` standalone marketplace | L4695 |
| `git` standalone marketplace | L4717 |
| `github` nested plugin path | L4895 |
| `git` nested plugin path | L4917 |
| `github` strict-known list | L5085 |
| `git` strict-known list | L5107 |

## No struct change

`SettingsMarketplaceSource` is `map[string]interface{}` (options.go:565), so `skipLfs` already round-trips end-to-end. This PR is docs + tests verifying that.

- Updates the `SettingsMarketplaceSource` type docstring to enumerate documented optional keys (including `skipLfs`) and cite the v0.3.168 line numbers.
- Adds a short `skipLfs` note on the `SettingsMarketplaceSourceGithub` and `SettingsMarketplaceSourceGit` constants.

## Testing

Two new sub-tests on the existing `TestSettingsMarketplaceSourceVariants`:

- `"github source with skipLfs true round-trips"`
- `"git source with skipLfs false round-trips"` (verifies explicit `false` round-trips, not omitted)

No integration test slot — same admin-policy rationale as the v0.3.150 marketplace settings cluster.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `gofmt -l options.go options_test.go` empty