### PR TITLE
protocol: add Reinitialize to re-send initialize

### DIFF
--- a/client.go
+++ b/client.go
@@ -1244,6 +1244,24 @@ func (s *Stream) InitializationResult() (*SDKControlInitializeResponse, error) {
 	return cloneInitializeResponse(initResp), nil
 }
 
+// Reinitialize re-sends the initialize control request to the running CLI and
+// returns the fresh response. Unlike InitializationResult, which returns the
+// cached first-connect result, this always issues a new request. Use it after
+// a transport gap so the CLI redelivers any can_use_tool / request_user_dialog
+// control requests the loop is still blocked on; the SDK dedupes in-flight
+// request_ids, but callbacks should be idempotent per request_id since a
+// request whose response was lost in the gap is dispatched again.
+func (s *Stream) Reinitialize(ctx context.Context) (*SDKControlInitializeResponse, error) {
+	initResp, err := s.client.protocol.Reinitialize(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if initResp == nil {
+		return nil, ErrNotInitialized
+	}
+	return cloneInitializeResponse(initResp), nil
+}
+
 // SupportedCommands returns the cached list of available slash commands.
 // The context is accepted for API compatibility and is not used.
 func (s *Stream) SupportedCommands(ctx context.Context) ([]SlashCommand, error) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -2261,3 +2261,33 @@ func TestIntegrationSetMcpPermissionModeOverride(t *testing.T) {
 	_, err = stream.SetMcpPermissionModeOverride(ctx, "no-such-server", nil)
 	require.NoError(t, err)
 }
+
+// TestIntegrationReinitialize exercises Stream.Reinitialize against the live
+// CLI. Reinitialize re-sends the initialize control request to an
+// already-initialized session and must return a fresh response. CLIs that
+// reject a second initialize cause a clean skip.
+func TestIntegrationReinitialize(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithMaxTurns(1),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	stream, err := client.Stream(ctx)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	resp, err := stream.Reinitialize(ctx)
+	if err != nil {
+		t.Skipf("CLI does not support reinitialize: %v", err)
+	}
+	require.NotNil(t, resp, "expected a fresh initialize response")
+}

--- a/protocol.go
+++ b/protocol.go
@@ -51,7 +51,23 @@ func (p *Protocol) Initialize(ctx context.Context) error {
 	if p.initialized.Load() {
 		return nil // Already initialized
 	}
+	return p.doInitialize(ctx)
+}
 
+// Reinitialize re-sends the initialize control request to an already-running
+// CLI, bypassing the initialized guard. Unlike Initialize, it always issues a
+// fresh request rather than short-circuiting, and refreshes the cached
+// initialize response. Use it after a transport gap (e.g. reattaching to a
+// daemon whose ring buffer evicted frames) so the CLI redelivers any
+// control requests the loop is still blocked on.
+func (p *Protocol) Reinitialize(ctx context.Context) (*SDKControlInitializeResponse, error) {
+	if err := p.doInitialize(ctx); err != nil {
+		return nil, err
+	}
+	return p.initResult(), nil
+}
+
+func (p *Protocol) doInitialize(ctx context.Context) error {
 	// SupportedDialogKinds is meaningless without a dialog handler, and the
 	// CLI would never route a dialog to a consumer that can't render it.
 	// Mirror the TS SDK and reject the contradictory option pairing here.

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -103,6 +103,83 @@ func TestProtocolInitialize(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestProtocolReinitializeBypassesGuard(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+	protocol := NewProtocol(transport, opts)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, transport.Connect(ctx))
+	defer transport.Close()
+
+	readerReady := make(chan struct{})
+	go func() {
+		close(readerReady)
+		for msg, err := range transport.ReadMessages(ctx) {
+			if err != nil {
+				continue
+			}
+			if ctrlResp, ok := msg.(SDKControlResponse); ok {
+				protocol.handleSDKControlResponse(ctrlResp)
+			}
+		}
+	}()
+	<-readerReady
+
+	// Answer every initialize request the CLI receives with a distinguishable
+	// output_style so we can prove a fresh request was actually sent.
+	go func() {
+		decoder := json.NewDecoder(runner.StdinPipe)
+		for {
+			var req SDKControlRequest
+			if err := decoder.Decode(&req); err != nil {
+				return
+			}
+			resp := SDKControlResponse{
+				Type: "control_response",
+				Response: SDKControlResponseBody{
+					Subtype:   "success",
+					RequestID: req.RequestID,
+					Response:  map[string]interface{}{"output_style": "fresh"},
+				},
+			}
+			data, _ := json.Marshal(resp)
+			data = append(data, '\n')
+			runner.StdoutPipe.Write(data)
+		}
+	}()
+
+	// Simulate an already-initialized session: Initialize would no-op, but
+	// Reinitialize must still issue a fresh request and refresh the cache.
+	protocol.initialized.Store(true)
+
+	type result struct {
+		resp *SDKControlInitializeResponse
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		resp, err := protocol.Reinitialize(ctx)
+		done <- result{resp, err}
+	}()
+
+	select {
+	case r := <-done:
+		require.NoError(t, r.err)
+		require.NotNil(t, r.resp)
+		assert.Equal(t, "fresh", r.resp.OutputStyle)
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for Reinitialize to complete")
+	}
+
+	assert.Equal(t, "fresh", protocol.initResult().OutputStyle,
+		"Reinitialize should refresh the cached initialize response")
+}
+
 func TestProtocolInitializeSupportedDialogKindsRequiresCallback(t *testing.T) {
 	runner := NewMockSubprocessRunner()
 	opts := NewOptions()


### PR DESCRIPTION
Mirrors `Query.reinitialize()` added in TS SDK v0.3.195 (sdk.d.ts L2289-2306). In the TS SDK, `reinitialize()` is `() => this.initialize()` — it forces a fresh `initialize` control request instead of returning the cached first-connect result.

See `memory/catchup-v0.3.195/PLAN.md` §"PR 02".

- `Stream.Reinitialize(ctx) (*SDKControlInitializeResponse, error)` re-sends the `initialize` control request to the running CLI and returns the fresh response, refreshing the cached one.
- `Protocol.Initialize` keeps its idempotent guard; the request-building body is factored into `doInitialize`, which both `Initialize` and the new `Protocol.Reinitialize` (guard-bypassing) call.
- Use after a transport gap so the CLI redelivers any `can_use_tool` / `request_user_dialog` requests the loop is still blocked on; callbacks should be idempotent per request_id (documented on the method).
- Unit test: pre-marks the session initialized, then asserts Reinitialize still issues a fresh request and refreshes the cache (distinguishable `output_style`). Integration test passes live against the installed CLI (re-sends initialize and gets a fresh response).