### PR TITLE
messages: model background_tasks_changed message (v0.3.207)

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -1272,6 +1272,30 @@ type ThinkingTokensMessage struct {
 // MessageType implements Message.
 func (m ThinkingTokensMessage) MessageType() string { return "system" }
 
+// BackgroundTasksChangedMessage carries the full set of live background tasks,
+// emitted whenever membership changes (start, completion, kill, a foreground
+// agent being backgrounded). REPLACE semantics: swap the tracked set for Tasks
+// on each message. It is a level signal, not an edge, and is per-process — reset
+// the set to empty whenever the CLI process restarts.
+type BackgroundTasksChangedMessage struct {
+	Type      string           `json:"type"`       // Always "system"
+	Subtype   string           `json:"subtype"`    // "background_tasks_changed"
+	Tasks     []BackgroundTask `json:"tasks"`      // Every live background task after the change
+	UUID      string           `json:"uuid"`       // Unique message ID
+	SessionID string           `json:"session_id"` // Session identifier
+}
+
+// BackgroundTask identifies one live background task in a
+// BackgroundTasksChangedMessage.
+type BackgroundTask struct {
+	TaskID      string `json:"task_id"`
+	TaskType    string `json:"task_type"`
+	Description string `json:"description"`
+}
+
+// MessageType implements Message.
+func (m BackgroundTasksChangedMessage) MessageType() string { return "system" }
+
 // WorkerShuttingDownMessage is emitted by the bridge on an opt-in graceful
 // worker teardown (only when the teardown caller supplied a reason), before the
 // heartbeat stops, so remote clients can show why the worker went away instead
@@ -1548,6 +1572,10 @@ func ParseMessage(data []byte) (Message, error) {
 			return msg, err
 		case "thinking_tokens":
 			var msg ThinkingTokensMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "background_tasks_changed":
+			var msg BackgroundTasksChangedMessage
 			err := json.Unmarshal(data, &msg)
 			return msg, err
 		case "worker_shutting_down":

--- a/messages_test.go
+++ b/messages_test.go
@@ -3409,6 +3409,51 @@ func TestParseMessageActiveGoalCleared(t *testing.T) {
 	assert.Nil(t, goalMsg.Value, "cleared goal carries a null value")
 }
 
+func TestParseMessageBackgroundTasksChanged(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "background_tasks_changed",
+		"tasks": [
+			{"task_id": "t1", "task_type": "agent", "description": "run the suite"},
+			{"task_id": "t2", "task_type": "shell", "description": "tail logs"}
+		],
+		"uuid": "550e8400-e29b-41d4-a716-446655440400",
+		"session_id": "sess_bg_001"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	bgMsg, ok := msg.(BackgroundTasksChangedMessage)
+	require.True(t, ok, "expected BackgroundTasksChangedMessage")
+
+	assert.Equal(t, "system", bgMsg.MessageType())
+	assert.Equal(t, "background_tasks_changed", bgMsg.Subtype)
+	require.Len(t, bgMsg.Tasks, 2)
+	assert.Equal(t, "t1", bgMsg.Tasks[0].TaskID)
+	assert.Equal(t, "agent", bgMsg.Tasks[0].TaskType)
+	assert.Equal(t, "run the suite", bgMsg.Tasks[0].Description)
+	assert.Equal(t, "t2", bgMsg.Tasks[1].TaskID)
+	assert.Equal(t, "sess_bg_001", bgMsg.SessionID)
+}
+
+func TestParseMessageBackgroundTasksChangedEmpty(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "background_tasks_changed",
+		"tasks": [],
+		"uuid": "550e8400-e29b-41d4-a716-446655440401",
+		"session_id": "sess_bg_002"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	bgMsg, ok := msg.(BackgroundTasksChangedMessage)
+	require.True(t, ok, "expected BackgroundTasksChangedMessage")
+	assert.Empty(t, bgMsg.Tasks, "empty task set clears all background work")
+}
+
 func TestParseMessageThinkingTokens(t *testing.T) {
 	input := `{
 		"type": "system",


### PR DESCRIPTION
Part of #154 (parity with TS Agent SDK v0.3.207).

TS SDK v0.3.207 concretizes `SDKBackgroundTasksChangedMessage` (`sdk.d.ts` L2836).

Adds the `system`/`background_tasks_changed` message: `Tasks []BackgroundTask` (`task_id`/`task_type`/`description`). REPLACE semantics — the payload is the full live set after each change, a level signal rather than a task_started/task_notification edge, and per-process (reset on CLI restart). Parse case + populated and empty-set tests.