### PR TITLE
docs: refresh parity to v0.3.185

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ stdin/stdout, giving you access to Claude's tool use, extended thinking,
 session management, and hook system.
 
 This repository tracks the official TypeScript Agent SDK surface through the
-v0.3.177 catchup work, using Go idioms where the API shape differs.
+v0.3.185 catchup work, using Go idioms where the API shape differs.
 
 ```mermaid
 flowchart TB
@@ -301,6 +301,32 @@ PRs in this cycle (squash-merged): #116 model_refusal_fallback + supersedes,
 #117 get_usage control request, #118 SupportedDialogKinds, #119
 pending_user_dialog_requests, #120 OrgMaxPermission, #121 SkipMcpDiscovery,
 #122 OverageInUse, #123 Settings parity.
+
+The v0.3.185 catchup added:
+
+- two new system message subtypes: `WorkerShuttingDownMessage`
+  (`worker_shutting_down`, a live-tail-only graceful-teardown signal) and
+  `InformationalMessage` (`informational`, a leveled text banner for hook
+  feedback / slash-command output)
+- `thinking_display` on `set_max_thinking_tokens`: `SetMaxThinkingTokens` now
+  takes optional `WithThinkingDisplay` / `WithThinkingDisplayAPIDefault`,
+  modeling the omit / value / explicit-null wire states
+- the optional `ExitWaiter` transport capability (`WaitForExit`), implemented
+  by `SubprocessTransport` and kept off the core `Transport` interface
+- new fields: `RateLimitInfo` credit-exhaustion (`ErrorCode`,
+  `CanUserPurchaseCredits`, `HasChargeableSavedPaymentMethod`),
+  `ResultMessage.TimeOriginMs`, `UserMessage.SenderTaskID`
+- Settings parity: `Settings.DisableClaudeAiConnectors`,
+  `SettingsAttribution.SessionURL`, `SettingsSandbox.AllowAppleEvents`
+
+PRs in this cycle (squash-merged): #126 worker_shutting_down, #129
+informational, #130 thinking_display, #131 RateLimitInfo credit fields, #132
+ResultMessage time_origin_ms, #133 UserMessage senderTaskId, #127 Settings
+parity, #128 transport WaitForExit, #134 docs refresh.
+
+Not ported this cycle: `set_mcp_permission_mode_override` is referenced in the
+upstream control-request union but ships without a type body or wire constant,
+so there is nothing to model yet — deferred until upstream emits a definition.
 
 Some areas remain intentionally limited by the CLI or integration harness:
 desktop/IDE-only settings are not modeled exhaustively, several runtime control

--- a/messages.go
+++ b/messages.go
@@ -922,15 +922,19 @@ type ModelRefusalFallbackMessage struct {
 	FallbackModel string  `json:"fallback_model"` // Model the turn retried on
 	RequestID     *string `json:"request_id"`     // Upstream request id; nil for JSON null
 
-	// APIRefusalCategory is stop_details.category from the refused API
-	// response ("cyber", "bio", …). Open string — new categories ship on the
-	// wire ahead of schema updates. nil when the response carried no category
-	// (normal, not an error) or when emitted by an older CLI.
+	// APIRefusalCategory is the refusal category ("cyber", "bio", …):
+	// stop_details.category from the refused API response (client lane), or
+	// the fallback block's server-gated trigger.category (server lane). Open
+	// string — new categories ship on the wire ahead of schema updates. nil
+	// when neither source carried a category (normal, not an error) or when
+	// emitted by an older CLI.
 	APIRefusalCategory *string `json:"api_refusal_category,omitempty"`
 
 	// APIRefusalExplanation is stop_details.explanation from the refused API
-	// response. Unstable human prose — display only, never parse. nil under
-	// the same rules as APIRefusalCategory.
+	// response (client lane only — the server-lane trigger carries no
+	// explanation). Unstable human prose — display only, never parse. nil when
+	// the response carried none, always nil on server-lane banners, and under
+	// the same older-CLI rule as APIRefusalCategory.
 	APIRefusalExplanation *string `json:"api_refusal_explanation,omitempty"`
 
 	// RetractedMessageUUIDs lists wire UUIDs of the messages this fallback

--- a/options.go
+++ b/options.go
@@ -193,7 +193,9 @@ type Options struct {
 	// loading allowlist, which is a different surface).
 	AllowedTools []string
 
-	// DisallowedTools is a list of disallowed tool names.
+	// DisallowedTools is a list of tool names to explicitly disallow for this
+	// agent. MCP server-level specs (mcp__server, mcp__server__*, mcp__*)
+	// remove every tool from the named server (or all MCP tools).
 	DisallowedTools []string
 
 	// Tools configures available built-in tools.
@@ -1943,7 +1945,10 @@ type TaskCompletedInput struct {
 	TaskSubject     string `json:"task_subject"`
 	TaskDescription string `json:"task_description,omitempty"`
 	TeammateName    string `json:"teammate_name,omitempty"`
-	TeamName        string `json:"team_name,omitempty"`
+	// Deprecated: sessions have a single implicit team; this carries the
+	// session-derived team name and will be removed upstream in a future
+	// release.
+	TeamName string `json:"team_name,omitempty"`
 }
 
 // HookType implements HookInput.
@@ -1959,7 +1964,10 @@ type TaskCreatedInput struct {
 	TaskSubject     string `json:"task_subject"`
 	TaskDescription string `json:"task_description,omitempty"`
 	TeammateName    string `json:"teammate_name,omitempty"`
-	TeamName        string `json:"team_name,omitempty"`
+	// Deprecated: sessions have a single implicit team; this carries the
+	// session-derived team name and will be removed upstream in a future
+	// release.
+	TeamName string `json:"team_name,omitempty"`
 }
 
 // HookType implements HookInput.
@@ -1972,7 +1980,10 @@ func (i TaskCreatedInput) Base() BaseHookInput { return i.BaseHookInput }
 type TeammateIdleInput struct {
 	BaseHookInput
 	TeammateName string `json:"teammate_name"`
-	TeamName     string `json:"team_name"`
+	// Deprecated: sessions have a single implicit team; this carries the
+	// session-derived team name and will be removed upstream in a future
+	// release.
+	TeamName string `json:"team_name"`
 }
 
 // HookType implements HookInput.


### PR DESCRIPTION
Closes the v0.3.185 catchup. Part of #125.

- README parity bumped v0.3.177 → v0.3.185 + a new catchup section summarizing the cycle and the #126–#134 roll-call, plus a note on the deferred `set_mcp_permission_mode_override`.
- Doc-only mirrors of upstream comment changes:
  - `AgentDefinition.DisallowedTools` — MCP server-level specs (`mcp__server`, `mcp__server__*`, `mcp__*`) remove all tools from the named server / all MCP tools.
  - `ModelRefusalFallbackMessage.APIRefusalCategory` / `APIRefusalExplanation` — client-lane vs server-lane semantics (field shapes unchanged).
  - `team_name` on the Task/Teammate hook inputs marked deprecated (single implicit team).

No behavior change; build/vet/test green.

See memory/catchup-v0.3.185/PLAN.md §"PR 09".