### PR TITLE
Add WithExistingAuth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ go get github.com/roasbeef/claude-agent-sdk-go
 Requirements:
 - Go 1.23+ (for `iter.Seq`)
 - Claude Code CLI: `npm install -g @anthropic-ai/claude-code`
-- `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN` in your environment
+- Either `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` in your environment,
+  or a completed Claude Code TUI login with `WithExistingAuth()`
 
 ## Quick Start
 
@@ -87,6 +88,19 @@ func main() {
     }
 }
 ```
+
+If Claude Code has already been authenticated through the TUI login flow, use
+`WithExistingAuth()` instead of passing API keys or OAuth tokens:
+
+```go
+client, err := claudeagent.NewClient(
+    claudeagent.WithExistingAuth(),
+    claudeagent.WithSystemPrompt("You are a helpful assistant."),
+)
+```
+
+The SDK will spawn the Claude Code subprocess without known Claude auth token
+environment variables, allowing the CLI to use its existing on-disk login.
 
 ## Streaming
 

--- a/options.go
+++ b/options.go
@@ -58,8 +58,15 @@ type Options struct {
 	// there is no opt-in flag for replace mode.
 	//
 	// ANTHROPIC_API_KEY should be set here or in the parent
-	// environment.
+	// environment unless ExistingAuth is enabled.
 	Env map[string]string
+
+	// ExistingAuth uses the Claude Code CLI's existing on-disk login state
+	// rather than forwarding SDK-provided auth secrets. When enabled, the
+	// subprocess is spawned without known Claude auth token environment
+	// variables so it can authenticate from the user's Claude Code config
+	// created by the TUI login flow.
+	ExistingAuth bool
 
 	// PermissionMode controls tool execution permissions.
 	// Default: PermissionModeDefault
@@ -1091,6 +1098,18 @@ func WithEnv(env map[string]string) Option {
 		for k, v := range env {
 			o.Env[k] = v
 		}
+	}
+}
+
+// WithExistingAuth uses the Claude Code CLI's existing login state.
+//
+// Use this when Claude Code has already been authenticated through the TUI
+// login flow. The SDK will not require callers to provide an API key or OAuth
+// token, and the subprocess environment will omit known Claude auth token
+// variables so the CLI falls back to its on-disk credentials.
+func WithExistingAuth() Option {
+	return func(o *Options) {
+		o.ExistingAuth = true
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWithExistingAuth(t *testing.T) {
+	opts := NewOptions()
+
+	WithExistingAuth()(opts)
+
+	assert.True(t, opts.ExistingAuth)
+}
+
 func TestSettingsHookArgsJSON(t *testing.T) {
 	t.Run("marshal includes args", func(t *testing.T) {
 		data, err := json.Marshal(SettingsHook{

--- a/transport.go
+++ b/transport.go
@@ -161,7 +161,7 @@ func (t *SubprocessTransport) SetStderrLogger(w io.Writer) {
 // - --resume-session-at: Resume from a specific message UUID (if SessionOptions.ResumeSessionAt is set)
 //
 // Environment variables are set for:
-// - ANTHROPIC_API_KEY: API authentication
+// - ANTHROPIC_API_KEY: API authentication, unless WithExistingAuth is used
 // - CLAUDE_CODE_ENTRYPOINT: "sdk-go"
 // - CLAUDE_AGENT_SDK_VERSION: SDK version
 func (t *SubprocessTransport) Connect(ctx context.Context) error {
@@ -398,7 +398,13 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 
 	// Build environment - start with current process env, then overlay options.
 	env := os.Environ()
+	if t.options.ExistingAuth {
+		env = withoutClaudeAuthEnv(env)
+	}
 	for k, v := range t.options.Env {
+		if t.options.ExistingAuth && isClaudeAuthEnvKey(k) {
+			continue
+		}
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 	// Add SDK markers.
@@ -447,6 +453,27 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+func withoutClaudeAuthEnv(env []string) []string {
+	filtered := env[:0]
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && isClaudeAuthEnvKey(key) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func isClaudeAuthEnvKey(key string) bool {
+	switch key {
+	case "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN":
+		return true
+	default:
+		return false
+	}
 }
 
 // Write sends a JSON message to the CLI stdin.

--- a/transport_test.go
+++ b/transport_test.go
@@ -73,6 +73,16 @@ func argIndex(args []string, flag string) int {
 	return -1
 }
 
+func envValue(env []string, key string) (string, bool) {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix), true
+		}
+	}
+	return "", false
+}
+
 type mockTransport struct {
 	mu       sync.Mutex
 	written  []Message
@@ -985,6 +995,64 @@ func TestSubprocessTransportExtraArgs(t *testing.T) {
 			assert.Equal(t, tt.wantTail, runner.StartArgs[len(runner.StartArgs)-len(tt.wantTail):])
 		})
 	}
+}
+
+func TestSubprocessTransportExistingAuthOmitsClaudeAuthEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "parent-api-key")
+	t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "parent-oauth-token")
+	t.Setenv("CLAUDE_CONFIG_DIR", "/tmp/existing-claude-config")
+
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	WithExistingAuth()(opts)
+	WithEnv(map[string]string{
+		"ANTHROPIC_API_KEY":       "option-api-key",
+		"CLAUDE_CODE_OAUTH_TOKEN": "option-oauth-token",
+		"OTHER_SETTING":           "kept",
+	})(opts)
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	err := transport.Connect(context.Background())
+	require.NoError(t, err)
+	defer transport.Close()
+
+	_, ok := envValue(runner.StartEnv, "ANTHROPIC_API_KEY")
+	assert.False(t, ok)
+	_, ok = envValue(runner.StartEnv, "CLAUDE_CODE_OAUTH_TOKEN")
+	assert.False(t, ok)
+
+	gotConfigDir, ok := envValue(runner.StartEnv, "CLAUDE_CONFIG_DIR")
+	require.True(t, ok)
+	assert.Equal(t, "/tmp/existing-claude-config", gotConfigDir)
+
+	gotOther, ok := envValue(runner.StartEnv, "OTHER_SETTING")
+	require.True(t, ok)
+	assert.Equal(t, "kept", gotOther)
+}
+
+func TestSubprocessTransportDefaultAuthEnvBehavior(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "parent-api-key")
+
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	WithEnv(map[string]string{
+		"CLAUDE_CODE_OAUTH_TOKEN": "option-oauth-token",
+	})(opts)
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	err := transport.Connect(context.Background())
+	require.NoError(t, err)
+	defer transport.Close()
+
+	gotAPIKey, ok := envValue(runner.StartEnv, "ANTHROPIC_API_KEY")
+	require.True(t, ok)
+	assert.Equal(t, "parent-api-key", gotAPIKey)
+
+	gotOAuth, ok := envValue(runner.StartEnv, "CLAUDE_CODE_OAUTH_TOKEN")
+	require.True(t, ok)
+	assert.Equal(t, "option-oauth-token", gotOAuth)
 }
 
 func TestSubprocessTransportSettingsPath(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `WithExistingAuth()` to let SDK callers explicitly use Claude Code's existing TUI login state
- scrub known Claude auth token env vars from the subprocess environment when existing auth is enabled
- document the new auth path in the README

## Verification
- `go test ./...`
- external throwaway proof module under `/tmp/existing-auth-proof`, importing this checkout via `replace`, run with both token env vars removed:
  - `env -u ANTHROPIC_API_KEY -u CLAUDE_CODE_OAUTH_TOKEN go run .`

The external proof used `WithExistingAuth()`, `WithCwd()`, and bypass permissions to ask Claude Code to read `input.txt` and create `output.txt`; the Go harness then verified the file contents.

Live proof output:

```text
workdir=/tmp/existing-auth-tool-proof-3204693270
result=success
assistant=I'll read input.txt first, then create output.txt with the specified content.existing auth tool proof: ALPHA BETA 42
output.txt=existing auth tool proof: ALPHA BETA 42
```
