### PR TITLE
messages,query: usage and enum parity for v0.3.195

### DIFF
--- a/client_introspection_test.go
+++ b/client_introspection_test.go
@@ -380,6 +380,15 @@ func TestStreamGetUsageExperimentalParsesCanonicalPayload(t *testing.T) {
 				"utilization": 42.5, "resets_at": "2026-06-15T20:00:00Z",
 			},
 			"seven_day": nil,
+			"model_scoped": []interface{}{
+				map[string]interface{}{
+					"display_name": "Fable", "utilization": 60.0,
+					"resets_at": "2026-06-22T00:00:00Z",
+				},
+				map[string]interface{}{
+					"display_name": "Opus", "utilization": nil, "resets_at": nil,
+				},
+			},
 			"extra_usage": map[string]interface{}{
 				"is_enabled": true, "monthly_limit": 50.0,
 				"used_credits": 12.5, "utilization": 25.0, "currency": "USD",
@@ -440,6 +449,14 @@ func TestStreamGetUsageExperimentalParsesCanonicalPayload(t *testing.T) {
 	require.NotNil(t, got.RateLimits.FiveHour.Utilization)
 	assert.InDelta(t, 42.5, *got.RateLimits.FiveHour.Utilization, 1e-9)
 	assert.Nil(t, got.RateLimits.SevenDay) // present-but-null window
+	require.Len(t, got.RateLimits.ModelScoped, 2)
+	assert.Equal(t, "Fable", got.RateLimits.ModelScoped[0].DisplayName)
+	require.NotNil(t, got.RateLimits.ModelScoped[0].Utilization)
+	assert.InDelta(t, 60.0, *got.RateLimits.ModelScoped[0].Utilization, 1e-9)
+	require.NotNil(t, got.RateLimits.ModelScoped[0].ResetsAt)
+	assert.Equal(t, "Opus", got.RateLimits.ModelScoped[1].DisplayName)
+	assert.Nil(t, got.RateLimits.ModelScoped[1].Utilization) // present-but-null
+	assert.Nil(t, got.RateLimits.ModelScoped[1].ResetsAt)
 	require.NotNil(t, got.RateLimits.ExtraUsage)
 	assert.True(t, got.RateLimits.ExtraUsage.IsEnabled)
 	require.NotNil(t, got.RateLimits.ExtraUsage.Currency)

--- a/messages.go
+++ b/messages.go
@@ -508,7 +508,10 @@ const (
 	TerminalReasonHookStopped        TerminalReason = "hook_stopped"
 	TerminalReasonToolDeferred       TerminalReason = "tool_deferred"
 	TerminalReasonMaxTurns           TerminalReason = "max_turns"
-	TerminalReasonCompleted          TerminalReason = "completed"
+	// TerminalReasonBackgroundRequested marks a loop that yielded because the
+	// turn was moved to a background task. Added in sdk.d.ts v0.3.195 L6475.
+	TerminalReasonBackgroundRequested TerminalReason = "background_requested"
+	TerminalReasonCompleted           TerminalReason = "completed"
 )
 
 // FastModeState is the current state of Claude Code fast mode.
@@ -528,7 +531,10 @@ const (
 	RateLimitTypeSevenDay       RateLimitType = "seven_day"
 	RateLimitTypeSevenDayOpus   RateLimitType = "seven_day_opus"
 	RateLimitTypeSevenDaySonnet RateLimitType = "seven_day_sonnet"
-	RateLimitTypeOverage        RateLimitType = "overage"
+	// RateLimitTypeSevenDayOverageIncluded is the seven-day window for the
+	// overage-included model bucket. Added in sdk.d.ts v0.3.195 L3926.
+	RateLimitTypeSevenDayOverageIncluded RateLimitType = "seven_day_overage_included"
+	RateLimitTypeOverage                 RateLimitType = "overage"
 )
 
 // RateLimitOverageDisabledReason explains why overage is unavailable.

--- a/messages_test.go
+++ b/messages_test.go
@@ -3869,3 +3869,8 @@ func BenchmarkContentText(b *testing.B) {
 		_ = msg.ContentText()
 	}
 }
+
+func TestV0195EnumWireValues(t *testing.T) {
+	assert.Equal(t, "background_requested", string(TerminalReasonBackgroundRequested))
+	assert.Equal(t, "seven_day_overage_included", string(RateLimitTypeSevenDayOverageIncluded))
+}

--- a/query_types.go
+++ b/query_types.go
@@ -218,7 +218,22 @@ type UsageRateLimits struct {
 	SevenDayOAuthApps *UsageRateLimitWindow `json:"seven_day_oauth_apps,omitempty"`
 	SevenDayOpus      *UsageRateLimitWindow `json:"seven_day_opus,omitempty"`
 	SevenDaySonnet    *UsageRateLimitWindow `json:"seven_day_sonnet,omitempty"`
-	ExtraUsage        *UsageExtraUsage      `json:"extra_usage,omitempty"`
+	// ModelScoped holds per-model weekly windows from the server limits[]
+	// array, filtered by the overage-included-models allowlist. Additive —
+	// present only when the server emits them. Mirrors sdk.d.ts v0.3.195 L3088.
+	ModelScoped []UsageModelScopedWindow `json:"model_scoped,omitempty"`
+	ExtraUsage  *UsageExtraUsage         `json:"extra_usage,omitempty"`
+}
+
+// UsageModelScopedWindow is a per-model weekly rate-limit window.
+type UsageModelScopedWindow struct {
+	// DisplayName is the server-supplied label for the model bucket (e.g.
+	// "Fable").
+	DisplayName string `json:"display_name"`
+	// Utilization is the percentage of the window used, or nil.
+	Utilization *float64 `json:"utilization"`
+	// ResetsAt is the ISO 8601 timestamp when the window resets, or nil.
+	ResetsAt *string `json:"resets_at"`
 }
 
 // UsageRateLimitWindow is a single rate-limit window's utilization.


### PR DESCRIPTION
Additive enum/usage parity for TS SDK v0.3.195.

See `memory/catchup-v0.3.195/PLAN.md` §"PR 07".

- `RateLimitType` gains `seven_day_overage_included` (`RateLimitTypeSevenDayOverageIncluded`). (sdk.d.ts L3926)
- `TerminalReason` gains `background_requested` (`TerminalReasonBackgroundRequested`). (sdk.d.ts L6475)
- `UsageRateLimits.ModelScoped []UsageModelScopedWindow` (`model_scoped,omitempty`) — per-model weekly windows (`display_name` + nullable `utilization`/`resets_at`), sibling to `extra_usage` in the `get_usage` response. (sdk.d.ts L3088)
- Tests: extends the canonical `get_usage` payload test with a two-entry `model_scoped` array (one populated, one present-but-null); wire-value guard for the two new enum constants.