### PR TITLE
messages: add AssistantMessageError 'overloaded' variant (v0.3.168 Phase J-7)

### DIFF
--- a/messages_test.go
+++ b/messages_test.go
@@ -509,20 +509,38 @@ func TestAssistantMessageJSONRoundTrip(t *testing.T) {
 }
 
 func TestAssistantMessageErrorRoundTrip(t *testing.T) {
-	msg := AssistantMessage{
-		Type:  "assistant",
-		Error: AssistantMessageErrorModelNotFound,
+	tests := []struct {
+		name  string
+		error AssistantMessageError
+	}{
+		{
+			name:  "model_not_found",
+			error: AssistantMessageErrorModelNotFound,
+		},
+		{
+			name:  "overloaded",
+			error: AssistantMessageErrorOverloaded,
+		},
 	}
-	msg.Message.Role = "assistant"
-	msg.Message.Content = []ContentBlock{{Type: "text", Text: "Model unavailable."}}
 
-	data, err := json.Marshal(msg)
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := AssistantMessage{
+				Type:  "assistant",
+				Error: tt.error,
+			}
+			msg.Message.Role = "assistant"
+			msg.Message.Content = []ContentBlock{{Type: "text", Text: "Model unavailable."}}
 
-	var got AssistantMessage
-	require.NoError(t, json.Unmarshal(data, &got))
+			data, err := json.Marshal(msg)
+			require.NoError(t, err)
 
-	assert.Equal(t, msg.Error, got.Error)
+			var got AssistantMessage
+			require.NoError(t, json.Unmarshal(data, &got))
+
+			assert.Equal(t, msg.Error, got.Error)
+		})
+	}
 }
 
 // TestParseMessageToolUseBlock tests parsing tool use requests.

--- a/options.go
+++ b/options.go
@@ -1844,6 +1844,7 @@ const (
 	AssistantMessageErrorOAuthOrgNotAllowed   AssistantMessageError = "oauth_org_not_allowed"
 	AssistantMessageErrorBillingError         AssistantMessageError = "billing_error"
 	AssistantMessageErrorRateLimit            AssistantMessageError = "rate_limit"
+	AssistantMessageErrorOverloaded           AssistantMessageError = "overloaded"
 	AssistantMessageErrorInvalidRequest       AssistantMessageError = "invalid_request"
 	AssistantMessageErrorModelNotFound        AssistantMessageError = "model_not_found"
 	AssistantMessageErrorServerError          AssistantMessageError = "server_error"


### PR DESCRIPTION
Mirrors `SDKAssistantMessageError = '... | rate_limit | overloaded | invalid_request | ...'` from `@anthropic-ai/claude-agent-sdk@0.3.168` (`sdk.d.ts` L2670).

## Changes
- `options.go`: add `AssistantMessageErrorOverloaded AssistantMessageError = "overloaded"` between `RateLimit` and `InvalidRequest` to preserve spec order.
- `messages_test.go`: refactor `TestAssistantMessageErrorRoundTrip` to a subtest table; add `overloaded` case alongside the existing `model_not_found` case.

## Test plan
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test -run AssistantMessageError ./...` green
- Integration: no new test — `TestIntegrationAssistantMessageError` is already t.Skip-tracked from v0.3.150 PR-16.

Refs: v0.3.168 catchup Phase J, brief `memory/catchup-v0.3.168/pr-14-overloaded-error-variant/BRIEF.md`.