### PR TITLE
options: settings parity for v0.3.201 (#145)

### DIFF
--- a/options.go
+++ b/options.go
@@ -385,19 +385,24 @@ type Settings struct {
 	AlwaysThinkingEnabled      *bool                        `json:"alwaysThinkingEnabled,omitempty"`
 	EffortLevel                EffortLevel                  `json:"effortLevel,omitempty"`
 	// Ultracode enables session-scoped workflow orchestration, typically via --settings or apply_flag_settings. Mirrors sdk.d.ts v0.3.168 L5413.
-	Ultracode                    *bool                           `json:"ultracode,omitempty"`
-	AutoCompactWindow            *int                            `json:"autoCompactWindow,omitempty"`
-	AdvisorModel                 string                          `json:"advisorModel,omitempty"`
-	FastMode                     *bool                           `json:"fastMode,omitempty"`
-	FastModePerSessionOptIn      *bool                           `json:"fastModePerSessionOptIn,omitempty"`
-	PromptSuggestionEnabled      *bool                           `json:"promptSuggestionEnabled,omitempty"`
-	ShowClearContextOnPlanAccept *bool                           `json:"showClearContextOnPlanAccept,omitempty"`
-	Agent                        string                          `json:"agent,omitempty"`
-	CompanyAnnouncements         []string                        `json:"companyAnnouncements,omitempty"`
-	PluginConfigs                map[string]SettingsPluginConfig `json:"pluginConfigs,omitempty"`
-	Remote                       *SettingsRemote                 `json:"remote,omitempty"`
-	AutoUpdatesChannel           string                          `json:"autoUpdatesChannel,omitempty"`
-	MinimumVersion               string                          `json:"minimumVersion,omitempty"`
+	Ultracode                    *bool  `json:"ultracode,omitempty"`
+	AutoCompactWindow            *int   `json:"autoCompactWindow,omitempty"`
+	AdvisorModel                 string `json:"advisorModel,omitempty"`
+	FastMode                     *bool  `json:"fastMode,omitempty"`
+	FastModePerSessionOptIn      *bool  `json:"fastModePerSessionOptIn,omitempty"`
+	PromptSuggestionEnabled      *bool  `json:"promptSuggestionEnabled,omitempty"`
+	ShowClearContextOnPlanAccept *bool  `json:"showClearContextOnPlanAccept,omitempty"`
+	// AskUserQuestionTimeout is the idle time before Claude's questions
+	// auto-continue with any answers selected so far. Defaults to never —
+	// auto-continue only runs when explicitly set to "60s", "5m", or "10m".
+	// Mirrors sdk.d.ts v0.3.201.
+	AskUserQuestionTimeout string                          `json:"askUserQuestionTimeout,omitempty"`
+	Agent                  string                          `json:"agent,omitempty"`
+	CompanyAnnouncements   []string                        `json:"companyAnnouncements,omitempty"`
+	PluginConfigs          map[string]SettingsPluginConfig `json:"pluginConfigs,omitempty"`
+	Remote                 *SettingsRemote                 `json:"remote,omitempty"`
+	AutoUpdatesChannel     string                          `json:"autoUpdatesChannel,omitempty"`
+	MinimumVersion         string                          `json:"minimumVersion,omitempty"`
 	// RequiredMinimumVersion prevents startup below the managed minimum version. Honored only from managed (policy) settings. Mirrors sdk.d.ts v0.3.168 L5488.
 	RequiredMinimumVersion string `json:"requiredMinimumVersion,omitempty"`
 	// RequiredMaximumVersion prevents startup above the managed maximum version. Honored only from managed (policy) settings. Mirrors sdk.d.ts v0.3.168 L5492.
@@ -468,6 +473,10 @@ type Settings struct {
 	DisableBundledSkills *bool `json:"disableBundledSkills,omitempty"`
 	// DisableArtifact disables the artifact view. Mirrors sdk.d.ts v0.3.177 L4905.
 	DisableArtifact *bool `json:"disableArtifact,omitempty"`
+	// EnableArtifact enables or disables the Artifact tool for this user.
+	// Unset defaults to enabled once the feature is available. Mirrors
+	// sdk.d.ts v0.3.201.
+	EnableArtifact *bool `json:"enableArtifact,omitempty"`
 	// FooterLinksRegexes adds clickable footer badges when a regex matches turn output. Read from user, flag, and managed settings only. At most 5 badges render. Mirrors sdk.d.ts v0.3.177 L4973.
 	FooterLinksRegexes []SettingsFooterLinkRegex `json:"footerLinksRegexes,omitempty"`
 	// WheelScrollAccelerationEnabled enables mouse-wheel scroll acceleration. Mirrors sdk.d.ts v0.3.177 L5988.

--- a/options_test.go
+++ b/options_test.go
@@ -1255,3 +1255,40 @@ func TestSettingsParityV0195FieldsJSON(t *testing.T) {
 		assert.Equal(t, "iterm2", out.TeammateMode)
 	})
 }
+
+func TestSettingsParityV0201FieldsJSON(t *testing.T) {
+	t.Run("enableArtifact explicit false is emitted", func(t *testing.T) {
+		f := false
+		data, err := json.Marshal(Settings{EnableArtifact: &f})
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, false, got["enableArtifact"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.NotNil(t, out.EnableArtifact)
+		assert.False(t, *out.EnableArtifact)
+	})
+
+	t.Run("askUserQuestionTimeout round-trips", func(t *testing.T) {
+		data, err := json.Marshal(Settings{AskUserQuestionTimeout: "5m"})
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, "5m", got["askUserQuestionTimeout"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, "5m", out.AskUserQuestionTimeout)
+	})
+
+	t.Run("nil/empty omits keys", func(t *testing.T) {
+		data, err := json.Marshal(Settings{})
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "enableArtifact")
+		assert.NotContains(t, got, "askUserQuestionTimeout")
+	})
+}


### PR DESCRIPTION
Part of #145 (parity with TS Agent SDK v0.3.201). See `memory/catchup-v0.3.201/PLAN.md` §"PR 07".

TS SDK v0.3.201 adds two user-settings fields (sdk.d.ts L5074–5077 / L6018–6021):

- `enableArtifact?: boolean` — enable or disable the Artifact tool for this user. Unset defaults to enabled once the feature is available. (Mirror of the existing `disableArtifact`.)
- `askUserQuestionTimeout?: '60s' | '5m' | '10m' | 'never'` — idle time before Claude's questions auto-continue with any answers selected so far. Defaults to never; auto-continue runs only when explicitly set to 60s/5m/10m.

Changes:
- Add `Settings.EnableArtifact` (`*bool`) and `Settings.AskUserQuestionTimeout` (`string`, enum values in the doc comment — matches how other literal-union settings are modeled), both `omitempty`.
- Round-trip tests (explicit false emitted; timeout value round-trips; nil/empty omitted).

No integration test: settings-schema marshal surface; covered by unit round-trip.