### PR TITLE
messages: add RefusedUserMessageUUID to refusal fallback

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -944,6 +944,13 @@ type ModelRefusalFallbackMessage struct {
 	// Absent when emitted by an older CLI.
 	RetractedMessageUUIDs []string `json:"retracted_message_uuids,omitempty"`
 
+	// RefusedUserMessageUUID is the UUID of the user message the refused
+	// request was for — the rewind target and composer prefill for
+	// edit-and-retry. nil when the refused turn was not human-authored (e.g. a
+	// background task notification or auto-continuation) or cannot be
+	// identified; absent from older CLIs.
+	RefusedUserMessageUUID *string `json:"refused_user_message_uuid,omitempty"`
+
 	Content   string `json:"content"`    // Human-readable fallback notice
 	UUID      string `json:"uuid"`       // Unique message ID
 	SessionID string `json:"session_id"` // Session identifier

--- a/messages_test.go
+++ b/messages_test.go
@@ -2652,6 +2652,7 @@ func TestParseMessageModelRefusalFallback(t *testing.T) {
 			"api_refusal_category": "cyber",
 			"api_refusal_explanation": "declined for safety",
 			"retracted_message_uuids": ["550e8400-e29b-41d4-a716-446655440300"],
+			"refused_user_message_uuid": "550e8400-e29b-41d4-a716-446655440310",
 			"content": "Retried on a fallback model.",
 			"uuid": "550e8400-e29b-41d4-a716-446655440301",
 			"session_id": "sess_refusal_001"
@@ -2675,6 +2676,8 @@ func TestParseMessageModelRefusalFallback(t *testing.T) {
 		require.NotNil(t, fb.APIRefusalExplanation)
 		assert.Equal(t, "declined for safety", *fb.APIRefusalExplanation)
 		assert.Equal(t, []string{"550e8400-e29b-41d4-a716-446655440300"}, fb.RetractedMessageUUIDs)
+		require.NotNil(t, fb.RefusedUserMessageUUID)
+		assert.Equal(t, "550e8400-e29b-41d4-a716-446655440310", *fb.RefusedUserMessageUUID)
 	})
 
 	t.Run("older CLI: null request_id, optional fields absent", func(t *testing.T) {
@@ -2700,6 +2703,7 @@ func TestParseMessageModelRefusalFallback(t *testing.T) {
 		assert.Nil(t, fb.APIRefusalCategory)
 		assert.Nil(t, fb.APIRefusalExplanation)
 		assert.Nil(t, fb.RetractedMessageUUIDs)
+		assert.Nil(t, fb.RefusedUserMessageUUID)
 	})
 }
 


### PR DESCRIPTION
Adds the `refused_user_message_uuid` field to `ModelRefusalFallbackMessage`, new in TS SDK v0.3.195 (sdk.d.ts L3783).

See `memory/catchup-v0.3.195/PLAN.md` §"PR 04".

- `RefusedUserMessageUUID *string` (`refused_user_message_uuid,omitempty`) — UUID of the user message the refused request was for; the rewind target and composer prefill for edit-and-retry. nil when the refused turn was not human-authored (background task / auto-continuation) or cannot be identified; absent from older CLIs.
- Extends the existing `TestParseMessageModelRefusalFallback` cases: full-payload asserts the value, older-CLI asserts nil.
- No integration test (struct field; the sibling `model_refusal_no_fallback` slot already tracks the refusal path).