### PR TITLE
messages: assert pending_permission_requests round-trips on control success (v0.3.168 Phase J-1)

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -338,12 +338,17 @@ type SDKControlResponse struct {
 }
 
 // SDKControlResponseBody contains the actual response data.
+//
+// PendingPermissionRequests is emitted on both "success" and "error"
+// subtypes. The TS SDK attaches it to the `initialize` response so a
+// client joining an already-initialized session learns about in-flight
+// permission prompts. See sdk.d.ts (v0.3.168) L294-L312.
 type SDKControlResponseBody struct {
 	Subtype                   string                 `json:"subtype"`                               // "success" or "error"
 	RequestID                 string                 `json:"request_id"`                            // Correlates to request
 	Response                  map[string]interface{} `json:"response,omitempty"`                    // Success response data
 	Error                     string                 `json:"error,omitempty"`                       // Error message
-	PendingPermissionRequests []SDKControlRequest    `json:"pending_permission_requests,omitempty"` // Pending requests
+	PendingPermissionRequests []SDKControlRequest    `json:"pending_permission_requests,omitempty"` // In-flight permission prompts (success+error)
 }
 
 // MessageType implements Message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -3147,6 +3147,81 @@ func BenchmarkParseMessage(b *testing.B) {
 
 func intPtr(i int) *int { return &i }
 
+func TestSDKControlResponseBodyPendingPermissionRequestsRoundTrip(t *testing.T) {
+	pending := []SDKControlRequest{
+		{
+			Type:      "control_request",
+			RequestID: "req-pending-1",
+			Request: SDKControlRequestBody{
+				Subtype:   "can_use_tool",
+				ToolName:  "Bash",
+				ToolUseID: "toolu_pending_1",
+				Input:     map[string]interface{}{"command": "ls"},
+			},
+		},
+		{
+			Type:      "control_request",
+			RequestID: "req-pending-2",
+			Request: SDKControlRequestBody{
+				Subtype:   "can_use_tool",
+				ToolName:  "Edit",
+				ToolUseID: "toolu_pending_2",
+				Input:     map[string]interface{}{"file_path": "/tmp/x"},
+			},
+		},
+	}
+
+	for _, subtype := range []string{"success", "error"} {
+		t.Run(subtype, func(t *testing.T) {
+			body := SDKControlResponseBody{
+				Subtype:                   subtype,
+				RequestID:                 "req-init-1",
+				PendingPermissionRequests: pending,
+			}
+			if subtype == "success" {
+				body.Response = map[string]interface{}{"ok": true}
+			} else {
+				body.Error = "boom"
+			}
+
+			data, err := json.Marshal(body)
+			require.NoError(t, err)
+
+			var got map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &got))
+
+			assert.Equal(t, subtype, got["subtype"])
+			assert.Equal(t, "req-init-1", got["request_id"])
+
+			raw, ok := got["pending_permission_requests"].([]interface{})
+			require.True(t, ok, "pending_permission_requests must be present on %q", subtype)
+			require.Len(t, raw, 2)
+
+			var decoded SDKControlResponseBody
+			require.NoError(t, json.Unmarshal(data, &decoded))
+			assert.Equal(t, pending, decoded.PendingPermissionRequests)
+		})
+	}
+}
+
+func TestSDKControlResponseBodyPendingPermissionRequestsOmitEmpty(t *testing.T) {
+	for _, subtype := range []string{"success", "error"} {
+		t.Run(subtype, func(t *testing.T) {
+			body := SDKControlResponseBody{
+				Subtype:   subtype,
+				RequestID: "req-init-1",
+			}
+			data, err := json.Marshal(body)
+			require.NoError(t, err)
+
+			var got map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &got))
+
+			assert.NotContains(t, got, "pending_permission_requests")
+		})
+	}
+}
+
 // BenchmarkContentText benchmarks content text extraction.
 func BenchmarkContentText(b *testing.B) {
 	msg := AssistantMessage{


### PR DESCRIPTION
## Summary

TS SDK v0.3.168 moved `pending_permission_requests?: SDKControlRequest[]` onto `SDKControlSuccess` in addition to `SDKControlError` (sdk.d.ts L294-L312). It's emitted on the `initialize` response so a client joining an already-initialized session learns about in-flight permission prompts.

The Go SDK already round-trips this on both subtypes — `SDKControlResponseBody` (`messages.go:340`) is a unified struct with `PendingPermissionRequests []SDKControlRequest`. This PR pins that with test coverage and updates the docstring to spell out the dual-subtype contract.

## Changes

- `messages.go` — `SDKControlResponseBody` docstring now states the field is emitted on both `success` and `error`, with the v0.3.168 sdk.d.ts cite.
- `messages_test.go` — adds two tests:
  - `TestSDKControlResponseBodyPendingPermissionRequestsRoundTrip` — sub-tests over `{success, error}`, marshals two pending `SDKControlRequest`s, asserts the wire JSON carries them and the round-trip preserves the slice.
  - `TestSDKControlResponseBodyPendingPermissionRequestsOmitEmpty` — verifies the `omitempty` tag drops the field on both subtypes when empty.

No struct change. No behavior change.

## Test plan

- [x] `gofmt -l .` empty
- [x] `go vet ./...`
- [x] `go test ./...`