### PR TITLE
messages: add model_refusal_fallback message + assistant supersedes

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -89,6 +89,15 @@ type AssistantMessage struct {
 	// when available. Optional.
 	RequestID string `json:"request_id,omitempty"`
 
+	// Supersedes lists wire UUIDs of previously-delivered messages that this
+	// message replaces (refusal-fallback supersede). The list can include
+	// tombstoned tool_result frames from the refused leg, not only assistant
+	// frames. Evict the named messages on arrival and treat this frame as
+	// their canonical replacement; eviction is idempotent. The end-of-turn
+	// ModelRefusalFallbackMessage.RetractedMessageUUIDs remains the complete
+	// audit record for the turn. Absent when emitted by an older CLI.
+	Supersedes []string `json:"supersedes,omitempty"`
+
 	// SubagentType is the subagent type that produced this message, when
 	// the message originated from a subagent task. Empty for top-level
 	// assistant turns.
@@ -843,6 +852,46 @@ type APIRetryMessage struct {
 // MessageType implements Message.
 func (m APIRetryMessage) MessageType() string { return "system" }
 
+// ModelRefusalFallbackMessage is emitted when the primary model ends the stream
+// with stop_reason "refusal" and the turn is retried once on a fallback model
+// with the swap made persistent for the session (Direction "retry"). "revert"
+// and "sticky" are retained in the Direction enum for SDK-consumer compat and
+// are no longer emitted.
+type ModelRefusalFallbackMessage struct {
+	Type          string  `json:"type"`           // Always "system"
+	Subtype       string  `json:"subtype"`        // "model_refusal_fallback"
+	Trigger       string  `json:"trigger"`        // Always "refusal"
+	Direction     string  `json:"direction"`      // "retry" | "revert" | "sticky"
+	OriginalModel string  `json:"original_model"` // Model that refused
+	FallbackModel string  `json:"fallback_model"` // Model the turn retried on
+	RequestID     *string `json:"request_id"`     // Upstream request id; nil for JSON null
+
+	// APIRefusalCategory is stop_details.category from the refused API
+	// response ("cyber", "bio", …). Open string — new categories ship on the
+	// wire ahead of schema updates. nil when the response carried no category
+	// (normal, not an error) or when emitted by an older CLI.
+	APIRefusalCategory *string `json:"api_refusal_category,omitempty"`
+
+	// APIRefusalExplanation is stop_details.explanation from the refused API
+	// response. Unstable human prose — display only, never parse. nil under
+	// the same rules as APIRefusalCategory.
+	APIRefusalExplanation *string `json:"api_refusal_explanation,omitempty"`
+
+	// RetractedMessageUUIDs lists wire UUIDs of the messages this fallback
+	// retracted — the refused partial as the consumer received it plus any
+	// tombstoned tool_results. Emitted AFTER the retraction: a resolution-time
+	// eviction signal. Idempotent; unknown/already-removed UUIDs are a no-op.
+	// Absent when emitted by an older CLI.
+	RetractedMessageUUIDs []string `json:"retracted_message_uuids,omitempty"`
+
+	Content   string `json:"content"`    // Human-readable fallback notice
+	UUID      string `json:"uuid"`       // Unique message ID
+	SessionID string `json:"session_id"` // Session identifier
+}
+
+// MessageType implements Message.
+func (m ModelRefusalFallbackMessage) MessageType() string { return "system" }
+
 // ElicitationCompleteMessage reports completion of a URL-mode MCP elicitation.
 type ElicitationCompleteMessage struct {
 	Type          string `json:"type"`            // Always "system"
@@ -1260,6 +1309,10 @@ func ParseMessage(data []byte) (Message, error) {
 			return msg, err
 		case "memory_recall":
 			var msg MemoryRecallMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "model_refusal_fallback":
+			var msg ModelRefusalFallbackMessage
 			err := json.Unmarshal(data, &msg)
 			return msg, err
 		case "mirror_error":

--- a/messages_test.go
+++ b/messages_test.go
@@ -2567,6 +2567,91 @@ func TestParseMessageAPIRetry(t *testing.T) {
 	}
 }
 
+func TestParseMessageModelRefusalFallback(t *testing.T) {
+	t.Run("full payload", func(t *testing.T) {
+		input := `{
+			"type": "system",
+			"subtype": "model_refusal_fallback",
+			"trigger": "refusal",
+			"direction": "retry",
+			"original_model": "claude-opus-4-8",
+			"fallback_model": "claude-sonnet-4-6",
+			"request_id": "req_01HXYZ",
+			"api_refusal_category": "cyber",
+			"api_refusal_explanation": "declined for safety",
+			"retracted_message_uuids": ["550e8400-e29b-41d4-a716-446655440300"],
+			"content": "Retried on a fallback model.",
+			"uuid": "550e8400-e29b-41d4-a716-446655440301",
+			"session_id": "sess_refusal_001"
+		}`
+
+		msg, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+
+		fb, ok := msg.(ModelRefusalFallbackMessage)
+		require.True(t, ok, "expected ModelRefusalFallbackMessage")
+		assert.Equal(t, "system", fb.MessageType())
+		assert.Equal(t, "model_refusal_fallback", fb.Subtype)
+		assert.Equal(t, "refusal", fb.Trigger)
+		assert.Equal(t, "retry", fb.Direction)
+		assert.Equal(t, "claude-opus-4-8", fb.OriginalModel)
+		assert.Equal(t, "claude-sonnet-4-6", fb.FallbackModel)
+		require.NotNil(t, fb.RequestID)
+		assert.Equal(t, "req_01HXYZ", *fb.RequestID)
+		require.NotNil(t, fb.APIRefusalCategory)
+		assert.Equal(t, "cyber", *fb.APIRefusalCategory)
+		require.NotNil(t, fb.APIRefusalExplanation)
+		assert.Equal(t, "declined for safety", *fb.APIRefusalExplanation)
+		assert.Equal(t, []string{"550e8400-e29b-41d4-a716-446655440300"}, fb.RetractedMessageUUIDs)
+	})
+
+	t.Run("older CLI: null request_id, optional fields absent", func(t *testing.T) {
+		input := `{
+			"type": "system",
+			"subtype": "model_refusal_fallback",
+			"trigger": "refusal",
+			"direction": "retry",
+			"original_model": "claude-opus-4-8",
+			"fallback_model": "claude-sonnet-4-6",
+			"request_id": null,
+			"content": "Retried on a fallback model.",
+			"uuid": "550e8400-e29b-41d4-a716-446655440302",
+			"session_id": "sess_refusal_002"
+		}`
+
+		msg, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+
+		fb, ok := msg.(ModelRefusalFallbackMessage)
+		require.True(t, ok, "expected ModelRefusalFallbackMessage")
+		assert.Nil(t, fb.RequestID)
+		assert.Nil(t, fb.APIRefusalCategory)
+		assert.Nil(t, fb.APIRefusalExplanation)
+		assert.Nil(t, fb.RetractedMessageUUIDs)
+	})
+}
+
+func TestParseMessageAssistantSupersedes(t *testing.T) {
+	input := `{
+		"type": "assistant",
+		"uuid": "550e8400-e29b-41d4-a716-446655440400",
+		"session_id": "sess_refusal_003",
+		"message": {"role": "assistant", "content": []},
+		"parent_tool_use_id": null,
+		"supersedes": ["550e8400-e29b-41d4-a716-446655440401", "550e8400-e29b-41d4-a716-446655440402"]
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	am, ok := msg.(AssistantMessage)
+	require.True(t, ok, "expected AssistantMessage")
+	assert.Equal(t, []string{
+		"550e8400-e29b-41d4-a716-446655440401",
+		"550e8400-e29b-41d4-a716-446655440402",
+	}, am.Supersedes)
+}
+
 func TestParseMessageElicitationComplete(t *testing.T) {
 	input := `{
 		"type": "system",


### PR DESCRIPTION
Part of #115 (parity with TS Agent SDK v0.3.177).

TS v0.3.177 adds the `model_refusal_fallback` system subtype — emitted when the primary model ends a stream with `stop_reason: "refusal"` and the turn is retried once on a fallback model (the swap is made persistent; `direction: "retry"`; `revert`/`sticky` retained in the enum for consumer compat, no longer emitted).

## Changes
- `ModelRefusalFallbackMessage` (full wire shape) + dispatch case for `model_refusal_fallback`.
  - `request_id` is `*string` (nil for JSON null).
  - `api_refusal_category` / `api_refusal_explanation` are open strings, display-only, `omitempty` (absent on older CLIs).
  - `retracted_message_uuids` is the resolution-time eviction list.
- `AssistantMessage.Supersedes []string` — wire UUIDs a refusal-fallback assistant frame replaces (`omitempty`).

## Tests
`TestParseMessageModelRefusalFallback` (full payload + older-CLI null/absent), `TestParseMessageAssistantSupersedes`. `go test ./...`, `go vet`, `gofmt -l` clean.

## Integration
No deterministic CLI trigger (requires an actual model refusal). Tracked in `INTEGRATION-FOLLOWUPS.md`.