### PR TITLE
messages: add observer message-origin kinds (#145)

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -212,6 +212,13 @@ const (
 	MessageOriginKindTaskNotification MessageOriginKind = "task-notification"
 	MessageOriginKindCoordinator      MessageOriginKind = "coordinator"
 	MessageOriginKindAutoContinuation MessageOriginKind = "auto-continuation"
+	// MessageOriginKindObserver marks a message injected by a background
+	// observer agent (AgentDefinition.observer). It carries From (the
+	// observer agent type) and SenderTaskID (the observer's task id).
+	MessageOriginKindObserver MessageOriginKind = "observer"
+	// MessageOriginKindObserverActivity marks an activity digest routed to
+	// the observer. It carries no additional fields.
+	MessageOriginKindObserverActivity MessageOriginKind = "observer-activity"
 )
 
 // MessageOrigin describes the originating actor for a message.
@@ -220,6 +227,9 @@ type MessageOrigin struct {
 	Server string            `json:"server,omitempty"`
 	From   string            `json:"from,omitempty"`
 	Name   string            `json:"name,omitempty"`
+	// SenderTaskID is the observer's task id; set only for the
+	// "observer" kind (sdk.d.ts v0.3.201).
+	SenderTaskID string `json:"senderTaskId,omitempty"`
 }
 
 // StreamEvent represents a progressive delta update during streaming.

--- a/messages_test.go
+++ b/messages_test.go
@@ -1381,6 +1381,60 @@ func TestMessageOriginAutoContinuationRoundTrip(t *testing.T) {
 	assert.Empty(t, decoded.Origin.Name)
 }
 
+func TestMessageOriginObserverRoundTrip(t *testing.T) {
+	msg := ResultMessage{
+		Type:    "result",
+		Subtype: "success",
+		Origin: &MessageOrigin{
+			Kind:         MessageOriginKindObserver,
+			From:         "security-reviewer",
+			SenderTaskID: "task-abc123",
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	origin, ok := raw["origin"].(map[string]interface{})
+	require.True(t, ok, "origin must marshal to an object")
+	assert.Equal(t, "observer", origin["kind"])
+	assert.Equal(t, "security-reviewer", origin["from"])
+	assert.Equal(t, "task-abc123", origin["senderTaskId"])
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Origin)
+	assert.Equal(t, MessageOriginKindObserver, decoded.Origin.Kind)
+	assert.Equal(t, "security-reviewer", decoded.Origin.From)
+	assert.Equal(t, "task-abc123", decoded.Origin.SenderTaskID)
+}
+
+func TestMessageOriginObserverActivityRoundTrip(t *testing.T) {
+	msg := ResultMessage{
+		Type:    "result",
+		Subtype: "success",
+		Origin:  &MessageOrigin{Kind: MessageOriginKindObserverActivity},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	origin, ok := raw["origin"].(map[string]interface{})
+	require.True(t, ok, "origin must marshal to an object")
+	assert.Equal(t, "observer-activity", origin["kind"])
+	assert.NotContains(t, origin, "senderTaskId")
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Origin)
+	assert.Equal(t, MessageOriginKindObserverActivity, decoded.Origin.Kind)
+	assert.Empty(t, decoded.Origin.SenderTaskID)
+}
+
 func TestResultMessageFieldAdditionsBackwardCompat(t *testing.T) {
 	input := []byte(`{
 		"type": "result",


### PR DESCRIPTION
Part of #145 (parity with TS Agent SDK v0.3.201). See `memory/catchup-v0.3.201/PLAN.md` §"PR 02".

TS SDK v0.3.201 extends the `MessageOrigin` provenance union with two kinds (sdk.d.ts L3793–3801):

- `observer` — a message injected by a background observer agent (`AgentDefinition.observer`); carries `from` (observer agent type) and `senderTaskId` (observer task id).
- `observer-activity` — an activity digest routed to the observer; no extra fields.

Changes:
- Add `MessageOriginKindObserver` / `MessageOriginKindObserverActivity` constants.
- Add `MessageOrigin.SenderTaskID` (`senderTaskId,omitempty`), set only for the observer kind — mirrors the existing `SenderTaskID` on the replayed user message.
- Round-trip tests for both kinds (observer with from+senderTaskId; observer-activity bare).

No integration test: observer spawn isn't deterministically CLI-triggerable; covered by unit round-trip.