### PR TITLE
messages: add ModelRefusalNoFallbackMessage

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2261,3 +2261,9 @@ func TestIntegrationSetMcpPermissionModeOverride(t *testing.T) {
 	_, err = stream.SetMcpPermissionModeOverride(ctx, "no-such-server", nil)
 	require.NoError(t, err)
 }
+
+func TestIntegrationModelRefusalNoFallback(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+	t.Skip("not triggerable from CLI: model_refusal_no_fallback requires the model to end a turn with stop_reason \"refusal\" while no fallback model is configured - a server-side refusal condition that cannot be deterministically reproduced in an integration run; tracked in INTEGRATION-FOLLOWUPS.md")
+}

--- a/messages.go
+++ b/messages.go
@@ -952,6 +952,41 @@ type ModelRefusalFallbackMessage struct {
 // MessageType implements Message.
 func (m ModelRefusalFallbackMessage) MessageType() string { return "system" }
 
+// ModelRefusalNoFallbackMessage is emitted when the model ends the stream with
+// stop_reason "refusal" and no fallback model is configured, so the turn ends
+// as an error. It is the structured counterpart to detecting stop_reason
+// "refusal" on the assistant error frame. Not emitted when a fallback existed
+// but was declined or gate-failed — ModelRefusalFallbackMessage covers the
+// retry case. Absent from older CLIs.
+type ModelRefusalNoFallbackMessage struct {
+	Type          string  `json:"type"`           // Always "system"
+	Subtype       string  `json:"subtype"`        // "model_refusal_no_fallback"
+	OriginalModel string  `json:"original_model"` // Model that refused
+	RequestID     *string `json:"request_id"`     // Upstream request id; nil for JSON null
+
+	// APIRefusalCategory is the refusal category ("cyber", "bio", …). Open
+	// string — new categories ship on the wire ahead of schema updates. nil
+	// when none was carried or when emitted by an older CLI.
+	APIRefusalCategory *string `json:"api_refusal_category,omitempty"`
+
+	// APIRefusalExplanation is the refusal explanation. Unstable human prose —
+	// display only, never parse. nil when none was carried or on older CLIs.
+	APIRefusalExplanation *string `json:"api_refusal_explanation,omitempty"`
+
+	// RefusedUserMessageUUID is the UUID of the user message the refused
+	// request was for — the rewind target and composer prefill for
+	// edit-and-retry. nil when the refused turn was not human-authored or
+	// cannot be identified; absent from older CLIs.
+	RefusedUserMessageUUID *string `json:"refused_user_message_uuid,omitempty"`
+
+	Content   string `json:"content"`    // Human-readable refusal notice
+	UUID      string `json:"uuid"`       // Unique message ID
+	SessionID string `json:"session_id"` // Session identifier
+}
+
+// MessageType implements Message.
+func (m ModelRefusalNoFallbackMessage) MessageType() string { return "system" }
+
 // ElicitationCompleteMessage reports completion of a URL-mode MCP elicitation.
 type ElicitationCompleteMessage struct {
 	Type          string `json:"type"`            // Always "system"
@@ -1435,6 +1470,10 @@ func ParseMessage(data []byte) (Message, error) {
 			return msg, err
 		case "model_refusal_fallback":
 			var msg ModelRefusalFallbackMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "model_refusal_no_fallback":
+			var msg ModelRefusalNoFallbackMessage
 			err := json.Unmarshal(data, &msg)
 			return msg, err
 		case "mirror_error":

--- a/messages_test.go
+++ b/messages_test.go
@@ -2703,6 +2703,63 @@ func TestParseMessageModelRefusalFallback(t *testing.T) {
 	})
 }
 
+func TestParseMessageModelRefusalNoFallback(t *testing.T) {
+	t.Run("full payload", func(t *testing.T) {
+		input := `{
+			"type": "system",
+			"subtype": "model_refusal_no_fallback",
+			"original_model": "claude-opus-4-8",
+			"request_id": "req_01NOFB",
+			"api_refusal_category": "cyber",
+			"api_refusal_explanation": "declined for safety",
+			"refused_user_message_uuid": "550e8400-e29b-41d4-a716-446655440500",
+			"content": "The model declined and no fallback was configured.",
+			"uuid": "550e8400-e29b-41d4-a716-446655440501",
+			"session_id": "sess_nofb_001"
+		}`
+
+		msg, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+
+		nf, ok := msg.(ModelRefusalNoFallbackMessage)
+		require.True(t, ok, "expected ModelRefusalNoFallbackMessage")
+		assert.Equal(t, "system", nf.MessageType())
+		assert.Equal(t, "model_refusal_no_fallback", nf.Subtype)
+		assert.Equal(t, "claude-opus-4-8", nf.OriginalModel)
+		require.NotNil(t, nf.RequestID)
+		assert.Equal(t, "req_01NOFB", *nf.RequestID)
+		require.NotNil(t, nf.APIRefusalCategory)
+		assert.Equal(t, "cyber", *nf.APIRefusalCategory)
+		require.NotNil(t, nf.APIRefusalExplanation)
+		assert.Equal(t, "declined for safety", *nf.APIRefusalExplanation)
+		require.NotNil(t, nf.RefusedUserMessageUUID)
+		assert.Equal(t, "550e8400-e29b-41d4-a716-446655440500", *nf.RefusedUserMessageUUID)
+		assert.Equal(t, "sess_nofb_001", nf.SessionID)
+	})
+
+	t.Run("older CLI: null request_id, optional fields absent", func(t *testing.T) {
+		input := `{
+			"type": "system",
+			"subtype": "model_refusal_no_fallback",
+			"original_model": "claude-opus-4-8",
+			"request_id": null,
+			"content": "The model declined and no fallback was configured.",
+			"uuid": "550e8400-e29b-41d4-a716-446655440502",
+			"session_id": "sess_nofb_002"
+		}`
+
+		msg, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+
+		nf, ok := msg.(ModelRefusalNoFallbackMessage)
+		require.True(t, ok, "expected ModelRefusalNoFallbackMessage")
+		assert.Nil(t, nf.RequestID)
+		assert.Nil(t, nf.APIRefusalCategory)
+		assert.Nil(t, nf.APIRefusalExplanation)
+		assert.Nil(t, nf.RefusedUserMessageUUID)
+	})
+}
+
 func TestParseMessageAssistantSupersedes(t *testing.T) {
 	input := `{
 		"type": "assistant",


### PR DESCRIPTION
Adds the `model_refusal_no_fallback` system message subtype from TS SDK v0.3.195 (sdk.d.ts L3793-3805; added to the `SDKMessage` union + `coreTypes` namespace export).

See `memory/catchup-v0.3.195/PLAN.md` §"PR 03".

- New `ModelRefusalNoFallbackMessage` (`type:system`, `subtype:model_refusal_no_fallback`) + `MessageType()` + parser dispatch case, mirroring the existing `ModelRefusalFallbackMessage` pattern.
- Emitted when the model ends the stream with stop_reason `"refusal"` and no fallback model is configured, so the turn ends as an error (the structured counterpart to detecting `stop_reason:"refusal"` on the assistant error frame). Not emitted when a fallback existed but was declined — that stays `model_refusal_fallback`.
- Fields: `original_model`, `request_id` (nullable), optional `api_refusal_category` / `api_refusal_explanation` / `refused_user_message_uuid`, plus `content`/`uuid`/`session_id`.
- Unit tests: full payload + older-CLI (null request_id, optionals absent). Integration: skip-stub (server-side refusal condition, not deterministically CLI-triggerable; the installed CLI 2.1.177 does not emit the subtype).