### PR TITLE
client: add get_usage control request (experimental)

### DIFF
--- a/client.go
+++ b/client.go
@@ -1209,6 +1209,35 @@ func (s *Stream) GetContextUsage(
 	return &out, nil
 }
 
+// GetUsageExperimental fetches the structured data behind the `/usage`
+// command: session cost/usage totals plus claude.ai plan rate-limit
+// utilization windows (5-hour, 7-day, per-model) when available.
+// RateLimitsAvailable is false (and RateLimits nil) for API key, Bedrock,
+// Vertex, and other sessions where plan limits do not apply.
+//
+// EXPERIMENTAL: this control request is unstable upstream and may change or
+// be removed in any release without notice — do not rely on it yet. The
+// method name will change when the API stabilizes.
+func (s *Stream) GetUsageExperimental(
+	ctx context.Context,
+) (*SDKControlGetUsageResponse, error) {
+	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "get_usage",
+	})
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := json.Marshal(resp.Response.Response)
+	if err != nil {
+		return nil, fmt.Errorf("get_usage: marshal: %w", err)
+	}
+	var out SDKControlGetUsageResponse
+	if err := json.Unmarshal(bytes, &out); err != nil {
+		return nil, fmt.Errorf("get_usage: unmarshal: %w", err)
+	}
+	return &out, nil
+}
+
 // ReconnectMcpServer asks the CLI to reconnect the named MCP server.
 // Returns an error if the server is unknown or reconnection fails.
 func (s *Stream) ReconnectMcpServer(ctx context.Context, serverName string) error {

--- a/client_introspection_test.go
+++ b/client_introspection_test.go
@@ -359,6 +359,135 @@ func TestStreamGetContextUsageApiUsageNullable(t *testing.T) {
 	assert.Nil(t, got.APIUsage)
 }
 
+func TestStreamGetUsageExperimentalParsesCanonicalPayload(t *testing.T) {
+	payload := map[string]interface{}{
+		"session": map[string]interface{}{
+			"total_cost_usd":        1.25,
+			"total_api_duration_ms": 4200,
+			"total_duration_ms":     9000,
+			"total_lines_added":     120,
+			"total_lines_removed":   40,
+			"model_usage": map[string]interface{}{
+				"claude-opus-4-8": map[string]interface{}{
+					"inputTokens": 1000, "outputTokens": 500, "costUSD": 1.25,
+				},
+			},
+		},
+		"subscription_type":     "max",
+		"rate_limits_available": true,
+		"rate_limits": map[string]interface{}{
+			"five_hour": map[string]interface{}{
+				"utilization": 42.5, "resets_at": "2026-06-15T20:00:00Z",
+			},
+			"seven_day": nil,
+			"extra_usage": map[string]interface{}{
+				"is_enabled": true, "monthly_limit": 50.0,
+				"used_credits": 12.5, "utilization": 25.0, "currency": "USD",
+			},
+		},
+		"behaviors": map[string]interface{}{
+			"day": map[string]interface{}{
+				"request_count": 10, "session_count": 3,
+				"behaviors": []interface{}{
+					map[string]interface{}{"key": "cache_miss", "pct": 30.0, "count": 3},
+				},
+				"agents":      []interface{}{map[string]interface{}{"name": "Explore", "pct": 20.0}},
+				"skills":      []interface{}{},
+				"plugins":     []interface{}{},
+				"mcp_servers": []interface{}{map[string]interface{}{"name": "github", "pct": 5.0}},
+			},
+			"week": map[string]interface{}{
+				"request_count": 70, "session_count": 14,
+				"behaviors":   []interface{}{},
+				"agents":      []interface{}{},
+				"skills":      []interface{}{},
+				"plugins":     []interface{}{},
+				"mcp_servers": []interface{}{},
+			},
+		},
+	}
+
+	var gotSubtype string
+	stream, _, _ := newStreamControlTest(func(req SDKControlRequest) SDKControlResponse {
+		gotSubtype = req.Request.Subtype
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "success",
+				RequestID: req.RequestID,
+				Response:  payload,
+			},
+		}
+	})
+
+	got, err := stream.GetUsageExperimental(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	assert.Equal(t, "get_usage", gotSubtype)
+
+	assert.InDelta(t, 1.25, got.Session.TotalCostUSD, 1e-9)
+	assert.Equal(t, 120, got.Session.TotalLinesAdded)
+	require.Contains(t, got.Session.ModelUsage, "claude-opus-4-8")
+	assert.Equal(t, 1000, got.Session.ModelUsage["claude-opus-4-8"].InputTokens)
+
+	require.NotNil(t, got.SubscriptionType)
+	assert.Equal(t, "max", *got.SubscriptionType)
+	assert.True(t, got.RateLimitsAvailable)
+
+	require.NotNil(t, got.RateLimits)
+	require.NotNil(t, got.RateLimits.FiveHour)
+	require.NotNil(t, got.RateLimits.FiveHour.Utilization)
+	assert.InDelta(t, 42.5, *got.RateLimits.FiveHour.Utilization, 1e-9)
+	assert.Nil(t, got.RateLimits.SevenDay) // present-but-null window
+	require.NotNil(t, got.RateLimits.ExtraUsage)
+	assert.True(t, got.RateLimits.ExtraUsage.IsEnabled)
+	require.NotNil(t, got.RateLimits.ExtraUsage.Currency)
+	assert.Equal(t, "USD", *got.RateLimits.ExtraUsage.Currency)
+
+	require.NotNil(t, got.Behaviors)
+	assert.Equal(t, 10, got.Behaviors.Day.RequestCount)
+	require.Len(t, got.Behaviors.Day.Behaviors, 1)
+	assert.Equal(t, "cache_miss", got.Behaviors.Day.Behaviors[0].Key)
+	assert.Equal(t, 3, got.Behaviors.Day.Behaviors[0].Count)
+	require.Len(t, got.Behaviors.Day.Agents, 1)
+	assert.Equal(t, "Explore", got.Behaviors.Day.Agents[0].Name)
+	assert.Equal(t, 70, got.Behaviors.Week.RequestCount)
+}
+
+func TestStreamGetUsageExperimentalNullables(t *testing.T) {
+	payload := map[string]interface{}{
+		"session": map[string]interface{}{
+			"total_cost_usd": 0.0, "total_api_duration_ms": 0,
+			"total_duration_ms": 0, "total_lines_added": 0,
+			"total_lines_removed": 0, "model_usage": map[string]interface{}{},
+		},
+		"subscription_type":     nil,
+		"rate_limits_available": false,
+		"rate_limits":           nil,
+		"behaviors":             nil,
+	}
+
+	stream, _, _ := newStreamControlTest(func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "success",
+				RequestID: req.RequestID,
+				Response:  payload,
+			},
+		}
+	})
+
+	got, err := stream.GetUsageExperimental(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Nil(t, got.SubscriptionType)
+	assert.False(t, got.RateLimitsAvailable)
+	assert.Nil(t, got.RateLimits)
+	assert.Nil(t, got.Behaviors)
+}
+
 // Sanity-check that AccountInfo with apiProvider round-trips through JSON.
 func TestAccountInfoAPIProviderJSON(t *testing.T) {
 	tests := []struct {

--- a/integration_test.go
+++ b/integration_test.go
@@ -2215,3 +2215,9 @@ func TestIntegrationCommandsChangedMessage(t *testing.T) {
 	skipIfNoCLI(t)
 	t.Skip("not triggerable from CLI: commands_changed fires when the CLI dynamically discovers new skills mid-session, which requires modifying the skills directory while a session is live - not exercisable in standard integration runs; tracked in INTEGRATION-FOLLOWUPS.md")
 }
+
+func TestIntegrationGetUsageExperimental(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+	t.Skip("get_usage is EXPERIMENTAL upstream (unstable wire shape) and its response is account-dependent — rate_limits/behaviors are null for non-claude.ai-subscriber sessions and the installed CLI may not support the subtype; a live assertion would be brittle. Mirrors GetContextUsage, which ships without an integration test. Tracked in INTEGRATION-FOLLOWUPS.md")
+}

--- a/query_types.go
+++ b/query_types.go
@@ -172,6 +172,109 @@ type SDKControlGetContextUsageResponse struct {
 	APIUsage             *ContextUsageAPIUsage         `json:"apiUsage"`
 }
 
+// SDKControlGetUsageResponse is the structured data behind the `/usage`
+// command: session cost/usage totals plus claude.ai plan rate-limit
+// utilization windows.
+//
+// EXPERIMENTAL: the wire shape is unstable upstream and may change or be
+// removed in any release without notice. See Stream.GetUsageExperimental.
+type SDKControlGetUsageResponse struct {
+	// Session is the cost and usage accumulated by the current session.
+	Session UsageSession `json:"session"`
+
+	// SubscriptionType is the claude.ai subscription tier ('pro', 'max',
+	// 'team', 'enterprise') or nil for API key / 3P provider sessions.
+	SubscriptionType *string `json:"subscription_type"`
+
+	// RateLimitsAvailable is false when plan rate limits do not apply (API
+	// key, Bedrock, Vertex, or missing profile scope) — RateLimits is nil.
+	RateLimitsAvailable bool `json:"rate_limits_available"`
+
+	// RateLimits holds plan rate-limit utilization windows from the
+	// claude.ai usage endpoint, or nil when unavailable.
+	RateLimits *UsageRateLimits `json:"rate_limits"`
+
+	// Behaviors describes what's contributing to limits usage, from a scan
+	// of local transcripts on this machine. Approximate; nil for
+	// non-claude.ai-subscriber sessions or when the scan fails.
+	Behaviors *UsageBehaviors `json:"behaviors"`
+}
+
+// UsageSession is the per-session cost/usage rollup.
+type UsageSession struct {
+	TotalCostUSD       float64               `json:"total_cost_usd"`
+	TotalAPIDurationMS int                   `json:"total_api_duration_ms"`
+	TotalDurationMS    int                   `json:"total_duration_ms"`
+	TotalLinesAdded    int                   `json:"total_lines_added"`
+	TotalLinesRemoved  int                   `json:"total_lines_removed"`
+	ModelUsage         map[string]ModelUsage `json:"model_usage"`
+}
+
+// UsageRateLimits holds the plan rate-limit utilization windows. Each window
+// is a pointer so absent (nil) and present-but-null are both representable.
+type UsageRateLimits struct {
+	FiveHour          *UsageRateLimitWindow `json:"five_hour,omitempty"`
+	SevenDay          *UsageRateLimitWindow `json:"seven_day,omitempty"`
+	SevenDayOAuthApps *UsageRateLimitWindow `json:"seven_day_oauth_apps,omitempty"`
+	SevenDayOpus      *UsageRateLimitWindow `json:"seven_day_opus,omitempty"`
+	SevenDaySonnet    *UsageRateLimitWindow `json:"seven_day_sonnet,omitempty"`
+	ExtraUsage        *UsageExtraUsage      `json:"extra_usage,omitempty"`
+}
+
+// UsageRateLimitWindow is a single rate-limit window's utilization.
+type UsageRateLimitWindow struct {
+	// Utilization is the percentage of the window used, 0-100, or nil.
+	Utilization *float64 `json:"utilization"`
+	// ResetsAt is the ISO 8601 timestamp when the window resets, or nil.
+	ResetsAt *string `json:"resets_at"`
+}
+
+// UsageExtraUsage describes overage/extra-usage credit state.
+type UsageExtraUsage struct {
+	IsEnabled    bool     `json:"is_enabled"`
+	MonthlyLimit *float64 `json:"monthly_limit"`
+	UsedCredits  *float64 `json:"used_credits"`
+	Utilization  *float64 `json:"utilization"`
+	Currency     *string  `json:"currency,omitempty"`
+}
+
+// UsageBehaviors holds the day/week behavioral attribution scanned from local
+// transcripts.
+type UsageBehaviors struct {
+	Day  UsageBehaviorsWindow `json:"day"`  // Last 24 hours.
+	Week UsageBehaviorsWindow `json:"week"` // Last 7 days.
+}
+
+// UsageBehaviorsWindow is the attribution for a single time window.
+type UsageBehaviorsWindow struct {
+	RequestCount int                     `json:"request_count"`
+	SessionCount int                     `json:"session_count"`
+	Behaviors    []UsageBehaviorEntry    `json:"behaviors"`
+	Agents       []UsageAttributionEntry `json:"agents"`
+	Skills       []UsageAttributionEntry `json:"skills"`
+	Plugins      []UsageAttributionEntry `json:"plugins"`
+	McpServers   []UsageAttributionEntry `json:"mcp_servers"`
+}
+
+// UsageBehaviorEntry is one behavioral characteristic. Categories overlap —
+// percentages do not sum to 100.
+type UsageBehaviorEntry struct {
+	// Key is one of cache_miss, long_context, subagent_heavy, high_parallel,
+	// cron. Open string for forward-compat with new categories on the wire.
+	Key string `json:"key"`
+	// Pct is the share of weighted local usage for this behavior, 0-100.
+	Pct float64 `json:"pct"`
+	// Count is requests in the window exhibiting the behavior.
+	Count int `json:"count"`
+}
+
+// UsageAttributionEntry attributes a share of local usage to a named
+// agent/skill/plugin/MCP server.
+type UsageAttributionEntry struct {
+	Name string  `json:"name"`
+	Pct  float64 `json:"pct"` // Share of weighted local usage, 0-100.
+}
+
 type ContextUsageCategory struct {
 	Name       string `json:"name"`
 	Tokens     int    `json:"tokens"`


### PR DESCRIPTION
Part of #115 (parity with TS Agent SDK v0.3.177).

TS v0.3.177 adds the `get_usage` control request — the structured data behind the `/usage` command: session cost/usage totals, claude.ai plan rate-limit utilization windows (5-hour, 7-day, per-model, extra-usage credits), and a local-transcript behavioral attribution breakdown (day/week).

## Changes
- `SDKControlGetUsageResponse` + nested `UsageSession` / `UsageRateLimits` / `UsageRateLimitWindow` / `UsageExtraUsage` / `UsageBehaviors` / `UsageBehaviorsWindow` / `UsageBehaviorEntry` / `UsageAttributionEntry`.
  - Rate-limit windows are pointers — absent and present-but-null both round-trip.
  - `RateLimits`/`Behaviors` are nil for sessions where plan limits don't apply (API key, Bedrock, Vertex) or the local scan fails.
- `Stream.GetUsageExperimental(ctx)` sends `{subtype:"get_usage"}` and decodes the response.
- Named `*Experimental` + documented unstable: upstream wire shape and method name may change without notice (mirrors the TS `usage_EXPERIMENTAL_MAY_CHANGE_...` method).

## Tests
`TestStreamGetUsageExperimentalParsesCanonicalPayload` (asserts the outgoing `get_usage` subtype + full nested parse, incl. a present-but-null window) and `TestStreamGetUsageExperimentalNullables`. `go test ./...`, `go vet`, `gofmt -l` clean; `-tags integration` builds.

## Integration
Skip with rationale (experimental + account-dependent; mirrors `GetContextUsage`). Tracked in `INTEGRATION-FOLLOWUPS.md`.