### PR TITLE
docs: refresh parity to v0.3.168 (Phase K)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ stdin/stdout, giving you access to Claude's tool use, extended thinking,
 session management, and hook system.
 
 This repository tracks the official TypeScript Agent SDK surface through the
-v0.3.150 catchup work, using Go idioms where the API shape differs.
+v0.3.168 catchup work, using Go idioms where the API shape differs.
 
 ```mermaid
 flowchart TB
@@ -210,7 +210,7 @@ For detailed guides and examples, see [docs/examples/](docs/examples/):
 ## TypeScript SDK Parity
 
 The SDK tracks the upstream TypeScript Agent SDK release cadence. Coverage
-landed across two catchup cycles.
+landed across three catchup cycles.
 
 The v0.2.119 catchup added:
 
@@ -245,6 +245,42 @@ The v0.3.150 catchup added:
   clearing, host-side `host_auth_token_refresh` and `submit_feedback` control
   subtypes
 
+The v0.3.168 catchup added:
+
+- new system message subtypes (`ThinkingTokensMessage`, `CommandsChangedMessage`),
+  the `MessageDisplay` hook event, and the `MessageOriginKindAutoContinuation`
+  origin variant
+- `ResultMessage` timing fields (`Duration*MS`), an `Overloaded`
+  `SDKAssistantMessage.Error` variant, and the `SessionTitle` field on
+  `SessionStart` + `UserPromptSubmit` hook inputs
+- hook output additions: `ReloadSkills` on `SessionStart` and
+  `AdditionalContext` on `Notification` / `PostToolBatch` / `PostToolUse*` /
+  `PreToolUse` / `SessionStart` / `Setup` / `Stop` / `SubagentStart` /
+  `SubagentStop` / `UserPromptExpansion` / `UserPromptSubmit`
+- new control RPCs: `OnUserDialog` callback for `request_user_dialog`,
+  `Stream.ReloadSkills`, and `Stream.RegisterRepoRoot` with
+  `WithReloadClaudeMD` / `WithReloadPlugins` / `WithReloadSkills`
+- managed-settings batch: `RequiredMinimumVersion`, `RequiredMaximumVersion`,
+  `SwitchModelsOnFlag`, `ForceLoginMethod` `"gateway"`, `Settings.FallbackModel`
+  list, `PluginSuggestionMarketplaces`, marketplace `SkipLfs`, plus
+  `Workflows` / `EnableWorkflows` / `WorkflowKeywordTriggerEnabled` /
+  `Ultracode` knobs
+- correctness fixes: `pending_permission_requests` round-trips on control
+  success payloads, marketplace source variants document `skipLfs` flow, and
+  `Effort` / strict-MCP docstrings refreshed for clarity
+
+PRs in this cycle (squash-merged): #96 MessageDisplay hook, #97
+ThinkingTokensMessage, #98 SessionStart reloadSkills, #99 SessionTitle hook
+fields, #100 workflows + ultracode + pluginSuggestionMarketplaces, #101
+marketplace skipLfs, #102 option docstring refresh, #103
+pending_permission_requests round-trip, #104 CommandsChangedMessage, #105
+Stop/SubagentStop additionalContext, #106 OnUserDialog + request_user_dialog,
+#107 reload_skills RPC, #108 register_repo_root + Stream.RegisterRepoRoot,
+#109 overloaded assistant error, #110 MessageOriginKindAutoContinuation,
+#111 ResultMessage timing fields, #112 Settings.FallbackModel list, #113
+managed required/maximum version + switchModelsOnFlag + forceLoginMethod
+"gateway".
+
 Some areas remain intentionally limited by the CLI or integration harness:
 desktop/IDE-only settings are not modeled exhaustively, several runtime control
 paths have unit coverage plus skipped integration slots until stable live CLI
@@ -277,6 +313,16 @@ you are translating TS code, watch for these:
   models the CLI silently downgrades per its own policy. The CLI is the
   authority on which model accepts which level - the SDK only forwards the enum
   value.
+- **`OnUserDialog` answers cancelled by default, including on unknown
+  `dialogKind`.** Per TS SDK v0.3.168, `dialogKind` is an open string union: a
+  new CLI release can ship a kind the host has never seen. The contract is
+  that the host MUST respond cancelled in that case, and the CLI then applies
+  the dialog's default behavior. The Go SDK enforces this automatically: if
+  `OnUserDialog` is unset, or the callback returns a non-nil error, the SDK
+  emits cancelled on the host's behalf. Callbacks that do recognize the kind
+  should still return `UserDialogBehaviorCancelled` (rather than fabricating a
+  result) for any branch they cannot honor — a misbehaving host should never
+  wedge the CLI on an unresolved dialog.
 
 For internal architecture, see [DESIGN.md](docs/DESIGN.md). For CLI protocol
 details (how this and the official Typescript SDK actually work), see

--- a/client.go
+++ b/client.go
@@ -596,6 +596,9 @@ func (c *Client) GetSkill(name string) (*Skill, error) {
 // This is useful for picking up new Skills or changes to existing Skills
 // without restarting the client. Returns ErrSkillsDisabled if Skills are
 // disabled in configuration.
+//
+// This reloads the SDK's local Skill cache only. To ask the running CLI
+// subprocess to refresh its skill commands, use Stream.ReloadSkills.
 func (c *Client) ReloadSkills() error {
 	if !c.options.SkillsConfig.EnableSkills {
 		return &ErrSkillsDisabled{}
@@ -838,6 +841,10 @@ func WithReloadSkills(reload ...bool) RegisterRepoRootOption {
 
 // RegisterRepoRoot adds a subdirectory of the session cwd as a working-directory
 // root and optionally asks the CLI to reload repo-scoped resources.
+//
+// Use WithReloadClaudeMD, WithReloadPlugins, and WithReloadSkills to trigger
+// the matching CLI-side reload as part of the same request. Only available
+// in streaming input mode.
 func (s *Stream) RegisterRepoRoot(
 	ctx context.Context,
 	directory string,
@@ -956,7 +963,12 @@ func (s *Stream) ReloadPlugins(
 	return &out, nil
 }
 
-// ReloadSkills reloads skills from disk and returns refreshed skill commands.
+// ReloadSkills asks the running CLI subprocess to rescan its skills
+// directories and returns the refreshed skill command list.
+//
+// This is the streaming control RPC counterpart to Client.ReloadSkills, which
+// only refreshes the SDK's local Skill cache. Only available in streaming
+// input mode.
 func (s *Stream) ReloadSkills(
 	ctx context.Context,
 ) (*SDKControlReloadSkillsResponse, error) {

--- a/options.go
+++ b/options.go
@@ -2408,7 +2408,9 @@ func WithSystemPromptPreset(preset string, append string) Option {
 	}
 }
 
-// WithFallbackModel sets the model to use if primary fails.
+// WithFallbackModel sets the fallback model list used when the primary
+// model is overloaded or unavailable. Accepts a comma-separated list to try
+// in order; the primary model is re-tried at the start of each user turn.
 func WithFallbackModel(model string) Option {
 	return func(o *Options) {
 		o.FallbackModel = model


### PR DESCRIPTION
Closes out the v0.3.168 catchup with a docs sweep, mirroring the v0.3.150 PR-34 pattern (`#93` `docs: refresh v0.3.150 parity docs`).

