### PR TITLE
options: add AgentDefinition observer fields (#145)

### DIFF
--- a/messages_test.go
+++ b/messages_test.go
@@ -112,6 +112,8 @@ func TestAgentDefinitionJSON(t *testing.T) {
 		Memory:                             AgentMemoryProject,
 		Effort:                             AgentEffort{Numeric: &effortBudget},
 		PermissionMode:                     PermissionModeAcceptEdits,
+		Observer:                           "security-reviewer",
+		ObserverMessage:                    "flag unsafe patterns",
 	}
 
 	data, err := json.Marshal(agent)
@@ -136,6 +138,8 @@ func TestAgentDefinitionJSON(t *testing.T) {
 	assert.Equal(t, "project", got["memory"])
 	assert.Equal(t, float64(30000), got["effort"])
 	assert.Equal(t, "acceptEdits", got["permissionMode"])
+	assert.Equal(t, "security-reviewer", got["observer"])
+	assert.Equal(t, "flag unsafe patterns", got["observerMessage"])
 
 	var decoded AgentDefinition
 	require.NoError(t, json.Unmarshal(data, &decoded))
@@ -156,6 +160,8 @@ func TestAgentDefinitionJSON(t *testing.T) {
 	require.NotNil(t, decoded.Effort.Numeric)
 	assert.Equal(t, effortBudget, *decoded.Effort.Numeric)
 	assert.Equal(t, agent.PermissionMode, decoded.PermissionMode)
+	assert.Equal(t, agent.Observer, decoded.Observer)
+	assert.Equal(t, agent.ObserverMessage, decoded.ObserverMessage)
 }
 
 func TestAgentDefinitionJSONOmitUnset(t *testing.T) {
@@ -170,7 +176,7 @@ func TestAgentDefinitionJSONOmitUnset(t *testing.T) {
 
 	assert.Equal(t, "Reviews changes", got["description"])
 	assert.Equal(t, "Review carefully", got["prompt"])
-	for _, key := range []string{"memory", "effort", "maxTurns", "background"} {
+	for _, key := range []string{"memory", "effort", "maxTurns", "background", "observer", "observerMessage"} {
 		assert.NotContains(t, got, key)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -2269,6 +2269,15 @@ type AgentDefinition struct {
 	Memory                             AgentMemoryScope     `json:"memory,omitempty"`
 	Effort                             AgentEffort          `json:"effort,omitempty"`
 	PermissionMode                     PermissionMode       `json:"permissionMode,omitempty"`
+	// Observer names an agent type auto-spawned as a background observer
+	// whenever this agent runs. The observer receives read-only activity
+	// digests and reports via the ObserverReport tool; it never
+	// participates in the task (sdk.d.ts v0.3.201).
+	Observer string `json:"observer,omitempty"`
+	// ObserverMessage is a supplemental postamble appended (after the
+	// harness-owned default) to each activity digest sent to the observer.
+	// Blank values are ignored.
+	ObserverMessage string `json:"observerMessage,omitempty"`
 }
 
 // MarshalJSON emits the TypeScript SDK agent wire shape.
@@ -2288,6 +2297,8 @@ func (a AgentDefinition) MarshalJSON() ([]byte, error) {
 		Memory                             AgentMemoryScope     `json:"memory,omitempty"`
 		Effort                             *AgentEffort         `json:"effort,omitempty"`
 		PermissionMode                     PermissionMode       `json:"permissionMode,omitempty"`
+		Observer                           string               `json:"observer,omitempty"`
+		ObserverMessage                    string               `json:"observerMessage,omitempty"`
 	}
 
 	out := agentDefinitionJSON{
@@ -2304,6 +2315,8 @@ func (a AgentDefinition) MarshalJSON() ([]byte, error) {
 		Background:                         a.Background,
 		Memory:                             a.Memory,
 		PermissionMode:                     a.PermissionMode,
+		Observer:                           a.Observer,
+		ObserverMessage:                    a.ObserverMessage,
 	}
 	if !a.Effort.IsZero() {
 		out.Effort = &a.Effort


### PR DESCRIPTION
Part of #145 (parity with TS Agent SDK v0.3.201). See `memory/catchup-v0.3.201/PLAN.md` §"PR 01".

TS SDK v0.3.201 adds two fields to the agent definition (sdk.d.ts L92–99):

- `observer?: string` — an agent type auto-spawned as a background observer whenever this agent runs. The observer receives read-only activity digests and reports via the `ObserverReport` tool; it never participates in the task.
- `observerMessage?: string` — a supplemental postamble appended (after the harness-owned default) to each activity digest sent to the observer. Blank values are ignored.

Changes:
- Add `Observer` / `ObserverMessage` to `AgentDefinition` and its `MarshalJSON` wire shape (both `omitempty`).
- Extend the marshal round-trip test and the omit-unset test.

No integration test: observer spawn isn't deterministically CLI-triggerable; covered by unit round-trip.