### PR TITLE
client: add Stream.ReloadSkills control RPC (v0.3.168 Phase J-5)

### DIFF
--- a/client.go
+++ b/client.go
@@ -889,6 +889,27 @@ func (s *Stream) ReloadPlugins(
 	return &out, nil
 }
 
+// ReloadSkills reloads skills from disk and returns refreshed skill commands.
+func (s *Stream) ReloadSkills(
+	ctx context.Context,
+) (*SDKControlReloadSkillsResponse, error) {
+	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "reload_skills",
+	})
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := json.Marshal(resp.Response.Response)
+	if err != nil {
+		return nil, fmt.Errorf("reload_skills: marshal: %w", err)
+	}
+	var out SDKControlReloadSkillsResponse
+	if err := json.Unmarshal(bytes, &out); err != nil {
+		return nil, fmt.Errorf("reload_skills: unmarshal: %w", err)
+	}
+	return &out, nil
+}
+
 // ApplyFlagSettings merges the provided settings into the flag settings layer,
 // updating the active configuration. Top-level keys are shallow-merged by the
 // CLI across successive calls and fall back to lower-precedence sources when

--- a/client_file_plugin_control_test.go
+++ b/client_file_plugin_control_test.go
@@ -368,6 +368,74 @@ func TestStreamReloadPluginsParsesResponse(t *testing.T) {
 	})
 }
 
+func TestStreamReloadSkillsRoundTrip(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{
+			"skills": []interface{}{
+				map[string]interface{}{
+					"name":         "review",
+					"description":  "Run review",
+					"argumentHint": "[target]",
+					"aliases":      []interface{}{"inspect"},
+				},
+				map[string]interface{}{
+					"name":         "fix",
+					"description":  "Apply a focused fix",
+					"argumentHint": "",
+				},
+			},
+		}),
+	)
+
+	var got *SDKControlReloadSkillsResponse
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		var err error
+		got, err = stream.ReloadSkills(ctx)
+		return err
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, []SlashCommand{
+		{
+			Name:         "review",
+			Description:  "Run review",
+			ArgumentHint: "[target]",
+			Aliases:      []string{"inspect"},
+		},
+		{
+			Name:         "fix",
+			Description:  "Apply a focused fix",
+			ArgumentHint: "",
+		},
+	}, got.Skills)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"reload_skills"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamReloadSkillsErrorResponse(t *testing.T) {
+	stream, _, _ := newStreamControlTest(controlErrorResponse("reload skills failed"))
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		_, err := stream.ReloadSkills(ctx)
+		return err
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reload skills failed")
+}
+
+func TestStreamReloadSkillsCancelledContext(t *testing.T) {
+	stream, _, _ := newStreamControlTest(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := stream.ReloadSkills(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestStreamApplyFlagSettingsNonEmpty(t *testing.T) {
 	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
 

--- a/messages_test.go
+++ b/messages_test.go
@@ -3321,6 +3321,47 @@ func TestSDKControlResponseBodyPendingPermissionRequestsOmitEmpty(t *testing.T) 
 	}
 }
 
+func TestSDKControlReloadSkillsResponseJSON(t *testing.T) {
+	response := SDKControlReloadSkillsResponse{
+		Skills: []SlashCommand{
+			{
+				Name:         "review",
+				Description:  "Run review",
+				ArgumentHint: "[target]",
+				Aliases:      []string{"inspect"},
+			},
+			{
+				Name:         "fix",
+				Description:  "Apply a focused fix",
+				ArgumentHint: "",
+			},
+		},
+	}
+
+	data, err := json.Marshal(response)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"skills": [
+			{
+				"name": "review",
+				"description": "Run review",
+				"argumentHint": "[target]",
+				"aliases": ["inspect"]
+			},
+			{
+				"name": "fix",
+				"description": "Apply a focused fix",
+				"argumentHint": ""
+			}
+		]
+	}`, string(data))
+
+	var got SDKControlReloadSkillsResponse
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, response, got)
+}
+
 // BenchmarkContentText benchmarks content text extraction.
 func BenchmarkContentText(b *testing.B) {
 	msg := AssistantMessage{

--- a/query_types.go
+++ b/query_types.go
@@ -110,6 +110,11 @@ type SDKControlReloadPluginsResponse struct {
 	ErrorCount int               `json:"error_count"`
 }
 
+// SDKControlReloadSkillsResponse reports refreshed skill commands.
+type SDKControlReloadSkillsResponse struct {
+	Skills []SlashCommand `json:"skills"`
+}
+
 // PluginInfo describes a plugin loaded by the CLI.
 type PluginInfo struct {
 	Name   string `json:"name"`


### PR DESCRIPTION
## Summary

Adds the `reload_skills` control RPC for v0.3.168 Phase J-5. The host can ask the CLI to reload skills from disk and receive the refreshed `SlashCommand` list back.

- `query_types.go` — `SDKControlReloadSkillsResponse{ Skills []SlashCommand }` placed alongside `SDKControlReloadPluginsResponse`.
- `client.go` — `Stream.ReloadSkills(ctx)` mirrors `Stream.ReloadPlugins`: issues the `reload_skills` subtype via `sendSDKControlRequest`, then JSON re-decodes `Response.Response` into the typed result.
- `client_file_plugin_control_test.go` — three unit tests: round-trip (asserts both the written wire envelope and the decoded `Skills` slice), error-subtype path, and ctx cancellation returns `context.Canceled`.
- `messages_test.go` — JSON round-trip for `SDKControlReloadSkillsResponse`.

Source: `scratch/ts-sdk-0.3.168/package/sdk.d.ts` L2318-L2325 (Streaming method) + L3114-L3127 (request + response types).

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green
- [ ] `TestIntegrationStreamReloadSkills` — deferred to integration follow-ups if the CLI fixture does not deterministically tolerate the call on an empty skills dir.
