### PR TITLE
messages: add credit-exhaustion fields to RateLimitInfo

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -556,7 +556,20 @@ type RateLimitInfo struct {
 	IsUsingOverage        *bool                           `json:"isUsingOverage,omitempty"`
 	OverageInUse          *bool                           `json:"overageInUse,omitempty"`
 	SurpassedThreshold    *float64                        `json:"surpassedThreshold,omitempty"`
+	// ErrorCode signals a credit-exhaustion condition; the only defined value
+	// is "credits_required". Open string for forward compatibility.
+	ErrorCode string `json:"errorCode,omitempty"`
+	// CanUserPurchaseCredits reports whether the user can buy credits to lift
+	// the limit.
+	CanUserPurchaseCredits *bool `json:"canUserPurchaseCredits,omitempty"`
+	// HasChargeableSavedPaymentMethod reports whether a chargeable payment
+	// method is already on file.
+	HasChargeableSavedPaymentMethod *bool `json:"hasChargeableSavedPaymentMethod,omitempty"`
 }
+
+// RateLimitErrorCodeCreditsRequired is the only defined RateLimitInfo.ErrorCode
+// value: the limit can be lifted by purchasing credits.
+const RateLimitErrorCodeCreditsRequired = "credits_required"
 
 // AuthStatusMessage reports authentication status.
 type AuthStatusMessage struct {

--- a/messages_test.go
+++ b/messages_test.go
@@ -1139,6 +1139,47 @@ func TestRateLimitEventMessageRoundTripAndParse(t *testing.T) {
 		require.NotNil(t, rateLimitMsg.RateLimitInfo.OverageDisabledReason)
 		assert.Equal(t, RateLimitOverageDisabledReason("future_reason"), *rateLimitMsg.RateLimitInfo.OverageDisabledReason)
 	})
+
+	t.Run("credit fields round-trip", func(t *testing.T) {
+		msg := RateLimitEventMessage{
+			Type: "rate_limit_event",
+			RateLimitInfo: RateLimitInfo{
+				Status:                          RateLimitStatusRejected,
+				ErrorCode:                       RateLimitErrorCodeCreditsRequired,
+				CanUserPurchaseCredits:          boolPtr(true),
+				HasChargeableSavedPaymentMethod: boolPtr(false),
+			},
+			UUID:      "550e8400-e29b-41d4-a716-446655440036",
+			SessionID: "sess_top_123",
+		}
+
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		info := got["rate_limit_info"].(map[string]interface{})
+		assert.Equal(t, "credits_required", info["errorCode"])
+		assert.Equal(t, true, info["canUserPurchaseCredits"])
+		assert.Equal(t, false, info["hasChargeableSavedPaymentMethod"])
+
+		parsed, err := ParseMessage(data)
+		require.NoError(t, err)
+		rateLimitMsg, ok := parsed.(RateLimitEventMessage)
+		require.True(t, ok, "expected RateLimitEventMessage")
+		assert.Equal(t, msg, rateLimitMsg)
+	})
+
+	t.Run("credit fields omitted when unset", func(t *testing.T) {
+		data, err := json.Marshal(RateLimitInfo{Status: RateLimitStatusAllowed})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "errorCode")
+		assert.NotContains(t, got, "canUserPurchaseCredits")
+		assert.NotContains(t, got, "hasChargeableSavedPaymentMethod")
+	})
 }
 
 func TestToolProgressMessageTaskIDRoundTrip(t *testing.T) {


### PR DESCRIPTION
Ports the three credit-exhaustion fields added to `SDKRateLimitInfo` in TS SDK v0.3.185 (sdk.d.ts L3831–3834). Part of #125.

- `RateLimitInfo.ErrorCode` (open string; only defined value `credits_required`, exposed as `RateLimitErrorCodeCreditsRequired`).
- `RateLimitInfo.CanUserPurchaseCredits *bool`.
- `RateLimitInfo.HasChargeableSavedPaymentMethod *bool`.

All `omitempty`; round-trip + omitempty unit tests added.

See memory/catchup-v0.3.185/PLAN.md §"PR 04".