### PR TITLE
messages: add senderTaskId to user message

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -29,6 +29,11 @@ type UserMessage struct {
 	Priority        *UserMessagePriority `json:"priority,omitempty"`         // Scheduling priority
 	SubagentType    string               `json:"subagent_type,omitempty"`    // Subagent type that produced this message
 	TaskDescription string               `json:"task_description,omitempty"` // Description of the subagent task that produced this message
+	// SenderTaskID is the task id of the in-process background subagent that
+	// sent this message, stamped by the harness from the sending loop (never
+	// from tool input). Absent for cross-session peers. Note: camelCase wire
+	// key, matching the TS SDK.
+	SenderTaskID string `json:"senderTaskId,omitempty"`
 }
 
 // APIUserMessage represents the message content in Anthropic API format.

--- a/messages_test.go
+++ b/messages_test.go
@@ -314,6 +314,26 @@ func TestParseMessageUserMessageSubagentFields(t *testing.T) {
 	assert.Equal(t, "Inspect repo", userMsg.TaskDescription)
 }
 
+func TestParseMessageUserMessageSenderTaskID(t *testing.T) {
+	input := `{
+		"type": "user",
+		"session_id": "s1",
+		"message": {
+			"role": "user",
+			"content": [{"type": "text", "text": "from a bg subagent"}]
+		},
+		"parent_tool_use_id": null,
+		"senderTaskId": "task_abc123"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	userMsg, ok := msg.(UserMessage)
+	require.True(t, ok, "expected UserMessage")
+	assert.Equal(t, "task_abc123", userMsg.SenderTaskID)
+}
+
 func TestUserMessageSubagentFieldsOmitEmpty(t *testing.T) {
 	msg := UserMessage{Type: "user", SessionID: "s1"}
 
@@ -325,6 +345,7 @@ func TestUserMessageSubagentFieldsOmitEmpty(t *testing.T) {
 
 	assert.NotContains(t, got, "subagent_type")
 	assert.NotContains(t, got, "task_description")
+	assert.NotContains(t, got, "senderTaskId")
 }
 
 func TestUserMessageSubagentFieldsRoundTrip(t *testing.T) {


### PR DESCRIPTION
Ports `senderTaskId` added to `SDKUserMessage` in TS SDK v0.3.185 (sdk.d.ts L3649). Part of #125.

- `UserMessage.SenderTaskID string` with the camelCase wire key `senderTaskId` (`omitempty`) — task id of the in-process background subagent that sent the message, stamped by the harness; absent for cross-session peers.
- Parse + omitempty unit tests added.

See memory/catchup-v0.3.185/PLAN.md §"PR 06".