### PR TITLE
messages: add OverageInUse to RateLimitInfo

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -521,6 +521,7 @@ type RateLimitInfo struct {
 	OverageResetsAt       *int64                          `json:"overageResetsAt,omitempty"`
 	OverageDisabledReason *RateLimitOverageDisabledReason `json:"overageDisabledReason,omitempty"`
 	IsUsingOverage        *bool                           `json:"isUsingOverage,omitempty"`
+	OverageInUse          *bool                           `json:"overageInUse,omitempty"`
 	SurpassedThreshold    *float64                        `json:"surpassedThreshold,omitempty"`
 }
 

--- a/messages_test.go
+++ b/messages_test.go
@@ -1055,6 +1055,7 @@ func TestRateLimitEventMessageRoundTripAndParse(t *testing.T) {
 			"overageResetsAt",
 			"overageDisabledReason",
 			"isUsingOverage",
+			"overageInUse",
 			"surpassedThreshold",
 		} {
 			assert.NotContains(t, info, key)
@@ -1079,6 +1080,7 @@ func TestRateLimitEventMessageRoundTripAndParse(t *testing.T) {
 				OverageResetsAt:       int64Ptr(1763942400),
 				OverageDisabledReason: rateLimitOverageDisabledReasonPtr(RateLimitOverageDisabledReasonOutOfCredits),
 				IsUsingOverage:        boolPtr(true),
+				OverageInUse:          boolPtr(true),
 				SurpassedThreshold:    float64Ptr(0.8),
 			},
 			UUID:      "550e8400-e29b-41d4-a716-446655440033",
@@ -1098,6 +1100,7 @@ func TestRateLimitEventMessageRoundTripAndParse(t *testing.T) {
 				"overageResetsAt": 1763942400,
 				"overageDisabledReason": "out_of_credits",
 				"isUsingOverage": true,
+				"overageInUse": true,
 				"surpassedThreshold": 0.8
 			},
 			"uuid": "550e8400-e29b-41d4-a716-446655440033",


### PR DESCRIPTION
Part of #115 (parity with TS Agent SDK v0.3.177).

TS v0.3.177 adds `overageInUse` to `SDKRateLimitInfo`, alongside the existing `isUsingOverage`.

## Changes
- `RateLimitInfo.OverageInUse *bool` (`overageInUse,omitempty`).

## Tests
Extended `TestRateLimitEventMessageRoundTripAndParse` (populated round-trip + omit-when-unset). `go test ./...`, `go vet`, `gofmt -l` clean.