### PR TITLE
messages: model active_goal message (v0.3.207)

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -483,6 +483,29 @@ type PromptSuggestionMessage struct {
 // MessageType implements Message.
 func (m PromptSuggestionMessage) MessageType() string { return "prompt_suggestion" }
 
+// ActiveGoalMessage reports the state of the session's /goal Stop hook: it fires
+// when the hook reports the goal met (Value cleared to nil) or not-yet-met
+// (Value bumps Iterations and LastReason). Any surface with a goal indicator
+// re-renders from it.
+type ActiveGoalMessage struct {
+	Type      string           `json:"type"`       // Always "active_goal"
+	Value     *ActiveGoalValue `json:"value"`      // Goal state; nil when the goal is cleared
+	UUID      string           `json:"uuid"`       // Unique message ID
+	SessionID string           `json:"session_id"` // Session identifier
+}
+
+// ActiveGoalValue is the goal state carried by an ActiveGoalMessage.
+type ActiveGoalValue struct {
+	Condition     string `json:"condition"`             // Goal condition text
+	Iterations    int    `json:"iterations"`            // Iterations elapsed while the goal is unmet
+	SetAt         int64  `json:"set_at"`                // When the goal was set
+	TokensAtStart int    `json:"tokens_at_start"`       // Token count when the goal was set
+	LastReason    string `json:"last_reason,omitempty"` // Latest not-yet-met reason from the hook
+}
+
+// MessageType implements Message.
+func (m ActiveGoalMessage) MessageType() string { return "active_goal" }
+
 // RateLimitEventMessage reports rate limit information changes.
 type RateLimitEventMessage struct {
 	Type          string        `json:"type"`            // Always "rate_limit_event"
@@ -1578,6 +1601,11 @@ func ParseMessage(data []byte) (Message, error) {
 
 	case "prompt_suggestion":
 		var msg PromptSuggestionMessage
+		err := json.Unmarshal(data, &msg)
+		return msg, err
+
+	case "active_goal":
+		var msg ActiveGoalMessage
 		err := json.Unmarshal(data, &msg)
 		return msg, err
 

--- a/messages_test.go
+++ b/messages_test.go
@@ -3363,6 +3363,52 @@ func TestParseMessageSessionStateChanged(t *testing.T) {
 	}
 }
 
+func TestParseMessageActiveGoal(t *testing.T) {
+	input := `{
+		"type": "active_goal",
+		"value": {
+			"condition": "all tests pass",
+			"iterations": 3,
+			"set_at": 1710000000,
+			"tokens_at_start": 4096,
+			"last_reason": "two tests still red"
+		},
+		"uuid": "550e8400-e29b-41d4-a716-446655440300",
+		"session_id": "sess_goal_001"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	goalMsg, ok := msg.(ActiveGoalMessage)
+	require.True(t, ok, "expected ActiveGoalMessage")
+
+	assert.Equal(t, "active_goal", goalMsg.MessageType())
+	require.NotNil(t, goalMsg.Value)
+	assert.Equal(t, "all tests pass", goalMsg.Value.Condition)
+	assert.Equal(t, 3, goalMsg.Value.Iterations)
+	assert.Equal(t, int64(1710000000), goalMsg.Value.SetAt)
+	assert.Equal(t, 4096, goalMsg.Value.TokensAtStart)
+	assert.Equal(t, "two tests still red", goalMsg.Value.LastReason)
+	assert.Equal(t, "sess_goal_001", goalMsg.SessionID)
+}
+
+func TestParseMessageActiveGoalCleared(t *testing.T) {
+	input := `{
+		"type": "active_goal",
+		"value": null,
+		"uuid": "550e8400-e29b-41d4-a716-446655440301",
+		"session_id": "sess_goal_002"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	goalMsg, ok := msg.(ActiveGoalMessage)
+	require.True(t, ok, "expected ActiveGoalMessage")
+	assert.Nil(t, goalMsg.Value, "cleared goal carries a null value")
+}
+
 func TestParseMessageThinkingTokens(t *testing.T) {
 	input := `{
 		"type": "system",


### PR DESCRIPTION
Part of #154 (parity with TS Agent SDK v0.3.207).

TS SDK v0.3.207 gives `SDKActiveGoalMessage` a concrete wire shape (`sdk.d.ts` L2758) — the v0.3.201 cycle deferred it as type-only with no shipped shape.

Adds the top-level `active_goal` message: `Value *ActiveGoalValue` is nil when the goal is cleared, otherwise carries `condition`, `iterations`, `set_at`, `tokens_at_start`, and optional `last_reason`. Parse case + round-trip and cleared-value tests.