### PR TITLE
messages: add MessageOriginKindAutoContinuation variant (v0.3.168 Phase J-8)

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -188,6 +188,7 @@ const (
 	MessageOriginKindPeer             MessageOriginKind = "peer"
 	MessageOriginKindTaskNotification MessageOriginKind = "task-notification"
 	MessageOriginKindCoordinator      MessageOriginKind = "coordinator"
+	MessageOriginKindAutoContinuation MessageOriginKind = "auto-continuation"
 )
 
 // MessageOrigin describes the originating actor for a message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -1189,6 +1189,34 @@ func TestResultMessageOriginRoundTrip(t *testing.T) {
 	assert.Equal(t, int64(250), decoded.TTFTMs)
 }
 
+func TestMessageOriginAutoContinuationRoundTrip(t *testing.T) {
+	msg := ResultMessage{
+		Type:    "result",
+		Subtype: "success",
+		Origin:  &MessageOrigin{Kind: MessageOriginKindAutoContinuation},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	origin, ok := raw["origin"].(map[string]interface{})
+	require.True(t, ok, "origin must marshal to an object")
+	assert.Equal(t, "auto-continuation", origin["kind"])
+	assert.NotContains(t, origin, "server")
+	assert.NotContains(t, origin, "from")
+	assert.NotContains(t, origin, "name")
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Origin)
+	assert.Equal(t, MessageOriginKindAutoContinuation, decoded.Origin.Kind)
+	assert.Empty(t, decoded.Origin.Server)
+	assert.Empty(t, decoded.Origin.From)
+	assert.Empty(t, decoded.Origin.Name)
+}
+
 func TestResultMessageFieldAdditionsBackwardCompat(t *testing.T) {
 	input := []byte(`{
 		"type": "result",


### PR DESCRIPTION
Mirrors the new \`{ kind: 'auto-continuation' }\` arm of \`SDKMessageOrigin\` from \`@anthropic-ai/claude-agent-sdk@0.3.168\` (\`sdk.d.ts\` L3392-3396). The variant carries no additional fields, so \`MessageOrigin\`'s struct shape is unchanged.

## Changes
- \`messages.go\`: add \`MessageOriginKindAutoContinuation MessageOriginKind = \"auto-continuation\"\` after \`MessageOriginKindCoordinator\` to preserve spec order.
- \`messages_test.go\`: add \`TestMessageOriginAutoContinuationRoundTrip\` — \`ResultMessage{Origin: &MessageOrigin{Kind: ...AutoContinuation}}\` JSON-roundtrips, marshals \`{ "kind": "auto-continuation" }\` with no extra fields (\`server\`/\`from\`/\`name\` all \`omitempty\`-elided), and decodes back to an empty-field origin.

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l messages.go messages_test.go\` clean
- [x] \`go test -run MessageOrigin ./...\` green
- Integration: no new test — covered by existing \`TestIntegrationResultMessageOriginTTFT\` t.Skip from v0.3.150 PR-17.

Refs: v0.3.168 catchup Phase J-8, brief \`memory/catchup-v0.3.168/pr-15-auto-continuation-task-origin/BRIEF.md\`.