### PR TITLE
query_types: add ModelInfo.ResolvedModel (#145)

### DIFF
--- a/client_introspection_test.go
+++ b/client_introspection_test.go
@@ -94,6 +94,21 @@ func TestStreamSupportedModelsReadsCachedInit(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-5-20250929", again[0].Value)
 }
 
+func TestModelInfoResolvedModelRoundTrip(t *testing.T) {
+	// Alias rows carry resolvedModel; explicit-id rows omit it.
+	raw := []byte(`{"value":"sonnet","displayName":"Sonnet","description":"balanced","resolvedModel":"claude-sonnet-5"}`)
+
+	var info ModelInfo
+	require.NoError(t, json.Unmarshal(raw, &info))
+	assert.Equal(t, "sonnet", info.Value)
+	assert.Equal(t, "claude-sonnet-5", info.ResolvedModel)
+
+	// Absent on explicit-id rows: omitempty drops it on the way out.
+	out, err := json.Marshal(ModelInfo{Value: "claude-opus-4-8", DisplayName: "Opus", Description: "deep"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "resolvedModel")
+}
+
 func TestStreamSupportedAgentsReadsCachedInit(t *testing.T) {
 	stream, _, protocol := newStreamControlTest(nil)
 	storeInitResponse(protocol, canonicalInitResponse())

--- a/query_types.go
+++ b/query_types.go
@@ -13,6 +13,11 @@ type ModelInfo struct {
 	Value       string `json:"value"`       // Model ID to use in API calls
 	DisplayName string `json:"displayName"` // Human-readable model name
 	Description string `json:"description"` // Model capabilities description
+	// ResolvedModel is the canonical wire model id this row's Value
+	// resolves to (e.g. "sonnet" -> "claude-sonnet-5"). Lets hosts match a
+	// persisted explicit id against the alias row that covers it. Present
+	// only for alias rows (sdk.d.ts v0.3.201).
+	ResolvedModel string `json:"resolvedModel,omitempty"`
 }
 
 // AgentInfo describes a subagent available to the Task tool.


### PR DESCRIPTION
Part of #145 (parity with TS Agent SDK v0.3.201). See `memory/catchup-v0.3.201/PLAN.md` §"PR 04".

TS SDK v0.3.201 adds `resolvedModel?: string` to the model-catalog row (sdk.d.ts L1191–1194): the canonical wire model id this row's `value` resolves to (e.g. `sonnet` → `claude-sonnet-5`). Lets hosts match a persisted explicit id against the alias row that covers it. Present only on alias rows.

- Add `ModelInfo.ResolvedModel` (`resolvedModel,omitempty`).
- Round-trip test: alias row carries it; explicit-id row omits it.

No integration test: field is a passive parse target on the initialize response; covered by unit round-trip.