### PR TITLE
client: add SetMcpPermissionModeOverride control request

### DIFF
--- a/client.go
+++ b/client.go
@@ -783,6 +783,80 @@ func (s *Stream) SetModel(ctx context.Context, model string) error {
 	return err
 }
 
+// McpPermissionOverrideMode is a per-MCP-server permission-mode override. The
+// override is tighten-only: it applies only when the session mode would
+// already auto-allow (bypassPermissions/auto), so it can never widen
+// privilege.
+type McpPermissionOverrideMode string
+
+const (
+	// McpPermissionOverrideModeDefault forces per-action permission prompts
+	// for the server.
+	McpPermissionOverrideModeDefault McpPermissionOverrideMode = "default"
+	// McpPermissionOverrideModeAuto routes the server through the auto-mode
+	// classifier.
+	McpPermissionOverrideModeAuto McpPermissionOverrideMode = "auto"
+)
+
+// McpPermissionModeOverrideResult is the result of SetMcpPermissionModeOverride.
+type McpPermissionModeOverrideResult struct {
+	// Warning is set when serverName matched no currently known MCP server.
+	// The override is stored regardless and applies once a server with that
+	// exact name connects; the warning is informational (typo detection).
+	Warning string
+}
+
+// mcpPermissionModeOverrideRequest is the wire envelope for
+// set_mcp_permission_mode_override. It is sent instead of the shared
+// SDKControlRequestBody because mode must serialize as an explicit JSON null
+// (to clear the override), which the shared body's omitempty mode field cannot
+// express.
+type mcpPermissionModeOverrideRequest struct {
+	Type      string                               `json:"type"`
+	RequestID string                               `json:"request_id"`
+	Request   mcpPermissionModeOverrideRequestBody `json:"request"`
+}
+
+type mcpPermissionModeOverrideRequestBody struct {
+	Subtype    string                     `json:"subtype"`
+	ServerName string                     `json:"serverName"`
+	Mode       *McpPermissionOverrideMode `json:"mode"`
+}
+
+// MessageType implements Message so the envelope can be written to the transport.
+func (m mcpPermissionModeOverrideRequest) MessageType() string { return "control_request" }
+
+// SetMcpPermissionModeOverride pins (or, with a nil mode, clears) a
+// per-MCP-server permission-mode override. Only McpPermissionOverrideModeDefault,
+// McpPermissionOverrideModeAuto, or nil (clear) are accepted; the override is
+// tighten-only and can never widen privilege. Only available in streaming
+// input mode. It blocks until the CLI acknowledges the request or returns an
+// error.
+func (s *Stream) SetMcpPermissionModeOverride(
+	ctx context.Context, serverName string, mode *McpPermissionOverrideMode,
+) (McpPermissionModeOverrideResult, error) {
+	requestID := s.client.protocol.nextRequestID()
+	req := mcpPermissionModeOverrideRequest{
+		Type:      "control_request",
+		RequestID: requestID,
+		Request: mcpPermissionModeOverrideRequestBody{
+			Subtype:    "set_mcp_permission_mode_override",
+			ServerName: serverName,
+			Mode:       mode,
+		},
+	}
+	resp, err := s.dispatchControlRequest(ctx, requestID, req.Request.Subtype, req)
+	if err != nil {
+		return McpPermissionModeOverrideResult{}, err
+	}
+
+	var result McpPermissionModeOverrideResult
+	if w, ok := resp.Response.Response["warning"].(string); ok {
+		result.Warning = w
+	}
+	return result, nil
+}
+
 // setMaxThinkingTokensOptions accumulates optional set_max_thinking_tokens
 // parameters.
 type setMaxThinkingTokensOptions struct {
@@ -1122,21 +1196,31 @@ func (s *Stream) BackgroundTasks(
 func (s *Stream) sendSDKControlRequest(
 	ctx context.Context, body SDKControlRequestBody,
 ) (*SDKControlResponse, error) {
-	p := s.client.protocol
-	requestID := p.nextRequestID()
+	requestID := s.client.protocol.nextRequestID()
 	req := SDKControlRequest{
 		Type:      "control_request",
 		RequestID: requestID,
 		Request:   body,
 	}
+	return s.dispatchControlRequest(ctx, requestID, body.Subtype, req)
+}
+
+// dispatchControlRequest writes a pre-built control-request envelope and waits
+// for its correlated response. envelope is marshaled as-is, so callers whose
+// payload does not fit SDKControlRequestBody (e.g. a field that must serialize
+// as an explicit JSON null) can supply their own request struct.
+func (s *Stream) dispatchControlRequest(
+	ctx context.Context, requestID, subtype string, envelope Message,
+) (*SDKControlResponse, error) {
+	p := s.client.protocol
 
 	// Register before writing so a fast CLI response cannot race the waiter.
 	ch := make(chan SDKControlResponse, 1)
 	p.pendingReqs.Store(requestID, ch)
 
-	if err := s.client.transport.Write(ctx, req); err != nil {
+	if err := s.client.transport.Write(ctx, envelope); err != nil {
 		p.pendingReqs.Delete(requestID)
-		return nil, fmt.Errorf("control request %q: write: %w", body.Subtype, err)
+		return nil, fmt.Errorf("control request %q: write: %w", subtype, err)
 	}
 
 	select {
@@ -1145,7 +1229,7 @@ func (s *Stream) sendSDKControlRequest(
 		return nil, ctx.Err()
 	case resp := <-ch:
 		if resp.Response.Subtype == "error" {
-			return nil, fmt.Errorf("control request %q: %s", body.Subtype, resp.Response.Error)
+			return nil, fmt.Errorf("control request %q: %s", subtype, resp.Response.Error)
 		}
 		return &resp, nil
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -2221,3 +2221,43 @@ func TestIntegrationGetUsageExperimental(t *testing.T) {
 	skipIfNoCLI(t)
 	t.Skip("get_usage is EXPERIMENTAL upstream (unstable wire shape) and its response is account-dependent — rate_limits/behaviors are null for non-claude.ai-subscriber sessions and the installed CLI may not support the subtype; a live assertion would be brittle. Mirrors GetContextUsage, which ships without an integration test. Tracked in INTEGRATION-FOLLOWUPS.md")
 }
+
+// TestIntegrationSetMcpPermissionModeOverride exercises the
+// set_mcp_permission_mode_override control request against the live CLI. The
+// override targets an unknown server name, which a supporting CLI answers with
+// a typo-detection warning (the override is stored regardless). CLIs predating
+// the control request reject the subtype; the test skips in that case so the
+// slot activates once the CLI catches up.
+func TestIntegrationSetMcpPermissionModeOverride(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithMaxTurns(1),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	stream, err := client.Stream(ctx)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	mode := McpPermissionOverrideModeDefault
+	result, err := stream.SetMcpPermissionModeOverride(ctx, "no-such-server", &mode)
+	if err != nil {
+		t.Skipf("CLI does not support set_mcp_permission_mode_override: %v", err)
+	}
+
+	// Unknown server name => informational typo-detection warning.
+	assert.NotEmpty(t, result.Warning,
+		"expected a warning for an unknown server name")
+
+	// Clearing the override (nil mode => explicit wire null) must round-trip.
+	_, err = stream.SetMcpPermissionModeOverride(ctx, "no-such-server", nil)
+	require.NoError(t, err)
+}

--- a/stream_control_test.go
+++ b/stream_control_test.go
@@ -163,6 +163,14 @@ func callWithTimeout(t *testing.T, fn func(context.Context) error) error {
 	return fn(ctx)
 }
 
+func withResult[T any](t *testing.T, fn func(context.Context) (T, error)) (T, error) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	return fn(ctx)
+}
+
 func TestStreamInterruptSendsControlRequest(t *testing.T) {
 	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
 
@@ -204,6 +212,61 @@ func TestStreamSetModelSendsModelField(t *testing.T) {
 	body := genericRequestBody(t, generic)
 	assert.Equal(t, "set_model", body["subtype"])
 	assert.Equal(t, "claude-sonnet-4-5-20250929", body["model"])
+}
+
+func TestStreamSetMcpPermissionModeOverrideRoundTrip(t *testing.T) {
+	defaultMode := McpPermissionOverrideModeDefault
+	autoMode := McpPermissionOverrideModeAuto
+
+	tests := []struct {
+		name     string
+		mode     *McpPermissionOverrideMode
+		wantMode interface{} // string for a value, nil for explicit JSON null
+	}{
+		{name: "default", mode: &defaultMode, wantMode: "default"},
+		{name: "auto", mode: &autoMode, wantMode: "auto"},
+		{name: "clear sends null", mode: nil, wantMode: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+			_, err := withResult(t, func(ctx context.Context) (McpPermissionModeOverrideResult, error) {
+				return stream.SetMcpPermissionModeOverride(ctx, "my-server", tt.mode)
+			})
+			require.NoError(t, err)
+
+			_, generic := decodeWrittenSDKControlRequest(t, transport)
+			body := genericRequestBody(t, generic)
+			assert.Equal(t, "set_mcp_permission_mode_override", body["subtype"])
+			assert.Equal(t, "my-server", body["serverName"])
+			// mode key is always present (tristate): a string, or explicit null.
+			require.Contains(t, body, "mode")
+			assert.Equal(t, tt.wantMode, body["mode"])
+		})
+	}
+}
+
+func TestStreamSetMcpPermissionModeOverrideParsesWarning(t *testing.T) {
+	warnResponse := func(req SDKControlRequest) SDKControlResponse {
+		return SDKControlResponse{
+			Type: "control_response",
+			Response: SDKControlResponseBody{
+				Subtype:   "success",
+				RequestID: req.RequestID,
+				Response:  map[string]interface{}{"warning": "unknown server"},
+			},
+		}
+	}
+	stream, _, _ := newStreamControlTest(warnResponse)
+
+	mode := McpPermissionOverrideModeDefault
+	result, err := withResult(t, func(ctx context.Context) (McpPermissionModeOverrideResult, error) {
+		return stream.SetMcpPermissionModeOverride(ctx, "typo-server", &mode)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "unknown server", result.Warning)
 }
 
 func TestStreamSetMaxThinkingTokensRoundTrip(t *testing.T) {


### PR DESCRIPTION
Ungates the `set_mcp_permission_mode_override` control request, which was deferred in the v0.3.185 cycle (referenced in the `SDKControlRequestInner` union but with no wire shape). TS SDK v0.3.195 exposes it as `Query.setMcpPermissionModeOverride(serverName, mode)` (sdk.d.ts L2211-2228; wire shape from sdk.mjs: `{subtype:"set_mcp_permission_mode_override", serverName, mode}`).

See `memory/catchup-v0.3.195/PLAN.md` §"PR 01".

- New `Stream.SetMcpPermissionModeOverride(ctx, serverName, mode *McpPermissionOverrideMode) (McpPermissionModeOverrideResult, error)`. `mode` is a tristate: `McpPermissionOverrideModeDefault` / `McpPermissionOverrideModeAuto` send the string; a nil pointer serializes as explicit wire `null` to clear the override. Tighten-only — can never widen privilege.
- The shared `SDKControlRequestBody.Mode` field is `omitempty` and cannot emit an explicit null, so this subtype uses a dedicated wire envelope. Factored the send/await core of `sendSDKControlRequest` into `dispatchControlRequest`, which both paths share.
- Result carries the optional `warning` (typo detection: set when `serverName` matches no known MCP server; the override is stored regardless).
- Unit tests: tristate `mode` round-trip (default/auto/null) + `warning` parse. Integration test exercises the live control request and skips cleanly on CLIs predating the subtype (the installed CLI 2.1.177 returns `Unsupported control request subtype`, confirming the wire string is correct).