## Changes

- **README.md** — bump parity cite v0.3.150 → v0.3.168; add a new "v0.3.168 catchup added" bullet section summarizing the cycle and listing every merged PR; add an `OnUserDialog` entry under "Porting from the TypeScript SDK — Go-side differences" calling out the cancelled-on-unknown-`dialogKind` contract.
- **client.go** — cross-reference `Client.ReloadSkills` (SDK-local Skill cache) and `Stream.ReloadSkills` (streaming control RPC to the CLI subprocess) so the name collision is clear; note `Stream.RegisterRepoRoot`'s `WithReload*` opt-in reload set in the method docstring.
- **options.go** — refresh `WithFallbackModel` docstring to match the PR-17 field-level rollup (comma-separated list, primary re-tried at the start of each user turn).

PR-10's `HookResult.AdditionalContext` emits as `hookSpecificOutput.additionalContext`, which matches the TS shape; no Go-side divergence to document, so no Stop/SubagentStop entry was added.

## Cycle PRs (squash-merged)

- #96 — hooks: add MessageDisplay hook (deferred Phase I-1)
- #97 — messages: add ThinkingTokensMessage system subtype
- #98 — hooks: add SessionStart reloadSkills hook output
- #99 — hooks: add SessionTitle to SessionStart + UserPromptSubmit hook inputs
- #100 — options: add workflows + ultracode + pluginSuggestionMarketplaces settings
- #101 — options: document marketplace skipLfs key
- #102 — docs: refresh option docstrings (effort + strict MCP)
- #103 — messages: assert pending_permission_requests round-trips on control success
- #104 — messages: add CommandsChangedMessage system subtype
- #105 — hooks: add Stop + SubagentStop hookSpecificOutput additionalContext
- #106 — options: add OnUserDialog callback + request_user_dialog dispatch
- #107 — client: add reload_skills control RPC + Stream.ReloadSkills
- #108 — client: add register_repo_root control request + Stream.RegisterRepoRoot
- #109 — messages: add overloaded assistant error variant
- #110 — messages: add MessageOriginKindAutoContinuation variant
- #111 — messages: add ResultMessage timing fields
- #112 — options: add Settings.FallbackModel list + refresh Options.FallbackModel docstring
- #113 — options: add managed required/maximum version + switchModelsOnFlag + forceLoginMethod "gateway"

PR-19 (`SDKControlStageFileRequest`) remains gated upstream and is not part of this cycle.

See `memory/catchup-v0.3.168/PLAN.md` §"PR 20" and `pr-20-docs-refresh-0.3.168/BRIEF.md`.

## Verification

- `gofmt -l .` clean
- `go vet ./...` clean
- `go vet -tags integration ./...` clean
- `go test ./...` green