### PR TITLE
messages: parse capabilities on system/init (v0.3.207)

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -709,6 +709,12 @@ type SystemMessage struct {
 	Agents            []string        `json:"agents,omitempty"`          // Available agents
 	Betas             []string        `json:"betas,omitempty"`           // Enabled beta flags
 	FastModeState     *FastModeState  `json:"fast_mode_state,omitempty"` // Fast mode state
+	// Capabilities lists protocol capabilities this CLI supports, so consumers
+	// can feature-detect instead of version-sniffing. Open set — ignore unknown
+	// values and check each capability for exactly the behavior used.
+	// "interrupt_receipt_v1" means the interrupt control response carries
+	// still_queued. Absent on older CLIs.
+	Capabilities []string `json:"capabilities,omitempty"`
 }
 
 // MessageType implements Message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -1785,6 +1785,32 @@ func TestParseMessageSystemInit(t *testing.T) {
 	assert.Equal(t, PermissionModeAcceptEdits, systemMsg.PermissionMode)
 	assert.Equal(t, []string{"/help"}, systemMsg.SlashCommands)
 	assert.Equal(t, "default", systemMsg.OutputStyle)
+	assert.Empty(t, systemMsg.Capabilities, "capabilities absent on older CLIs")
+}
+
+func TestParseMessageSystemInitCapabilities(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "init",
+		"uuid": "550e8400-e29b-41d4-a716-446655440700",
+		"session_id": "sess_caps_001",
+		"apiKeySource": "env",
+		"cwd": "/workspace/project",
+		"tools": ["Read"],
+		"mcp_servers": [],
+		"model": "claude-opus-4-8",
+		"permissionMode": "default",
+		"slash_commands": [],
+		"output_style": "default",
+		"capabilities": ["interrupt_receipt_v1", "some_future_cap"]
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	systemMsg, ok := msg.(SystemMessage)
+	require.True(t, ok, "expected SystemMessage")
+	assert.Equal(t, []string{"interrupt_receipt_v1", "some_future_cap"}, systemMsg.Capabilities)
 }
 
 func TestParseMessageCompactBoundary(t *testing.T) {


### PR DESCRIPTION
Part of #154 (parity with TS Agent SDK v0.3.207).

TS SDK v0.3.207 adds `capabilities?: string[]` to the system/init message (`sdk.d.ts` L4316) — an open set for feature-detection instead of version-sniffing.

Adds `SystemMessage.Capabilities []string` (omitempty; absent on older CLIs). `interrupt_receipt_v1` is the first value and gates the interrupt-receipt behavior (PR-06). Extends the init parse test + a capabilities-present test.