### PR TITLE
options: add OrgMaxPermission to MCP tool policy

### DIFF
--- a/options.go
+++ b/options.go
@@ -2364,12 +2364,22 @@ type MCPServerConfig struct {
 type MCPServerToolPolicy struct {
 	Name             string `json:"name"`
 	PermissionPolicy string `json:"permission_policy"`
+	// OrgMaxPermission is the org admin's per-tool ceiling. It drives the
+	// auto-mode isOrgAskCeiling gate so an admin 'ask' cap forces a user
+	// prompt even in auto mode. One of MCPOrgMaxPermission*; empty when unset.
+	OrgMaxPermission string `json:"org_max_permission,omitempty"`
 }
 
 const (
 	MCPToolPolicyAllowAlways = "always_allow"
 	MCPToolPolicyAskAlways   = "always_ask"
 	MCPToolPolicyDenyAlways  = "always_deny"
+)
+
+const (
+	MCPOrgMaxPermissionAllow   = "allow"
+	MCPOrgMaxPermissionAsk     = "ask"
+	MCPOrgMaxPermissionBlocked = "blocked"
 )
 
 // SkillsConfig controls how Skills are loaded.

--- a/transport_test.go
+++ b/transport_test.go
@@ -1329,7 +1329,7 @@ func TestSubprocessTransportMCPConfigEncoding(t *testing.T) {
 				},
 				Tools: []MCPServerToolPolicy{
 					{Name: "foo", PermissionPolicy: MCPToolPolicyAllowAlways},
-					{Name: "bar", PermissionPolicy: MCPToolPolicyAskAlways},
+					{Name: "bar", PermissionPolicy: MCPToolPolicyAskAlways, OrgMaxPermission: MCPOrgMaxPermissionAsk},
 				},
 			},
 			want: map[string]interface{}{
@@ -1344,8 +1344,9 @@ func TestSubprocessTransportMCPConfigEncoding(t *testing.T) {
 						"permission_policy": "always_allow",
 					},
 					map[string]interface{}{
-						"name":              "bar",
-						"permission_policy": "always_ask",
+						"name":               "bar",
+						"permission_policy":  "always_ask",
+						"org_max_permission": "ask",
 					},
 				},
 			},


### PR DESCRIPTION
Part of #115 (parity with TS Agent SDK v0.3.177).

TS v0.3.177 adds `org_max_permission` to `McpServerToolPolicy` — the org admin's per-tool ceiling that drives the auto-mode `isOrgAskCeiling` gate, so an admin `ask` cap forces a user prompt even in auto mode.

## Changes
- `MCPServerToolPolicy.OrgMaxPermission string` (`org_max_permission,omitempty`) + `MCPOrgMaxPermission{Allow,Ask,Blocked}` constants.

## Tests
Extended the `mcp_set_servers` transport marshal test to carry `org_max_permission`. `go test ./...`, `go vet`, `gofmt -l` clean.