### PR TITLE
options: add Settings.FallbackModel list + refresh Options.FallbackModel docstring (v0.3.168 Phase J-10)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2051,8 +2051,9 @@ func TestIntegrationSettingsManagedOrgFields(t *testing.T) {
 
 	// TODO: Backfill when the CLI test fixture can deterministically inject a
 	// managed-settings.json / MDM policy tier so the SDK can observe these
-	// admin-controlled settings through the resolved-settings transport.
-	t.Skip("not directly assertable from CLI: managed-org settings are honored only from admin-controlled policy sources, not surfaced on user CLI flag entry points")
+	// admin-controlled settings, including fallbackModel, through the
+	// resolved-settings transport.
+	t.Skip("not directly assertable from CLI: managed-org settings including fallbackModel are honored only from admin-controlled policy sources, not surfaced on user CLI flag entry points")
 }
 
 func TestIntegrationSettingsWorkflowsFields(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -26,7 +26,9 @@ type Options struct {
 	// MainAgent names the agent to apply to the main thread.
 	MainAgent string
 
-	// FallbackModel is the model to use if primary fails.
+	// FallbackModel is the fallback model list to use if the primary model is
+	// overloaded or unavailable. Accepts a comma-separated list to try in order;
+	// the primary model is re-tried at the start of each user turn.
 	FallbackModel string
 
 	// CLIPath is the path to the Claude Code CLI executable.
@@ -315,6 +317,7 @@ type Settings struct {
 	IncludeGitInstructions          *bool                            `json:"includeGitInstructions,omitempty"`
 	Permissions                     *SettingsPermissions             `json:"permissions,omitempty"`
 	Model                           string                           `json:"model,omitempty"`
+	FallbackModel                   []string                         `json:"fallbackModel,omitempty"`
 	AvailableModels                 []string                         `json:"availableModels,omitempty"`
 	ModelOverrides                  map[string]string                `json:"modelOverrides,omitempty"`
 	EnableAllProjectMCPServers      *bool                            `json:"enableAllProjectMcpServers,omitempty"`

--- a/options_test.go
+++ b/options_test.go
@@ -114,6 +114,48 @@ func TestSettingsHookContinueOnBlockJSON(t *testing.T) {
 }
 
 func TestSettingsManagedOrgFieldsJSON(t *testing.T) {
+	t.Run("fallbackModel round-trips populated list", func(t *testing.T) {
+		in := Settings{
+			FallbackModel: []string{"opus", "sonnet", "default"},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, []interface{}{"opus", "sonnet", "default"}, got["fallbackModel"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, []string{"opus", "sonnet", "default"}, out.FallbackModel)
+	})
+
+	t.Run("fallbackModel nil and empty omitted", func(t *testing.T) {
+		for _, in := range []Settings{
+			{},
+			{FallbackModel: []string{}},
+		} {
+			data, err := json.Marshal(in)
+			require.NoError(t, err)
+
+			var got map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &got))
+			assert.NotContains(t, got, "fallbackModel")
+		}
+	})
+
+	t.Run("fallbackModel single value round-trips", func(t *testing.T) {
+		in := Settings{
+			FallbackModel: []string{"default"},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, []string{"default"}, out.FallbackModel)
+	})
+
 	t.Run("policyHelper round-trips with all fields", func(t *testing.T) {
 		timeout := 5000
 		refresh := 60000

--- a/transport_test.go
+++ b/transport_test.go
@@ -1003,6 +1003,7 @@ func TestSubprocessTransportManagedSettings(t *testing.T) {
 	runner := NewMockSubprocessRunner()
 	opts := NewOptions()
 	WithManagedSettings(Settings{
+		FallbackModel:   []string{"opus", "sonnet", "default"},
 		AvailableModels: []string{"opus", "sonnet"},
 		Sandbox: &SettingsSandbox{
 			Enabled:           boolPtr(true),
@@ -1022,6 +1023,7 @@ func TestSubprocessTransportManagedSettings(t *testing.T) {
 
 	var raw map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(runner.StartArgs[managedIndex+1]), &raw))
+	assert.Equal(t, []interface{}{"opus", "sonnet", "default"}, raw["fallbackModel"])
 	assert.Equal(t, []interface{}{"opus", "sonnet"}, raw["availableModels"])
 	assert.Equal(t, true, raw["sandbox"].(map[string]interface{})["enabled"])
 	assert.Equal(t, false, raw["sandbox"].(map[string]interface{})["failIfUnavailable"])


### PR DESCRIPTION
## Summary

Tracks two related TS SDK v0.3.168 changes in `sdk.d.ts`:

- **L1424-L1430** — `Options.fallbackModel` docstring update. The TS field gained list semantics in the docstring ("Accepts a comma-separated list to try each in order") and the new "primary model is re-tried at the start of each user turn" retry behavior. The Go field stays `string` (the CLI already accepts comma-separated input) but the docstring now reflects that.
- **L4274-L4281** — `Settings.fallbackModel` is new. Adds `FallbackModel []string` with `json:\"fallbackModel,omitempty\"` immediately above `AvailableModels` in the managed-org tier to match TS field order.

## Tests

- `TestSettingsManagedOrgFieldsJSON` gains three subtests: populated list round-trip, nil + empty omission, single-value round-trip.
- `TestSubprocessTransportManagedSettings` now asserts `fallbackModel` appears in the resolved-settings argv alongside the existing `availableModels` check.

No new integration test — managed-org settings are admin-policy-tier surface not exercisable through CLI flag entry points. The existing `TestIntegrationSettingsManagedOrgFields` skip note names `fallbackModel` explicitly so the gap is tracked at the same boundary as `AvailableModels`.

## Test Plan

- [x] `gofmt -l .` — clean
- [x] `go test ./...` — pass
- [x] `go vet ./...` — clean
- [x] `TestIntegrationSettingsManagedOrgFields` skips with the documented reason