### PR TITLE
messages: add time_origin_ms to result message

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -177,6 +177,7 @@ type ResultMessage struct {
 	TimeToRequestMs          *int64 `json:"time_to_request_ms,omitempty"`            // Time to request in milliseconds
 	TimeToRequestFromSpawnMs *int64 `json:"time_to_request_from_spawn_ms,omitempty"` // Time to request from spawn in milliseconds
 	WarmSpareClaimed         *bool  `json:"warm_spare_claimed,omitempty"`            // Whether a warm spare was claimed
+	TimeOriginMs             *int64 `json:"time_origin_ms,omitempty"`                // Wall-clock origin for the above timings, in milliseconds (success only)
 	IsError                  bool   `json:"is_error,omitempty"`                      // Whether this is an error result
 	NumTurns                 int    `json:"num_turns,omitempty"`                     // Number of conversation turns
 

--- a/messages_test.go
+++ b/messages_test.go
@@ -706,7 +706,8 @@ func TestParseResultMessageTimingFields(t *testing.T) {
 		"ttft_stream_ms": 42,
 		"time_to_request_ms": 84,
 		"time_to_request_from_spawn_ms": 126,
-		"warm_spare_claimed": true
+		"warm_spare_claimed": true,
+		"time_origin_ms": 1763856000000
 	}`)
 
 	msg, err := ParseMessage(input)
@@ -722,6 +723,8 @@ func TestParseResultMessageTimingFields(t *testing.T) {
 	assert.Equal(t, int64(126), *resultMsg.TimeToRequestFromSpawnMs)
 	require.NotNil(t, resultMsg.WarmSpareClaimed)
 	assert.True(t, *resultMsg.WarmSpareClaimed)
+	require.NotNil(t, resultMsg.TimeOriginMs)
+	assert.Equal(t, int64(1763856000000), *resultMsg.TimeOriginMs)
 }
 
 func TestResultMessageTimingFieldsOmitempty(t *testing.T) {
@@ -739,6 +742,7 @@ func TestResultMessageTimingFieldsOmitempty(t *testing.T) {
 	assert.NotContains(t, got, "time_to_request_ms")
 	assert.NotContains(t, got, "time_to_request_from_spawn_ms")
 	assert.NotContains(t, got, "warm_spare_claimed")
+	assert.NotContains(t, got, "time_origin_ms")
 }
 
 func TestResultMessageTimingFieldsExplicitFalse(t *testing.T) {


### PR DESCRIPTION
Ports `time_origin_ms` added to `SDKResultSuccess` in TS SDK v0.3.185 (sdk.d.ts L3869). Part of #125.

- `ResultMessage.TimeOriginMs *int64` (`omitempty`) — wall-clock origin for the success-result timing fields.
- Extends the existing result-timing parse + omitempty tests.

See memory/catchup-v0.3.185/PLAN.md §"PR 05".