### PR TITLE
messages: add pending_user_dialog_requests to control response

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -362,16 +362,18 @@ type SDKControlResponse struct {
 
 // SDKControlResponseBody contains the actual response data.
 //
-// PendingPermissionRequests is emitted on both "success" and "error"
-// subtypes. The TS SDK attaches it to the `initialize` response so a
-// client joining an already-initialized session learns about in-flight
-// permission prompts. See sdk.d.ts (v0.3.168) L294-L312.
+// PendingPermissionRequests and PendingUserDialogRequests are emitted on
+// both "success" and "error" subtypes. The TS SDK attaches them to the
+// `initialize` response so a client joining an already-initialized session
+// learns about in-flight permission prompts and user dialogs. See sdk.d.ts
+// (v0.3.177) L298-L320.
 type SDKControlResponseBody struct {
-	Subtype                   string                 `json:"subtype"`                               // "success" or "error"
-	RequestID                 string                 `json:"request_id"`                            // Correlates to request
-	Response                  map[string]interface{} `json:"response,omitempty"`                    // Success response data
-	Error                     string                 `json:"error,omitempty"`                       // Error message
-	PendingPermissionRequests []SDKControlRequest    `json:"pending_permission_requests,omitempty"` // In-flight permission prompts (success+error)
+	Subtype                   string                 `json:"subtype"`                                // "success" or "error"
+	RequestID                 string                 `json:"request_id"`                             // Correlates to request
+	Response                  map[string]interface{} `json:"response,omitempty"`                     // Success response data
+	Error                     string                 `json:"error,omitempty"`                        // Error message
+	PendingPermissionRequests []SDKControlRequest    `json:"pending_permission_requests,omitempty"`  // In-flight permission prompts (success+error)
+	PendingUserDialogRequests []SDKControlRequest    `json:"pending_user_dialog_requests,omitempty"` // In-flight user dialogs (success+error)
 }
 
 // MessageType implements Message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -3570,6 +3570,48 @@ func TestSDKControlResponseBodyPendingPermissionRequestsOmitEmpty(t *testing.T) 
 			require.NoError(t, json.Unmarshal(data, &got))
 
 			assert.NotContains(t, got, "pending_permission_requests")
+			assert.NotContains(t, got, "pending_user_dialog_requests")
+		})
+	}
+}
+
+func TestSDKControlResponseBodyPendingUserDialogRequestsRoundTrip(t *testing.T) {
+	pending := []SDKControlRequest{
+		{
+			Type:      "control_request",
+			RequestID: "req-dialog-1",
+			Request: SDKControlRequestBody{
+				Subtype: "request_user_dialog",
+			},
+		},
+	}
+
+	for _, subtype := range []string{"success", "error"} {
+		t.Run(subtype, func(t *testing.T) {
+			body := SDKControlResponseBody{
+				Subtype:                   subtype,
+				RequestID:                 "req-init-1",
+				PendingUserDialogRequests: pending,
+			}
+			if subtype == "success" {
+				body.Response = map[string]interface{}{"ok": true}
+			} else {
+				body.Error = "boom"
+			}
+
+			data, err := json.Marshal(body)
+			require.NoError(t, err)
+
+			var got map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &got))
+
+			raw, ok := got["pending_user_dialog_requests"].([]interface{})
+			require.True(t, ok, "pending_user_dialog_requests must be present on %q", subtype)
+			require.Len(t, raw, 1)
+
+			var decoded SDKControlResponseBody
+			require.NoError(t, json.Unmarshal(data, &decoded))
+			assert.Equal(t, pending, decoded.PendingUserDialogRequests)
 		})
 	}
 }


### PR DESCRIPTION
Part of #115 (parity with TS Agent SDK v0.3.177).

TS v0.3.177 adds `pending_user_dialog_requests` as a sibling of `pending_permission_requests` on both `ControlResponse` (success) and `ControlErrorResponse` (error) — attached to the `initialize` response so a client joining an already-initialized session can re-arm in-flight `request_user_dialog` requests.

## Changes
- `SDKControlResponseBody.PendingUserDialogRequests []SDKControlRequest` (`pending_user_dialog_requests,omitempty`).

## Tests
`TestSDKControlResponseBodyPendingUserDialogRequestsRoundTrip` (success+error) + omit-empty assertion extended. `go test ./...`, `go vet`, `gofmt -l` clean.