### PR TITLE
messages: add ResultMessage timing fields (v0.3.168 Phase J-9)

### DIFF
--- a/INTEGRATION-FOLLOWUPS.md
+++ b/INTEGRATION-FOLLOWUPS.md
@@ -11,6 +11,7 @@
 - Backfill `TestIntegrationUserMessageSubagentFields` when the CLI test fixture can deterministically run a Task-tool subagent whose tool-result user message round-trips `subagent_type` + `task_description`.
 - Backfill `TestIntegrationAssistantMessageError` when the CLI test fixture can deterministically force an upstream API failure into an `assistant` event.
 - Backfill `TestIntegrationResultMessageOriginTTFT` when the CLI test fixture can deterministically emit `origin` and/or `ttft_ms` on a result event.
+- Backfill `TestIntegrationResultMessageTimingFields` when the CLI test fixture can deterministically emit spawn-pool timing instrumentation (`ttft_stream_ms`, `time_to_request_ms`, `time_to_request_from_spawn_ms`, `warm_spare_claimed`) on a result event.
 - Backfill `TestIntegrationTaskLifecycleFields` when the CLI test fixture can deterministically run a Task-tool subagent (populates `subagent_type` on `task_started`/`task_progress`) and pause a running task (emits `task_updated` with `status:"paused"`).
 - Backfill `TestIntegrationThinkingTokensMessage` when the CLI test fixture can deterministically invoke a thinking-capable model through a redacted-thinking phase so `thinking_tokens` system events are emitted.
 - Backfill `TestIntegrationCompactBoundaryPreservedMessages` when the CLI test fixture can deterministically trigger a partial compaction with messagesToKeep so the `compact_metadata.preserved_messages` block is populated.

--- a/integration_test.go
+++ b/integration_test.go
@@ -822,6 +822,13 @@ func TestIntegrationResultMessageOriginTTFT(t *testing.T) {
 	t.Skip("requires CLI to emit origin/ttft_ms on result events (host-side multi-actor or measured TTFT); tracked in INTEGRATION-FOLLOWUPS.md")
 }
 
