### PR TITLE
messages: model conversation_reset message (v0.3.207)

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -506,6 +506,19 @@ type ActiveGoalValue struct {
 // MessageType implements Message.
 func (m ActiveGoalMessage) MessageType() string { return "active_goal" }
 
+// ConversationResetMessage is emitted by /clear, plan-mode exit, and
+// fresh-session flows. The surface should mount a fresh transcript under
+// NewConversationID and reset any cached session title.
+type ConversationResetMessage struct {
+	Type              string `json:"type"`                // Always "conversation_reset"
+	NewConversationID string `json:"new_conversation_id"` // Conversation ID to mount the fresh transcript under
+	UUID              string `json:"uuid"`                // Unique message ID
+	SessionID         string `json:"session_id"`          // Session identifier
+}
+
+// MessageType implements Message.
+func (m ConversationResetMessage) MessageType() string { return "conversation_reset" }
+
 // RateLimitEventMessage reports rate limit information changes.
 type RateLimitEventMessage struct {
 	Type          string        `json:"type"`            // Always "rate_limit_event"
@@ -1670,6 +1683,11 @@ func ParseMessage(data []byte) (Message, error) {
 
 	case "active_goal":
 		var msg ActiveGoalMessage
+		err := json.Unmarshal(data, &msg)
+		return msg, err
+
+	case "conversation_reset":
+		var msg ConversationResetMessage
 		err := json.Unmarshal(data, &msg)
 		return msg, err
 

--- a/messages_test.go
+++ b/messages_test.go
@@ -3363,6 +3363,25 @@ func TestParseMessageSessionStateChanged(t *testing.T) {
 	}
 }
 
+func TestParseMessageConversationReset(t *testing.T) {
+	input := `{
+		"type": "conversation_reset",
+		"new_conversation_id": "conv_9f00",
+		"uuid": "550e8400-e29b-41d4-a716-446655440600",
+		"session_id": "sess_reset_001"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	reset, ok := msg.(ConversationResetMessage)
+	require.True(t, ok, "expected ConversationResetMessage")
+
+	assert.Equal(t, "conversation_reset", reset.MessageType())
+	assert.Equal(t, "conv_9f00", reset.NewConversationID)
+	assert.Equal(t, "sess_reset_001", reset.SessionID)
+}
+
 func TestParseMessageActiveGoal(t *testing.T) {
 	input := `{
 		"type": "active_goal",


### PR DESCRIPTION
Part of #154 (parity with TS Agent SDK v0.3.207).

TS SDK v0.3.207 concretizes `SDKConversationResetMessage` (`sdk.d.ts` L3730).

Adds the top-level `conversation_reset` message: emitted by `/clear`, plan-mode exit, and fresh-session flows; the consumer mounts a fresh transcript under `NewConversationID` and resets any cached session title. Parse case + test.