### PR TITLE
transport: add optional WaitForExit capability

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -60,6 +60,25 @@ type Transport interface {
 	IsReady() bool
 }
 
+// ExitWaiter is an optional capability implemented by transports backed by a
+// subprocess whose exit can be awaited. Network and in-process transports do
+// not implement it. Mirrors the optional Transport.waitForExit in the TS SDK
+// (sdk.d.ts v0.3.185 L6418): cleanup awaits it (bounded) so teardown does not
+// resolve while the child is still draining the stdin EOF that Close sent.
+//
+// Callers should type-assert before use:
+//
+//	if ew, ok := transport.(ExitWaiter); ok {
+//		_ = ew.WaitForExit(ctx)
+//	}
+type ExitWaiter interface {
+	// WaitForExit blocks until the underlying subprocess exits, returning its
+	// exit error, or until ctx is done. Safe to call concurrently with Close
+	// and multiple times: the subprocess is waited on exactly once and every
+	// caller observes the same result.
+	WaitForExit(ctx context.Context) error
+}
+
 type SubprocessTransport struct {
 	runner    SubprocessRunner
 	stdin     io.WriteCloser
@@ -70,6 +89,19 @@ type SubprocessTransport struct {
 	options   *Options
 	mu        sync.Mutex
 	errLogger atomic.Pointer[writerRef]
+	exitOnce  sync.Once
+	exitErr   error
+}
+
+// awaitExit blocks on the subprocess exit exactly once and caches the result,
+// so Close and WaitForExit never double-Wait the underlying os/exec.Cmd.
+func (t *SubprocessTransport) awaitExit() error {
+	t.exitOnce.Do(func() {
+		if t.runner != nil {
+			t.exitErr = t.runner.Wait()
+		}
+	})
+	return t.exitErr
 }
 
 // NewSubprocessTransport creates a new transport for the Claude CLI.
@@ -549,7 +581,7 @@ func (t *SubprocessTransport) Close() error {
 	if t.runner != nil {
 		done := make(chan error, 1)
 		go func() {
-			done <- t.runner.Wait()
+			done <- t.awaitExit()
 		}()
 
 		// Wait with timeout
@@ -589,4 +621,26 @@ func (t *SubprocessTransport) IsReady() bool {
 	return t.IsAlive()
 }
 
-var _ Transport = (*SubprocessTransport)(nil)
+// WaitForExit blocks until the CLI subprocess exits or ctx is done. It
+// implements ExitWaiter. The wait is shared with Close, so the underlying
+// process is reaped exactly once.
+func (t *SubprocessTransport) WaitForExit(ctx context.Context) error {
+	if t.runner == nil {
+		return nil
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- t.awaitExit()
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+var (
+	_ Transport  = (*SubprocessTransport)(nil)
+	_ ExitWaiter = (*SubprocessTransport)(nil)
+)

--- a/transport_test.go
+++ b/transport_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"iter"
 	"strings"
 	"sync"
@@ -358,6 +360,53 @@ func TestSubprocessTransportCloseAfterEndInput(t *testing.T) {
 	assert.True(t, transport.closed.Load())
 	assert.False(t, transport.IsReady())
 }
+
+func TestSubprocessTransportWaitForExit(t *testing.T) {
+	t.Run("returns runner exit error", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		runner.exited = true
+		runner.exitErr = errors.New("boom")
+
+		transport := NewSubprocessTransportWithRunner(runner, NewOptions())
+		require.NoError(t, transport.Connect(context.Background()))
+
+		// ExitWaiter capability is advertised.
+		ew, ok := Transport(transport).(ExitWaiter)
+		require.True(t, ok)
+
+		err := ew.WaitForExit(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boom")
+
+		// Idempotent: a second call observes the same cached result.
+		assert.Equal(t, err, ew.WaitForExit(context.Background()))
+	})
+
+	t.Run("honors context cancellation", func(t *testing.T) {
+		runner := &blockingExitRunner{released: make(chan struct{})}
+		transport := NewSubprocessTransportWithRunner(runner, NewOptions())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := transport.WaitForExit(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+		close(runner.released)
+	})
+}
+
+// blockingExitRunner is a SubprocessRunner whose Wait blocks until released,
+// used to exercise WaitForExit's context cancellation path.
+type blockingExitRunner struct {
+	released chan struct{}
+}
+
+func (r *blockingExitRunner) Start(context.Context, []string, []string, string) (io.WriteCloser, io.ReadCloser, io.ReadCloser, error) {
+	return nil, nil, nil, nil
+}
+func (r *blockingExitRunner) Wait() error   { <-r.released; return nil }
+func (r *blockingExitRunner) Kill() error   { return nil }
+func (r *blockingExitRunner) IsAlive() bool { return true }
 
 // TestSubprocessTransportContextCancellation tests that context cancellation
 // stops message reading.


### PR DESCRIPTION
Ports the optional `Transport.waitForExit` from TS SDK v0.3.185 (sdk.d.ts L6418). Part of #125.

- New `ExitWaiter` capability interface — `WaitForExit(ctx) error`. Kept off the core `Transport` interface so external `Transport` implementers don't break; callers type-assert.
- `*SubprocessTransport` implements it: blocks until the CLI subprocess exits or ctx is done.
- The exit wait is now shared between `Close` and `WaitForExit` via a `sync.Once` latch, so the underlying `os/exec.Cmd` is reaped exactly once and concurrent callers all observe the same result.
- Tests cover the exit-error path, idempotency, and context cancellation (blocking runner).

Mirrors the upstream intent: cleanup awaits exit (bounded) so teardown doesn't resolve while the child is still draining the stdin EOF that Close sent.

See memory/catchup-v0.3.185/PLAN.md §"PR 08".