### PR TITLE
options: add sandbox credential mask mode (#145)

### DIFF
--- a/options.go
+++ b/options.go
@@ -743,14 +743,22 @@ type SettingsSandbox struct {
 }
 
 // SettingsSandboxCredentials configures credential protection inside the
-// sandbox. Only the "deny" mode is supported on each entry.
+// sandbox.
 type SettingsSandboxCredentials struct {
 	// Files are credential files or directories to protect. "deny" blocks
 	// reads inside the sandbox.
 	Files []SettingsSandboxCredentialFile `json:"files,omitempty"`
 	// EnvVars are environment variables to protect. "deny" unsets the
-	// variable for sandboxed commands.
+	// variable for sandboxed commands; "mask" substitutes a sentinel inside
+	// the sandbox and injects the real value at the proxy.
 	EnvVars []SettingsSandboxCredentialEnvVar `json:"envVars,omitempty"`
+	// AllowPlaintextInject allows sentinel->real substitution on the
+	// plain-HTTP proxy path. Defaults to false: without TLS termination the
+	// upstream identity is unverified and the credential travels in
+	// cleartext. Set only for trusted-network test fixtures. Only honored
+	// from user, managed/policy, or CLI (--settings) settings — project
+	// settings are ignored (sdk.d.ts v0.3.201).
+	AllowPlaintextInject *bool `json:"allowPlaintextInject,omitempty"`
 }
 
 // SettingsSandboxCredentialFile protects a single credential file or directory.
@@ -767,8 +775,17 @@ type SettingsSandboxCredentialFile struct {
 type SettingsSandboxCredentialEnvVar struct {
 	// Name is the environment variable name.
 	Name string `json:"name"`
-	// Mode is the access mode for this variable. Only "deny" is supported.
+	// Mode is the access mode for this variable. "deny" unsets the variable
+	// for sandboxed commands; "mask" shows sandboxed commands a sentinel
+	// value and the host proxy swaps sentinel->real on egress to
+	// InjectHosts (sdk.d.ts v0.3.201).
 	Mode string `json:"mode"`
+	// InjectHosts optionally narrows where the proxy substitutes this
+	// credential. Only meaningful when Mode is "mask"; accepted but ignored
+	// for "deny". If unset, defaults to network.allowedDomains — the
+	// credential is injected at every reachable host. Each entry must be
+	// reachable via network.allowedDomains.
+	InjectHosts []string `json:"injectHosts,omitempty"`
 }
 
 func (s SettingsSandbox) MarshalJSON() ([]byte, error) {

--- a/options_test.go
+++ b/options_test.go
@@ -714,6 +714,63 @@ func TestSettingsSandboxFieldsJSON(t *testing.T) {
 		assert.Equal(t, "AWS_SECRET_ACCESS_KEY", out.Sandbox.Credentials.EnvVars[0].Name)
 	})
 
+	t.Run("credentials mask mode with injectHosts and allowPlaintextInject", func(t *testing.T) {
+		allowPlaintext := true
+		in := Settings{
+			Sandbox: &SettingsSandbox{
+				Credentials: &SettingsSandboxCredentials{
+					EnvVars: []SettingsSandboxCredentialEnvVar{
+						{
+							Name:        "STRIPE_KEY",
+							Mode:        "mask",
+							InjectHosts: []string{"api.stripe.com"},
+						},
+					},
+					AllowPlaintextInject: &allowPlaintext,
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		creds := got["sandbox"].(map[string]interface{})["credentials"].(map[string]interface{})
+		assert.Equal(t, true, creds["allowPlaintextInject"])
+		env := creds["envVars"].([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, "mask", env["mode"])
+		assert.Equal(t, []interface{}{"api.stripe.com"}, env["injectHosts"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.NotNil(t, out.Sandbox.Credentials.AllowPlaintextInject)
+		assert.True(t, *out.Sandbox.Credentials.AllowPlaintextInject)
+		require.Len(t, out.Sandbox.Credentials.EnvVars, 1)
+		assert.Equal(t, "mask", out.Sandbox.Credentials.EnvVars[0].Mode)
+		assert.Equal(t, []string{"api.stripe.com"}, out.Sandbox.Credentials.EnvVars[0].InjectHosts)
+	})
+
+	t.Run("deny envVar omits injectHosts and nil allowPlaintextInject omits key", func(t *testing.T) {
+		in := Settings{
+			Sandbox: &SettingsSandbox{
+				Credentials: &SettingsSandboxCredentials{
+					EnvVars: []SettingsSandboxCredentialEnvVar{
+						{Name: "AWS_SECRET_ACCESS_KEY", Mode: "deny"},
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		creds := got["sandbox"].(map[string]interface{})["credentials"].(map[string]interface{})
+		assert.NotContains(t, creds, "allowPlaintextInject")
+		env := creds["envVars"].([]interface{})[0].(map[string]interface{})
+		assert.NotContains(t, env, "injectHosts")
+	})
+
 	t.Run("nil credentials omits key", func(t *testing.T) {
 		data, err := json.Marshal(Settings{Sandbox: &SettingsSandbox{}})
 		require.NoError(t, err)


### PR DESCRIPTION
Part of #145 (parity with TS Agent SDK v0.3.201). See `memory/catchup-v0.3.201/PLAN.md` §"PR 05".

TS SDK v0.3.201 extends sandbox credential protection (sdk.d.ts L2639–2648 / L5899–5921):

- envVar `mode` gains `mask` alongside `deny`: `mask` shows sandboxed commands a sentinel value; the host proxy swaps sentinel→real on egress.
- `injectHosts?: string[]` narrows where the proxy substitutes a masked credential (meaningful only for `mask`; ignored for `deny`). Unset ⇒ every host in `network.allowedDomains`.
- top-level `allowPlaintextInject?: boolean` permits sentinel→real substitution on the plain-HTTP proxy path — off by default (cleartext without TLS termination); trusted-network test fixtures only.

Changes:
- Add `SettingsSandboxCredentialEnvVar.InjectHosts` and `SettingsSandboxCredentials.AllowPlaintextInject` (both `omitempty`).
- `Mode` stays a plain string (`deny|mask`) — matches how other single-literal `mode` fields are modeled; update doc comments.
- Tests cover the mask + injectHosts + allowPlaintextInject path and the deny omit path.

No integration test: settings-schema marshal surface; covered by unit round-trip.