### PR TITLE
options: add SkipMcpDiscovery to PluginConfig

### DIFF
--- a/options.go
+++ b/options.go
@@ -789,9 +789,13 @@ type SandboxIgnoreViolations struct {
 // PluginConfig configures a plugin to load.
 type PluginConfig struct {
 	// Type must be "local" (only local plugins currently supported).
-	Type string
+	Type string `json:"type"`
 	// Path is the absolute or relative path to the plugin directory.
-	Path string
+	Path string `json:"path"`
+	// SkipMcpDiscovery, when true, loads skills/hooks/agents/commands from
+	// this plugin but does NOT read its .mcp.json or manifest mcpServers.
+	// Use when the SDK host owns this plugin's MCP connections.
+	SkipMcpDiscovery bool `json:"skipMcpDiscovery,omitempty"`
 }
 
 // OutputFormat defines structured output format for agent results.

--- a/options_test.go
+++ b/options_test.go
@@ -1048,3 +1048,38 @@ func TestUserDialogRequest_ToolUseIDOmitempty(t *testing.T) {
 		assert.Equal(t, "tu_42", got.ToolUseID)
 	})
 }
+
+func TestPluginConfigJSON(t *testing.T) {
+	t.Run("marshal includes skipMcpDiscovery when set", func(t *testing.T) {
+		data, err := json.Marshal(PluginConfig{
+			Type:             "local",
+			Path:             "./plugins/foo",
+			SkipMcpDiscovery: true,
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, "local", got["type"])
+		assert.Equal(t, "./plugins/foo", got["path"])
+		assert.Equal(t, true, got["skipMcpDiscovery"])
+	})
+
+	t.Run("omits skipMcpDiscovery when false", func(t *testing.T) {
+		data, err := json.Marshal(PluginConfig{Type: "local", Path: "./plugins/bar"})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "skipMcpDiscovery")
+	})
+
+	t.Run("WithPlugins round-trips the field", func(t *testing.T) {
+		opts := NewOptions()
+		WithPlugins([]PluginConfig{
+			{Type: "local", Path: "./p", SkipMcpDiscovery: true},
+		})(opts)
+		require.Len(t, opts.Plugins, 1)
+		assert.True(t, opts.Plugins[0].SkipMcpDiscovery)
+	})
+}


### PR DESCRIPTION
Part of #115 (parity with TS Agent SDK v0.3.177).

TS v0.3.177 adds `skipMcpDiscovery` to `SdkPluginConfig`: load a plugin's skills/hooks/agents/commands but do NOT read its `.mcp.json` or manifest `mcpServers` — for when the SDK host owns the plugin's MCP connections.

## Changes
- `PluginConfig.SkipMcpDiscovery bool` (`skipMcpDiscovery,omitempty`).
- Added explicit json tags to `PluginConfig` (`type`/`path`/`skipMcpDiscovery`); the struct was previously untagged, so this makes it serialize to the SDK wire shape. No behavioral change — `Plugins` has no serialization path today.

## Tests
`TestPluginConfigJSON` (marshal incl./omit + `WithPlugins` round-trip). `go test ./...`, `go vet`, `gofmt -l` clean.