### PR TITLE
messages: model control_request_progress message (v0.3.207)

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -1272,6 +1272,38 @@ type ThinkingTokensMessage struct {
 // MessageType implements Message.
 func (m ThinkingTokensMessage) MessageType() string { return "system" }
 
+// ControlRequestProgressStatus discriminates a ControlRequestProgressMessage.
+type ControlRequestProgressStatus string
+
+const (
+	// ControlRequestProgressStarted means the worker accepted the request and
+	// launched the work.
+	ControlRequestProgressStarted ControlRequestProgressStatus = "started"
+	// ControlRequestProgressAPIRetry carries the retry counters (same as
+	// APIRetryMessage) and is present only for this status.
+	ControlRequestProgressAPIRetry ControlRequestProgressStatus = "api_retry"
+)
+
+// ControlRequestProgressMessage reports progress for a long-running
+// client-originated control_request (currently only side_question), correlated
+// by RequestID. The retry counters are populated only when Status is
+// ControlRequestProgressAPIRetry.
+type ControlRequestProgressMessage struct {
+	Type         string                       `json:"type"`                     // Always "system"
+	Subtype      string                       `json:"subtype"`                  // "control_request_progress"
+	RequestID    string                       `json:"request_id"`               // The in-flight control_request this progress belongs to
+	Status       ControlRequestProgressStatus `json:"status"`                   // "started" or "api_retry"
+	Attempt      *int                         `json:"attempt,omitempty"`        // Retry attempt (api_retry only)
+	MaxRetries   *int                         `json:"max_retries,omitempty"`    // Max retries (api_retry only)
+	RetryDelayMs *int                         `json:"retry_delay_ms,omitempty"` // Delay before the retry in ms (api_retry only)
+	ErrorStatus  *int                         `json:"error_status,omitempty"`   // HTTP status; nil for connection errors with no response
+	UUID         string                       `json:"uuid"`                     // Unique message ID
+	SessionID    string                       `json:"session_id"`               // Session identifier
+}
+
+// MessageType implements Message.
+func (m ControlRequestProgressMessage) MessageType() string { return "system" }
+
 // BackgroundTasksChangedMessage carries the full set of live background tasks,
 // emitted whenever membership changes (start, completion, kill, a foreground
 // agent being backgrounded). REPLACE semantics: swap the tracked set for Tasks
@@ -1572,6 +1604,10 @@ func ParseMessage(data []byte) (Message, error) {
 			return msg, err
 		case "thinking_tokens":
 			var msg ThinkingTokensMessage
+			err := json.Unmarshal(data, &msg)
+			return msg, err
+		case "control_request_progress":
+			var msg ControlRequestProgressMessage
 			err := json.Unmarshal(data, &msg)
 			return msg, err
 		case "background_tasks_changed":

--- a/messages_test.go
+++ b/messages_test.go
@@ -3409,6 +3409,61 @@ func TestParseMessageActiveGoalCleared(t *testing.T) {
 	assert.Nil(t, goalMsg.Value, "cleared goal carries a null value")
 }
 
+func TestParseMessageControlRequestProgressStarted(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "control_request_progress",
+		"request_id": "req_42",
+		"status": "started",
+		"uuid": "550e8400-e29b-41d4-a716-446655440500",
+		"session_id": "sess_crp_001"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	prog, ok := msg.(ControlRequestProgressMessage)
+	require.True(t, ok, "expected ControlRequestProgressMessage")
+
+	assert.Equal(t, "system", prog.MessageType())
+	assert.Equal(t, "control_request_progress", prog.Subtype)
+	assert.Equal(t, "req_42", prog.RequestID)
+	assert.Equal(t, ControlRequestProgressStarted, prog.Status)
+	assert.Nil(t, prog.Attempt, "started carries no retry counters")
+	assert.Nil(t, prog.ErrorStatus)
+}
+
+func TestParseMessageControlRequestProgressAPIRetry(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "control_request_progress",
+		"request_id": "req_42",
+		"status": "api_retry",
+		"attempt": 2,
+		"max_retries": 5,
+		"retry_delay_ms": 1000,
+		"error_status": 529,
+		"uuid": "550e8400-e29b-41d4-a716-446655440501",
+		"session_id": "sess_crp_002"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	prog, ok := msg.(ControlRequestProgressMessage)
+	require.True(t, ok, "expected ControlRequestProgressMessage")
+
+	assert.Equal(t, ControlRequestProgressAPIRetry, prog.Status)
+	require.NotNil(t, prog.Attempt)
+	assert.Equal(t, 2, *prog.Attempt)
+	require.NotNil(t, prog.MaxRetries)
+	assert.Equal(t, 5, *prog.MaxRetries)
+	require.NotNil(t, prog.RetryDelayMs)
+	assert.Equal(t, 1000, *prog.RetryDelayMs)
+	require.NotNil(t, prog.ErrorStatus)
+	assert.Equal(t, 529, *prog.ErrorStatus)
+}
+
 func TestParseMessageBackgroundTasksChanged(t *testing.T) {
 	input := `{
 		"type": "system",


### PR DESCRIPTION
Part of #154 (parity with TS Agent SDK v0.3.207).

TS SDK v0.3.207 concretizes `SDKControlRequestProgressMessage` (`sdk.d.ts` L3627).

Adds the `system`/`control_request_progress` message: `RequestID` correlates it to the in-flight control_request, `Status` is `started`|`api_retry` (typed). The retry counters (`Attempt`/`MaxRetries`/`RetryDelayMs`/`ErrorStatus`) are pointers because they appear only for `api_retry`; `ErrorStatus` is nullable for connection errors with no HTTP response. Parse case + started/api_retry tests.