### PR TITLE
messages: add informational system message

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -1158,6 +1158,41 @@ type WorkerShuttingDownMessage struct {
 // MessageType implements Message.
 func (m WorkerShuttingDownMessage) MessageType() string { return "system" }
 
+// InformationalLevel is the render level of an InformationalMessage.
+type InformationalLevel string
+
+const (
+	// InformationalLevelInfo shows only in transcript mode.
+	InformationalLevelInfo InformationalLevel = "info"
+	// InformationalLevelNotice renders in inactive gray.
+	InformationalLevelNotice InformationalLevel = "notice"
+	// InformationalLevelSuggestion renders more prominently than notice.
+	InformationalLevelSuggestion InformationalLevel = "suggestion"
+	// InformationalLevelWarning is the most prominent render level.
+	InformationalLevelWarning InformationalLevel = "warning"
+)
+
+// InformationalMessage is a generic text banner emitted by the loop —
+// non-error status lines, hook feedback (e.g. a UserPromptSubmit hook's block
+// reason), slash-command output. Hosts render Content as plaintext at the
+// given Level.
+type InformationalMessage struct {
+	Type    string             `json:"type"`    // Always "system"
+	Subtype string             `json:"subtype"` // "informational"
+	Content string             `json:"content"` // Plaintext banner content
+	Level   InformationalLevel `json:"level"`   // Render level
+	// ToolUseID dedupes progress messages for the same tool use.
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	// PreventContinuation, when true, stops execution after this message
+	// (e.g. a Stop hook denied continuation).
+	PreventContinuation bool   `json:"prevent_continuation,omitempty"`
+	UUID                string `json:"uuid"`       // Unique message ID
+	SessionID           string `json:"session_id"` // Session identifier
+}
+
+// MessageType implements Message.
+func (m InformationalMessage) MessageType() string { return "system" }
+
 // SDKStatusValue is the non-null status payload for a status message.
 type SDKStatusValue string
 
@@ -1292,6 +1327,10 @@ func ParseMessage(data []byte) (Message, error) {
 			return msg, err
 		case "hook_started":
 			var msg HookStartedMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "informational":
+			var msg InformationalMessage
 			err := json.Unmarshal(data, &msg)
 			return msg, err
 		case "hook_progress":

--- a/messages_test.go
+++ b/messages_test.go
@@ -3245,6 +3245,49 @@ func TestParseMessageWorkerShuttingDown(t *testing.T) {
 	assert.Equal(t, "sess_misc_012", shutdownMsg.SessionID)
 }
 
+func TestParseMessageInformational(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "informational",
+		"content": "hook blocked the prompt",
+		"level": "warning",
+		"tool_use_id": "toolu_01",
+		"prevent_continuation": true,
+		"uuid": "550e8400-e29b-41d4-a716-4466554402D0",
+		"session_id": "sess_misc_013"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	infoMsg, ok := msg.(InformationalMessage)
+	require.True(t, ok, "expected InformationalMessage")
+
+	assert.Equal(t, "system", infoMsg.MessageType())
+	assert.Equal(t, "informational", infoMsg.Subtype)
+	assert.Equal(t, "hook blocked the prompt", infoMsg.Content)
+	assert.Equal(t, InformationalLevelWarning, infoMsg.Level)
+	assert.Equal(t, "toolu_01", infoMsg.ToolUseID)
+	assert.True(t, infoMsg.PreventContinuation)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-4466554402D0", infoMsg.UUID)
+	assert.Equal(t, "sess_misc_013", infoMsg.SessionID)
+}
+
+func TestInformationalMessageOmitempty(t *testing.T) {
+	data, err := json.Marshal(InformationalMessage{
+		Type:    "system",
+		Subtype: "informational",
+		Content: "compacting",
+		Level:   InformationalLevelInfo,
+	})
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.NotContains(t, got, "tool_use_id")
+	assert.NotContains(t, got, "prevent_continuation")
+}
+
 func TestParseMessageThinkingTokensZeroDelta(t *testing.T) {
 	input := `{
 		"type": "system",


### PR DESCRIPTION
Ports `SDKInformationalMessage` from TS SDK v0.3.185 (sdk.d.ts L3555–3577). Part of #125.

- New `InformationalMessage` (`type: system`, `subtype: informational`): a generic text banner — non-error status lines, hook feedback, slash-command output.
- `Content` plaintext + `Level` (`InformationalLevel`: info/notice/suggestion/warning).
- Optional `ToolUseID` (dedupes per-tool progress) and `PreventContinuation` (stop after this message, e.g. a Stop hook denial), both `omitempty`.
- Dispatch case in the system-subtype switch; round-trip + omitempty unit tests.

Integration: skipped — emitted on hook-feedback / slash-command paths; backfill slot left for a deterministic trigger.

See memory/catchup-v0.3.185/PLAN.md §"PR 02".