### PR TITLE
protocol: parse permission requires_user_interaction (#145)

### DIFF
--- a/options.go
+++ b/options.go
@@ -1408,7 +1408,13 @@ type PermissionContext struct {
 	SessionID string
 	ToolUseID string
 	AgentID   string
-	Metadata  map[string]interface{}
+	// RequiresUserInteraction is true when the tool's approval card is
+	// itself the user-interaction surface (Tool.requiresUserInteraction()).
+	// SDK hosts must not offer a one-tap allow/deny for these — the user has
+	// to open the session and respond on the card itself (sdk.d.ts
+	// v0.3.201).
+	RequiresUserInteraction bool
+	Metadata                map[string]interface{}
 }
 
 // PermissionDecisionClassification labels how a permission decision was reached

--- a/protocol.go
+++ b/protocol.go
@@ -257,14 +257,16 @@ func (p *Protocol) handlePermissionRequest(ctx context.Context, req ControlReque
 	input := req.Payload["input"]
 	toolUseID, _ := req.Payload["tool_use_id"].(string)
 	agentID, _ := req.Payload["agent_id"].(string)
+	requiresUserInteraction, _ := req.Payload["requires_user_interaction"].(bool)
 
 	// Build permission request.
 	permReq := ToolPermissionRequest{
 		ToolName:  toolName,
 		Arguments: marshalJSON(input),
 		Context: PermissionContext{
-			ToolUseID: toolUseID,
-			AgentID:   agentID,
+			ToolUseID:               toolUseID,
+			AgentID:                 agentID,
+			RequiresUserInteraction: requiresUserInteraction,
 		},
 	}
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -743,6 +743,56 @@ func TestProtocolHandlePermissionRequestClassification(t *testing.T) {
 	}
 }
 
+func TestProtocolHandlePermissionRequestRequiresUserInteraction(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload map[string]interface{}
+		want    bool
+	}{
+		{
+			name: "flag true is parsed into context",
+			payload: map[string]interface{}{
+				"tool_name":                 "AskUserQuestion",
+				"tool_use_id":               "tool_1",
+				"input":                     map[string]interface{}{},
+				"requires_user_interaction": true,
+			},
+			want: true,
+		},
+		{
+			name: "absent flag defaults to false",
+			payload: map[string]interface{}{
+				"tool_name":   "fetch_quote",
+				"tool_use_id": "tool_1",
+				"input":       map[string]interface{}{},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured PermissionContext
+			opts := NewOptions()
+			opts.CanUseTool = func(ctx context.Context, req ToolPermissionRequest) PermissionResult {
+				captured = req.Context
+				return PermissionAllow{}
+			}
+			protocol := NewProtocol(nil, opts)
+
+			resp := protocol.handlePermissionRequest(context.Background(), ControlRequest{
+				Type:      "control",
+				Subtype:   "can_use_tool",
+				RequestID: "req_1",
+				Payload:   tt.payload,
+			})
+
+			require.Equal(t, "success", resp.Response.Subtype)
+			assert.Equal(t, tt.want, captured.RequiresUserInteraction)
+		})
+	}
+}
+
 func TestProtocolHandleSDKPermissionRequestClassification(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Part of #145 (parity with TS Agent SDK v0.3.201). See `memory/catchup-v0.3.201/PLAN.md` §"PR 06".

TS SDK v0.3.201 adds `requires_user_interaction?: boolean` to the inbound permission control request (sdk.d.ts L3419–3423): true when the tool's approval card *is* the user-interaction surface (`Tool.requiresUserInteraction()`). SDK hosts must not offer a one-tap Approve/Deny for these — the user has to open the session and respond on the card itself.

- Parse `requires_user_interaction` in `handlePermissionRequest`, mirroring how `tool_use_id`/`agent_id` are pulled.
- Surface it as `PermissionContext.RequiresUserInteraction` so `CanUseTool` callbacks can suppress one-tap UI.
- Table test covers present (true) and absent (default false).

No integration test: exercising this needs a live tool whose approval card is the interaction surface; covered by the unit parse test (mirrors the existing classification tests).