### PR TITLE
options: add sandbox credentials protection config

### DIFF
--- a/options.go
+++ b/options.go
@@ -724,8 +724,40 @@ type SettingsSandbox struct {
 	// (e.g. Terminal) subject to per-app TCC automation consent. Honored only
 	// from user, managed/policy, or CLI (--settings) settings — project
 	// settings are ignored. Default false. Mirrors sdk.d.ts v0.3.185 L5718.
-	AllowAppleEvents *bool                  `json:"allowAppleEvents,omitempty"`
-	Extra            map[string]interface{} `json:"-"`
+	AllowAppleEvents *bool `json:"allowAppleEvents,omitempty"`
+	// Credentials protects credential files/directories and environment
+	// variables from sandboxed commands. Mirrors sdk.d.ts v0.3.195 L5822.
+	Credentials *SettingsSandboxCredentials `json:"credentials,omitempty"`
+	Extra       map[string]interface{}      `json:"-"`
+}
+
+// SettingsSandboxCredentials configures credential protection inside the
+// sandbox. Only the "deny" mode is supported on each entry.
+type SettingsSandboxCredentials struct {
+	// Files are credential files or directories to protect. "deny" blocks
+	// reads inside the sandbox.
+	Files []SettingsSandboxCredentialFile `json:"files,omitempty"`
+	// EnvVars are environment variables to protect. "deny" unsets the
+	// variable for sandboxed commands.
+	EnvVars []SettingsSandboxCredentialEnvVar `json:"envVars,omitempty"`
+}
+
+// SettingsSandboxCredentialFile protects a single credential file or directory.
+type SettingsSandboxCredentialFile struct {
+	// Path is the credential file or directory. Same resolution as
+	// sandbox.filesystem.* paths: absolute, ~ expanded, or relative to the
+	// settings file root.
+	Path string `json:"path"`
+	// Mode is the access mode for this path. Only "deny" is supported.
+	Mode string `json:"mode"`
+}
+
+// SettingsSandboxCredentialEnvVar protects a single environment variable.
+type SettingsSandboxCredentialEnvVar struct {
+	// Name is the environment variable name.
+	Name string `json:"name"`
+	// Mode is the access mode for this variable. Only "deny" is supported.
+	Mode string `json:"mode"`
 }
 
 func (s SettingsSandbox) MarshalJSON() ([]byte, error) {

--- a/options_test.go
+++ b/options_test.go
@@ -675,6 +675,54 @@ func TestSettingsSandboxFieldsJSON(t *testing.T) {
 		assert.Equal(t, "/etc/claude/ca.key", out.Sandbox.Network.TLSTerminate.CAKeyPath)
 	})
 
+	t.Run("credentials round-trip files and envVars", func(t *testing.T) {
+		in := Settings{
+			Sandbox: &SettingsSandbox{
+				Credentials: &SettingsSandboxCredentials{
+					Files: []SettingsSandboxCredentialFile{
+						{Path: "~/.aws/credentials", Mode: "deny"},
+					},
+					EnvVars: []SettingsSandboxCredentialEnvVar{
+						{Name: "AWS_SECRET_ACCESS_KEY", Mode: "deny"},
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		sb := got["sandbox"].(map[string]interface{})
+		creds, ok := sb["credentials"].(map[string]interface{})
+		require.True(t, ok)
+		files := creds["files"].([]interface{})
+		require.Len(t, files, 1)
+		assert.Equal(t, "~/.aws/credentials", files[0].(map[string]interface{})["path"])
+		assert.Equal(t, "deny", files[0].(map[string]interface{})["mode"])
+		envVars := creds["envVars"].([]interface{})
+		require.Len(t, envVars, 1)
+		assert.Equal(t, "AWS_SECRET_ACCESS_KEY", envVars[0].(map[string]interface{})["name"])
+		assert.Equal(t, "deny", envVars[0].(map[string]interface{})["mode"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.NotNil(t, out.Sandbox.Credentials)
+		require.Len(t, out.Sandbox.Credentials.Files, 1)
+		assert.Equal(t, "~/.aws/credentials", out.Sandbox.Credentials.Files[0].Path)
+		require.Len(t, out.Sandbox.Credentials.EnvVars, 1)
+		assert.Equal(t, "AWS_SECRET_ACCESS_KEY", out.Sandbox.Credentials.EnvVars[0].Name)
+	})
+
+	t.Run("nil credentials omits key", func(t *testing.T) {
+		data, err := json.Marshal(Settings{Sandbox: &SettingsSandbox{}})
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		sb := got["sandbox"].(map[string]interface{})
+		assert.NotContains(t, sb, "credentials")
+	})
+
 	t.Run("tlsTerminate empty struct emits empty object", func(t *testing.T) {
 		in := Settings{
 			Sandbox: &SettingsSandbox{


### PR DESCRIPTION
Mirrors the `sandbox.credentials` config added in TS SDK v0.3.195 (sdk.d.ts L5822-5848; `SandboxCredentialsConfig`).

See `memory/catchup-v0.3.195/PLAN.md` §"PR 05".

- `SettingsSandbox.Credentials *SettingsSandboxCredentials` (json `credentials,omitempty`).
- `Files []SettingsSandboxCredentialFile` (`path` + `mode`) — `deny` blocks reads of the file/dir inside the sandbox.
- `EnvVars []SettingsSandboxCredentialEnvVar` (`name` + `mode`) — `deny` unsets the variable for sandboxed commands.
- `mode` is the literal `"deny"` (only supported value) — kept as a plain string field, consistent with how other single-value `mode` literals are modeled here.
- Unit tests: files/envVars round-trip + nil omits the key.