### PR TITLE
options: add SupportedDialogKinds + initialize plumbing

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -38,3 +38,12 @@ func TestWithToolAliases(t *testing.T) {
 
 	assert.Equal(t, aliases, opts.ToolAliases)
 }
+
+func TestWithSupportedDialogKinds(t *testing.T) {
+	opts := NewOptions()
+	require.Nil(t, opts.SupportedDialogKinds)
+
+	WithSupportedDialogKinds("refusal_fallback_prompt", "other")(opts)
+
+	assert.Equal(t, []string{"refusal_fallback_prompt", "other"}, opts.SupportedDialogKinds)
+}

--- a/messages.go
+++ b/messages.go
@@ -311,6 +311,7 @@ type SDKControlRequestBody struct {
 	AgentProgressSummaries *bool                               `json:"agentProgressSummaries,omitempty"` // For initialize
 	ForwardSubagentText    *bool                               `json:"forwardSubagentText,omitempty"`    // For initialize
 	ToolAliases            map[string]string                   `json:"toolAliases,omitempty"`            // For initialize
+	SupportedDialogKinds   []string                            `json:"supportedDialogKinds,omitempty"`   // For initialize
 	ToolName               string                              `json:"tool_name,omitempty"`              // For can_use_tool/hook_callback
 	Input                  map[string]interface{}              `json:"input,omitempty"`                  // For can_use_tool/hook_callback
 	ToolUseID              string                              `json:"tool_use_id,omitempty"`            // For can_use_tool/hooks/background_tasks

--- a/messages_test.go
+++ b/messages_test.go
@@ -23,6 +23,7 @@ func TestSDKControlRequestBodyInitializeOptions(t *testing.T) {
 		AgentProgressSummaries: &trueVal,
 		ForwardSubagentText:    &falseVal,
 		ToolAliases:            map[string]string{"Bash": "mcp__workspace__bash"},
+		SupportedDialogKinds:   []string{"refusal_fallback_prompt"},
 	}
 
 	data, err := json.Marshal(body)
@@ -32,6 +33,7 @@ func TestSDKControlRequestBodyInitializeOptions(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &got))
 
 	assert.Equal(t, "initialize", got["subtype"])
+	assert.Equal(t, []interface{}{"refusal_fallback_prompt"}, got["supportedDialogKinds"])
 	assert.Equal(t, "plan first", got["planModeInstructions"])
 	assert.Equal(t, true, got["excludeDynamicSections"])
 	assert.Equal(t, "custom title", got["title"])
@@ -58,6 +60,7 @@ func TestSDKControlRequestBodyInitializeOptionsOmitUnset(t *testing.T) {
 		"agentProgressSummaries",
 		"forwardSubagentText",
 		"toolAliases",
+		"supportedDialogKinds",
 	} {
 		assert.NotContains(t, got, key)
 	}

--- a/options.go
+++ b/options.go
@@ -83,6 +83,15 @@ type Options struct {
 	// with cancelled.
 	OnUserDialog OnUserDialogFunc
 
+	// SupportedDialogKinds declares the request_user_dialog dialog_kind
+	// values this consumer's OnUserDialog can actually render (e.g.
+	// "refusal_fallback_prompt"). The CLI fails closed on absence: a dialog
+	// kind not declared here is never emitted to this session, and the flow
+	// behind it degrades to its no-dialog behavior. Requires OnUserDialog —
+	// a non-empty list without the callback is rejected at initialize. On
+	// multi-client sessions the first-attached client's declaration wins.
+	SupportedDialogKinds []string
+
 	// GetHostAuthToken handles host-auth-token refresh requests from the CLI.
 	// If unset, the SDK replies with an error response.
 	GetHostAuthToken GetHostAuthTokenFunc
@@ -1032,6 +1041,15 @@ func WithOnElicitation(fn OnElicitationFunc) Option {
 func WithOnUserDialog(fn OnUserDialogFunc) Option {
 	return func(o *Options) {
 		o.OnUserDialog = fn
+	}
+}
+
+// WithSupportedDialogKinds declares the request_user_dialog dialog_kind values
+// this consumer can render. Requires WithOnUserDialog; a non-empty list
+// without the callback is rejected when the session initializes.
+func WithSupportedDialogKinds(kinds ...string) Option {
+	return func(o *Options) {
+		o.SupportedDialogKinds = kinds
 	}
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -52,6 +52,13 @@ func (p *Protocol) Initialize(ctx context.Context) error {
 		return nil // Already initialized
 	}
 
+	// SupportedDialogKinds is meaningless without a dialog handler, and the
+	// CLI would never route a dialog to a consumer that can't render it.
+	// Mirror the TS SDK and reject the contradictory option pairing here.
+	if len(p.options.SupportedDialogKinds) > 0 && p.options.OnUserDialog == nil {
+		return fmt.Errorf("SupportedDialogKinds requires WithOnUserDialog")
+	}
+
 	// Build hook configuration in TypeScript SDK format.
 	var hooks map[string][]SDKHookCallbackMatcher
 	if len(p.options.Hooks) > 0 {
@@ -120,6 +127,7 @@ func (p *Protocol) Initialize(ctx context.Context) error {
 			AgentProgressSummaries: p.options.AgentProgressSummaries,
 			ForwardSubagentText:    p.options.ForwardSubagentText,
 			ToolAliases:            p.options.ToolAliases,
+			SupportedDialogKinds:   p.options.SupportedDialogKinds,
 		},
 	}
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -103,6 +103,21 @@ func TestProtocolInitialize(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestProtocolInitializeSupportedDialogKindsRequiresCallback(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	opts.SupportedDialogKinds = []string{"refusal_fallback_prompt"}
+	// No OnUserDialog set — the pairing is invalid. The check fires before
+	// any transport interaction, so an unconnected transport is fine.
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+	protocol := NewProtocol(transport, opts)
+
+	err := protocol.Initialize(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "WithOnUserDialog")
+}
+
 func TestProtocolInitializeOptions(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Part of #115 (parity with TS Agent SDK v0.3.177).

TS v0.3.177 adds `supportedDialogKinds` to both `Options` and `SDKControlInitializeRequest`: the `request_user_dialog` `dialog_kind` values a consumer's `onUserDialog` can render. The CLI fails closed on absence — an undeclared kind is never emitted, and the flow behind it degrades to its no-dialog behavior (for `refusal_fallback_prompt`, the classic refusal error).

## Changes
- `Options.SupportedDialogKinds []string` + `WithSupportedDialogKinds(...)`.
- Plumbed into the initialize request (`SDKControlRequestBody.SupportedDialogKinds`, `supportedDialogKinds,omitempty`).
- `Protocol.Initialize` rejects a non-empty list without `OnUserDialog` (mirrors the TS "throws at option intake" contract).

## Tests
`TestWithSupportedDialogKinds`, `TestProtocolInitializeSupportedDialogKindsRequiresCallback`, plus extended initialize-marshal/omit tests. `go test ./...`, `go vet`, `gofmt -l` clean.

## Integration
Covered by the existing OnUserDialog dialog flow; the declaration itself is asserted on the initialize wire by the unit tests.