+func TestIntegrationResultMessageTimingFields(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	t.Skip("not triggerable from CLI: ttft_stream_ms / time_to_request_ms / time_to_request_from_spawn_ms / warm_spare_claimed are populated by CLI-internal spawn-pool timing instrumentation not exercisable from the standard integration run; tracked in INTEGRATION-FOLLOWUPS.md")
+}
+
 func TestIntegrationTaskLifecycleFields(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/messages.go
+++ b/messages.go
@@ -160,8 +160,16 @@ type ResultMessage struct {
 	DurationMs    int64 `json:"duration_ms,omitempty"`     // Total duration in milliseconds
 	DurationAPIMs int64 `json:"duration_api_ms,omitempty"` // API call duration in milliseconds
 	TTFTMs        int64 `json:"ttft_ms,omitempty"`         // Time-to-first-token in milliseconds
-	IsError       bool  `json:"is_error,omitempty"`        // Whether this is an error result
-	NumTurns      int   `json:"num_turns,omitempty"`       // Number of conversation turns
+	/*
+		TS SDK v0.3.168 sdk.d.ts L3566-L3569 exposes these spawn-pool timing fields
+		between ttft_ms and is_error.
+	*/
+	TTFTStreamMs             *int64 `json:"ttft_stream_ms,omitempty"`                // Streaming time-to-first-token in milliseconds
+	TimeToRequestMs          *int64 `json:"time_to_request_ms,omitempty"`            // Time to request in milliseconds
+	TimeToRequestFromSpawnMs *int64 `json:"time_to_request_from_spawn_ms,omitempty"` // Time to request from spawn in milliseconds
+	WarmSpareClaimed         *bool  `json:"warm_spare_claimed,omitempty"`            // Whether a warm spare was claimed
+	IsError                  bool   `json:"is_error,omitempty"`                      // Whether this is an error result
+	NumTurns                 int    `json:"num_turns,omitempty"`                     // Number of conversation turns
 
 	TotalCostUSD float64 `json:"total_cost_usd,omitempty"` // Total cost in USD
 

--- a/messages_test.go
+++ b/messages_test.go
@@ -694,6 +694,98 @@ func TestParseMessageResultMessageTTFT(t *testing.T) {
 	assert.Equal(t, int64(137), resultMsg.TTFTMs)
 }
 
+func TestParseResultMessageTimingFields(t *testing.T) {
+	input := []byte(`{
+		"type": "result",
+		"status": "success",
+		"subtype": "success",
+		"result": "done",
+		"ttft_stream_ms": 42,
+		"time_to_request_ms": 84,
+		"time_to_request_from_spawn_ms": 126,
+		"warm_spare_claimed": true
+	}`)
+
+	msg, err := ParseMessage(input)
+	require.NoError(t, err)
+
+	resultMsg, ok := msg.(ResultMessage)
+	require.True(t, ok)
+	require.NotNil(t, resultMsg.TTFTStreamMs)
+	assert.Equal(t, int64(42), *resultMsg.TTFTStreamMs)
+	require.NotNil(t, resultMsg.TimeToRequestMs)
+	assert.Equal(t, int64(84), *resultMsg.TimeToRequestMs)
+	require.NotNil(t, resultMsg.TimeToRequestFromSpawnMs)
+	assert.Equal(t, int64(126), *resultMsg.TimeToRequestFromSpawnMs)
+	require.NotNil(t, resultMsg.WarmSpareClaimed)
+	assert.True(t, *resultMsg.WarmSpareClaimed)
+}
+
+func TestResultMessageTimingFieldsOmitempty(t *testing.T) {
+	msg := ResultMessage{
+		Type:    "result",
+		Subtype: "success",
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.NotContains(t, got, "ttft_stream_ms")
+	assert.NotContains(t, got, "time_to_request_ms")
+	assert.NotContains(t, got, "time_to_request_from_spawn_ms")
+	assert.NotContains(t, got, "warm_spare_claimed")
+}
+
+func TestResultMessageTimingFieldsExplicitFalse(t *testing.T) {
+	msg := ResultMessage{
+		Type:             "result",
+		Subtype:          "success",
+		WarmSpareClaimed: boolPtr(false),
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Contains(t, got, "warm_spare_claimed")
+	assert.Equal(t, false, got["warm_spare_claimed"])
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.WarmSpareClaimed)
+	assert.False(t, *decoded.WarmSpareClaimed)
+}
+
+func TestResultMessageTimingFieldsRoundTrip(t *testing.T) {
+	msg := ResultMessage{
+		Type:                     "result",
+		Status:                   "success",
+		Subtype:                  "success",
+		Result:                   "done",
+		TTFTStreamMs:             int64Ptr(7),
+		TimeToRequestMs:          int64Ptr(11),
+		TimeToRequestFromSpawnMs: int64Ptr(13),
+		WarmSpareClaimed:         boolPtr(true),
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.TTFTStreamMs)
+	assert.Equal(t, int64(7), *decoded.TTFTStreamMs)
+	require.NotNil(t, decoded.TimeToRequestMs)
+	assert.Equal(t, int64(11), *decoded.TimeToRequestMs)
+	require.NotNil(t, decoded.TimeToRequestFromSpawnMs)
+	assert.Equal(t, int64(13), *decoded.TimeToRequestFromSpawnMs)
+	require.NotNil(t, decoded.WarmSpareClaimed)
+	assert.True(t, *decoded.WarmSpareClaimed)
+}
+
 // TestParseMessageStreamEvent tests parsing stream events.
 func TestParseMessageStreamEvent(t *testing.T) {
 	input := `{


### PR DESCRIPTION
Tracks four optional `SDKResultSuccess` timing fields added upstream in
`@anthropic-ai/claude-agent-sdk@0.3.168` (sdk.d.ts L3566-L3569).

| TS field | Go field |
|----------|----------|
| `ttft_stream_ms?: number` | `TTFTStreamMs *int64` |
| `time_to_request_ms?: number` | `TimeToRequestMs *int64` |
| `time_to_request_from_spawn_ms?: number` | `TimeToRequestFromSpawnMs *int64` |
| `warm_spare_claimed?: boolean` | `WarmSpareClaimed *bool` |

All four are placed between `TTFTMs` and `IsError` to match the upstream
field order. Pointer types preserve the absent-vs-zero distinction under
`omitempty` — important for `warm_spare_claimed: false`, which has to
round-trip as an explicit `false`, not be elided.

Unit coverage in `messages_test.go`: parse, omitempty elision, explicit-false
round-trip, full round-trip with all four populated.

Integration is skipped: these are populated by CLI-internal spawn-pool
timing instrumentation and aren't reachable from the standard integration
run. An INTEGRATION-FOLLOWUPS entry tracks backfilling once the CLI test
fixture can deterministically emit them.

Part of v0.3.168 Phase J. Refs #95.