### PR TITLE
protocol: add thinking_display to set_max_thinking_tokens

### DIFF
--- a/client.go
+++ b/client.go
@@ -783,13 +783,52 @@ func (s *Stream) SetModel(ctx context.Context, model string) error {
 	return err
 }
 
+// setMaxThinkingTokensOptions accumulates optional set_max_thinking_tokens
+// parameters.
+type setMaxThinkingTokensOptions struct {
+	display *ThinkingDisplayOverride
+}
+
+// SetMaxThinkingTokensOption configures Stream.SetMaxThinkingTokens.
+type SetMaxThinkingTokensOption func(*setMaxThinkingTokensOptions)
+
+// WithThinkingDisplay sets the thinking display mode for the rest of the
+// session. The supplied value replaces the current session display mode.
+func WithThinkingDisplay(mode ThinkingDisplay) SetMaxThinkingTokensOption {
+	return func(o *setMaxThinkingTokensOptions) {
+		o.display = &ThinkingDisplayOverride{Mode: &mode}
+	}
+}
+
+// WithThinkingDisplayAPIDefault clears the thinking display mode back to the
+// API default for the rest of the session (wire null). Use this rather than
+// omitting the option when the goal is to reset rather than keep the
+// session-start display mode.
+func WithThinkingDisplayAPIDefault() SetMaxThinkingTokensOption {
+	return func(o *setMaxThinkingTokensOptions) {
+		o.display = &ThinkingDisplayOverride{}
+	}
+}
+
 // SetMaxThinkingTokens dynamically changes the max thinking tokens limit.
-// Pass nil to remove the limit.
+// Pass nil tokens to remove the limit.
+//
+// An optional WithThinkingDisplay / WithThinkingDisplayAPIDefault controls the
+// thinking display mode for the rest of the session; when no display option is
+// given the display mode from session start is kept. Note a session started
+// with thinking disabled has no display mode, so re-enabling thinking without
+// a display option yields the API's default display.
+//
 // It blocks until the CLI acknowledges the request or returns an error.
-func (s *Stream) SetMaxThinkingTokens(ctx context.Context, tokens *int) error {
+func (s *Stream) SetMaxThinkingTokens(ctx context.Context, tokens *int, opts ...SetMaxThinkingTokensOption) error {
+	var cfg setMaxThinkingTokensOptions
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
 		Subtype:           "set_max_thinking_tokens",
 		MaxThinkingTokens: tokens,
+		ThinkingDisplay:   cfg.display,
 	})
 	return err
 }

--- a/messages.go
+++ b/messages.go
@@ -292,6 +292,38 @@ type SDKControlRequest struct {
 	Request   SDKControlRequestBody `json:"request"`    // Nested request payload
 }
 
+// ThinkingDisplayOverride is the optional thinking_display payload of a
+// set_max_thinking_tokens control request. It distinguishes setting a mode
+// from clearing the mode back to the API default: a nil Mode marshals as JSON
+// null (clear to API default), while a non-nil Mode marshals as that value.
+// Omitting the whole field (a nil *ThinkingDisplayOverride) keeps the display
+// mode from session start.
+type ThinkingDisplayOverride struct {
+	Mode *ThinkingDisplay
+}
+
+// MarshalJSON implements json.Marshaler.
+func (d ThinkingDisplayOverride) MarshalJSON() ([]byte, error) {
+	if d.Mode == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(*d.Mode)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (d *ThinkingDisplayOverride) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		d.Mode = nil
+		return nil
+	}
+	var mode ThinkingDisplay
+	if err := json.Unmarshal(data, &mode); err != nil {
+		return err
+	}
+	d.Mode = &mode
+	return nil
+}
+
 // SDKControlRequestBody contains the actual request data.
 // Note: This is a union type - different fields are used for different subtypes.
 type SDKControlRequestBody struct {
@@ -320,6 +352,7 @@ type SDKControlRequestBody struct {
 	Mode                   string                              `json:"mode,omitempty"`                   // For set_permission_mode
 	Model                  string                              `json:"model,omitempty"`                  // For set_model
 	MaxThinkingTokens      *int                                `json:"max_thinking_tokens,omitempty"`    // For set_max_thinking_tokens
+	ThinkingDisplay        *ThinkingDisplayOverride            `json:"thinking_display,omitempty"`       // For set_max_thinking_tokens
 	Directory              string                              `json:"directory,omitempty"`              // For register_repo_root
 	ReloadClaudeMD         *bool                               `json:"reload_claude_md,omitempty"`       // For register_repo_root
 	ReloadPlugins          *bool                               `json:"reload_plugins,omitempty"`         // For register_repo_root

--- a/stream_control_test.go
+++ b/stream_control_test.go
@@ -242,6 +242,46 @@ func TestStreamSetMaxThinkingTokensRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStreamSetMaxThinkingTokensThinkingDisplay(t *testing.T) {
+	t.Run("omitted when no option", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			return stream.SetMaxThinkingTokens(ctx, intPtr(4096))
+		})
+		require.NoError(t, err)
+
+		_, generic := decodeWrittenSDKControlRequest(t, transport)
+		body := genericRequestBody(t, generic)
+		assert.NotContains(t, body, "thinking_display")
+	})
+
+	t.Run("mode value", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			return stream.SetMaxThinkingTokens(ctx, nil, WithThinkingDisplay(ThinkingDisplayOmitted))
+		})
+		require.NoError(t, err)
+
+		_, generic := decodeWrittenSDKControlRequest(t, transport)
+		body := genericRequestBody(t, generic)
+		assert.Equal(t, "omitted", body["thinking_display"])
+	})
+
+	t.Run("api default is explicit null", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			return stream.SetMaxThinkingTokens(ctx, nil, WithThinkingDisplayAPIDefault())
+		})
+		require.NoError(t, err)
+
+		_, generic := decodeWrittenSDKControlRequest(t, transport)
+		body := genericRequestBody(t, generic)
+		got, ok := body["thinking_display"]
+		require.True(t, ok, "thinking_display should be present as null")
+		assert.Nil(t, got)
+	})
+}
+
 func TestStreamRegisterRepoRootMinimal(t *testing.T) {
 	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
 


### PR DESCRIPTION
Ports the `thinking_display` parameter added to `set_max_thinking_tokens` in TS SDK v0.3.185 (sdk.d.ts L2229 method, L3432 control body). Part of #125.

- `SDKControlRequestBody.ThinkingDisplay *ThinkingDisplayOverride` — a wrapper over the existing `ThinkingDisplay` type that distinguishes three wire states: omitted (keep session-start display), a mode value, and explicit `null` (clear to API default).
- `Stream.SetMaxThinkingTokens` gains a variadic `...SetMaxThinkingTokensOption` (backward-compatible) with `WithThinkingDisplay(mode)` and `WithThinkingDisplayAPIDefault()`.
- Reuses the existing `ThinkingDisplay` / `ThinkingDisplaySummarized` / `ThinkingDisplayOmitted` rather than redeclaring.
- Unit tests round-trip the control body for all three states (omitted / value / explicit null).

Integration: covered by the control-request round-trip unit tests, matching the existing `SetMaxThinkingTokens` coverage pattern (the base method ships unit-only; the display override is not separately observable from the CLI).

See memory/catchup-v0.3.185/PLAN.md §"PR 03".