### PR TITLE
options: add BaseHookInput.PromptID (#145)

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -934,6 +934,54 @@ func TestIntegrationBaseHookInputEffort(t *testing.T) {
 	}, capturedEffort.Level)
 }
 
+// TestIntegrationBaseHookInputPromptID checks that the CLI populates
+// BaseHookInput.prompt_id on hook callbacks — the UUID correlating a user
+// prompt with its subsequent events (sdk.d.ts v0.3.201).
+func TestIntegrationBaseHookInputPromptID(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	var capturedPromptID string
+	preToolUseHook := func(ctx context.Context, input HookInput) (HookResult, error) {
+		if capturedPromptID == "" {
+			capturedPromptID = input.Base().PromptID
+		}
+		return HookResult{Continue: true}, nil
+	}
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. When asked to list a directory, use the Bash tool with 'ls'."),
+		WithPermissionMode(PermissionModeBypassAll),
+		WithAllowDangerouslySkipPermissions(true),
+		WithHooks(map[HookType][]HookConfig{
+			HookTypePreToolUse: {
+				{Matcher: "*", Callback: preToolUseHook},
+			},
+		}),
+		WithMaxTurns(5),
+		WithStderr(func(data string) { t.Logf("CLI stderr: %s", data) }),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	for msg := range client.Query(ctx, "Run 'ls' in the current directory using the Bash tool.") {
+		if m, ok := msg.(ResultMessage); ok {
+			t.Logf("Result: status=%s", m.Status)
+		}
+	}
+
+	if capturedPromptID == "" {
+		// TODO: Backfill once the integration fixture uses a CLI build that
+		// emits prompt_id on hook callbacks.
+		t.Skip("PreToolUse hook fired without BaseHookInput.prompt_id; current CLI fixture does not expose it")
+	}
+	assert.NotEmpty(t, capturedPromptID)
+}
+
 // TestIntegrationStopHookBlock tests that Stop hooks can block session exit
 // and reinject a new prompt using the Decision/Reason/SystemMessage fields.
 //

--- a/options.go
+++ b/options.go
@@ -1577,6 +1577,12 @@ type BaseHookInput struct {
 	SessionID      string `json:"session_id"`
 	TranscriptPath string `json:"transcript_path"`
 	Cwd            string `json:"cwd"`
+	// PromptID is a UUID correlating a user prompt with all subsequent
+	// events until the next prompt. The same value is emitted on
+	// OpenTelemetry events as the prompt.id attribute, so hook output can
+	// be joined to OTel events at prompt grain. Absent until the first user
+	// input of the process lifetime (sdk.d.ts v0.3.201).
+	PromptID       string `json:"prompt_id,omitempty"`
 	PermissionMode string `json:"permission_mode,omitempty"`
 	AgentID        string `json:"agent_id,omitempty"`
 	AgentType      string `json:"agent_type,omitempty"`

--- a/options_test.go
+++ b/options_test.go
@@ -1137,6 +1137,30 @@ func TestBaseHookInputEffortJSON(t *testing.T) {
 	})
 }
 
+func TestBaseHookInputPromptID(t *testing.T) {
+	t.Run("unmarshal populates prompt_id", func(t *testing.T) {
+		var input PreToolUseInput
+		require.NoError(t, json.Unmarshal(
+			[]byte(`{"session_id":"s","transcript_path":"/t","cwd":"/c","prompt_id":"p-123","tool_name":"Read"}`),
+			&input,
+		))
+		assert.Equal(t, "p-123", input.PromptID)
+		assert.Equal(t, "p-123", input.Base().PromptID)
+	})
+
+	t.Run("empty omitted on marshal", func(t *testing.T) {
+		data, err := json.Marshal(PreToolUseInput{
+			BaseHookInput: BaseHookInput{SessionID: "s", TranscriptPath: "/t", Cwd: "/c"},
+			ToolName:      "Read",
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "prompt_id")
+	})
+}
+
 func TestWithOnUserDialog(t *testing.T) {
 	t.Run("builder installs callback", func(t *testing.T) {
 		opts := NewOptions()


### PR DESCRIPTION
Part of #145 (parity with TS Agent SDK v0.3.201). See `memory/catchup-v0.3.201/PLAN.md` §"PR 03".

TS SDK v0.3.201 adds `prompt_id?: string` to `BaseHookInput` (sdk.d.ts L160–164): a UUID correlating a user prompt with all subsequent events until the next prompt. The same value is emitted on OpenTelemetry events as the `prompt.id` attribute, so hook output can be joined to OTel events at prompt grain. Absent until the first user input of the process lifetime.

- Add `BaseHookInput.PromptID` (`prompt_id,omitempty`).
- Unit round-trip (populate on unmarshal; omit when empty).
- Integration test `TestIntegrationBaseHookInputPromptID` captures it off a PreToolUse hook. Verified locally: current CLI fixture doesn't emit `prompt_id` yet, so it skips with a backfill TODO (same pattern as the effort hook test).