### PR TITLE
options: add v0.3.177 Settings parity fields

### DIFF
--- a/options.go
+++ b/options.go
@@ -449,6 +449,28 @@ type Settings struct {
 	DisableDeepLinkRegistration string `json:"disableDeepLinkRegistration,omitempty"`
 	// DefaultView controls the default transcript view. Mirrors sdk.d.ts v0.3.150 L5431.
 	DefaultView string `json:"defaultView,omitempty"`
+	// EnforceAvailableModels restricts model selection to AvailableModels. Mirrors sdk.d.ts v0.3.177 L4608.
+	EnforceAvailableModels *bool `json:"enforceAvailableModels,omitempty"`
+	// DisableBundledSkills removes the skills and workflows that ship with Claude Code: bundled skills/workflows are removed entirely and built-in slash commands stay typable but hidden from the model. Plugins, .claude/skills/, and .claude/commands/ are unaffected. Equivalent to CLAUDE_CODE_DISABLE_BUNDLED_SKILLS=1. Mirrors sdk.d.ts v0.3.177 L4636.
+	DisableBundledSkills *bool `json:"disableBundledSkills,omitempty"`
+	// DisableArtifact disables the artifact view. Mirrors sdk.d.ts v0.3.177 L4905.
+	DisableArtifact *bool `json:"disableArtifact,omitempty"`
+	// FooterLinksRegexes adds clickable footer badges when a regex matches turn output. Read from user, flag, and managed settings only. At most 5 badges render. Mirrors sdk.d.ts v0.3.177 L4973.
+	FooterLinksRegexes []SettingsFooterLinkRegex `json:"footerLinksRegexes,omitempty"`
+	// WheelScrollAccelerationEnabled enables mouse-wheel scroll acceleration. Mirrors sdk.d.ts v0.3.177 L5988.
+	WheelScrollAccelerationEnabled *bool `json:"wheelScrollAccelerationEnabled,omitempty"`
+}
+
+// SettingsFooterLinkRegex is a footer-badge rule: when Pattern matches turn
+// output, a badge linking to URL (with {name} placeholders filled from named
+// regex capture groups) is rendered. Type is the config variant — this client
+// understands "regex"; entries with other variants are preserved but skipped
+// at runtime.
+type SettingsFooterLinkRegex struct {
+	Type    string `json:"type"`
+	Pattern string `json:"pattern,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Label   string `json:"label,omitempty"`
 }
 
 type SettingsFileSuggestion struct {

--- a/options_test.go
+++ b/options_test.go
@@ -378,6 +378,51 @@ func TestSettingsRequiredVersionsJSON(t *testing.T) {
 	assert.NotContains(t, empty, "requiredMaximumVersion")
 }
 
+func TestSettingsParity0177JSON(t *testing.T) {
+	in := Settings{
+		EnforceAvailableModels:         boolPtr(true),
+		DisableBundledSkills:           boolPtr(true),
+		DisableArtifact:                boolPtr(false),
+		WheelScrollAccelerationEnabled: boolPtr(true),
+		FooterLinksRegexes: []SettingsFooterLinkRegex{
+			{Type: "regex", Pattern: `PR #(?<id>\d+)`, URL: "https://example.com/pr/{id}", Label: "PR"},
+		},
+	}
+	data, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, true, got["enforceAvailableModels"])
+	assert.Equal(t, true, got["disableBundledSkills"])
+	assert.Equal(t, false, got["disableArtifact"])
+	assert.Equal(t, true, got["wheelScrollAccelerationEnabled"])
+	regexes, ok := got["footerLinksRegexes"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, regexes, 1)
+	entry := regexes[0].(map[string]interface{})
+	assert.Equal(t, "regex", entry["type"])
+	assert.Equal(t, "https://example.com/pr/{id}", entry["url"])
+
+	var out Settings
+	require.NoError(t, json.Unmarshal(data, &out))
+	require.NotNil(t, out.EnforceAvailableModels)
+	assert.True(t, *out.EnforceAvailableModels)
+	require.Len(t, out.FooterLinksRegexes, 1)
+	assert.Equal(t, "PR", out.FooterLinksRegexes[0].Label)
+
+	empty := map[string]interface{}{}
+	data, err = json.Marshal(Settings{})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &empty))
+	for _, k := range []string{
+		"enforceAvailableModels", "disableBundledSkills", "disableArtifact",
+		"footerLinksRegexes", "wheelScrollAccelerationEnabled",
+	} {
+		assert.NotContains(t, empty, k)
+	}
+}
+
 func TestSettingsSwitchModelsOnFlagJSON(t *testing.T) {
 	t.Run("nil omits key", func(t *testing.T) {
 		data, err := json.Marshal(Settings{})


### PR DESCRIPTION
Part of #115 (parity with TS Agent SDK v0.3.177).

TS v0.3.177 adds five `Settings` fields. (`$schema` was already present.)

## Changes
- `EnforceAvailableModels *bool` (L4608) — restrict model selection to `AvailableModels`.
- `DisableBundledSkills *bool` (L4636) — drop bundled skills/workflows; built-in slash commands stay typable but hidden from the model. ≡ `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS=1`.
- `DisableArtifact *bool` (L4905).
- `FooterLinksRegexes []SettingsFooterLinkRegex` (L4973) — clickable footer badges built from named regex capture groups on turn output.
- `WheelScrollAccelerationEnabled *bool` (L5988).

`FooterLinksRegexes` uses a typed `SettingsFooterLinkRegex` for the `regex` variant — the Go SDK produces managed settings (host-constructed), so only known variants are emitted.

## Tests
`TestSettingsParity0177JSON` (marshal + round-trip + omit-when-unset). `go test ./...`, `go vet`, `gofmt -l` clean.