### PR TITLE
client: return interrupt receipt with still_queued uuids (v0.3.207)

### DIFF
--- a/client.go
+++ b/client.go
@@ -755,11 +755,51 @@ func (s *Stream) handleSends() {
 
 // Interrupt sends an interrupt signal to stop the current generation.
 // It blocks until the CLI acknowledges the request or returns an error.
+//
+// Use InterruptWithReceipt instead when you need the interrupt receipt (the
+// uuids of async user messages that survive the interrupt); this method
+// discards it.
 func (s *Stream) Interrupt(ctx context.Context) error {
-	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+	_, err := s.InterruptWithReceipt(ctx)
+	return err
+}
+
+// InterruptReceipt is the receipt returned by an interrupt on CLIs advertising
+// the "interrupt_receipt_v1" capability (see SystemMessage.Capabilities).
+type InterruptReceipt struct {
+	// StillQueued holds the uuids of async user messages that survive this
+	// interrupt: queued commands plus any batch already dequeued for the
+	// imminent turn but not yet reachable by the abort. They will run unless
+	// cancelled first. Empty on older CLIs, which do not report a receipt.
+	StillQueued []string `json:"still_queued"`
+}
+
+// InterruptWithReceipt sends an interrupt and returns its receipt. It blocks
+// until the CLI acknowledges the request or returns an error.
+//
+// On CLIs advertising the "interrupt_receipt_v1" capability the receipt carries
+// StillQueued — the uuids of async user messages that will still run unless
+// cancelled first. Older CLIs report no receipt, so the receipt is non-nil with
+// an empty StillQueued.
+func (s *Stream) InterruptWithReceipt(ctx context.Context) (*InterruptReceipt, error) {
+	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
 		Subtype: "interrupt",
 	})
-	return err
+	if err != nil {
+		return nil, err
+	}
+
+	receipt := &InterruptReceipt{}
+	if len(resp.Response.Response) > 0 {
+		bytes, err := json.Marshal(resp.Response.Response)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(bytes, receipt); err != nil {
+			return nil, err
+		}
+	}
+	return receipt, nil
 }
 
 // SetPermissionMode dynamically changes the permission mode for this session.

--- a/stream_control_test.go
+++ b/stream_control_test.go
@@ -186,6 +186,33 @@ func TestStreamInterruptSendsControlRequest(t *testing.T) {
 	assert.NotContains(t, body, "max_thinking_tokens")
 }
 
+func TestStreamInterruptWithReceiptStillQueued(t *testing.T) {
+	stream, _, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{
+			"still_queued": []string{"uuid-a", "uuid-b"},
+		}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	receipt, err := stream.InterruptWithReceipt(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+	assert.Equal(t, []string{"uuid-a", "uuid-b"}, receipt.StillQueued)
+}
+
+func TestStreamInterruptWithReceiptOlderCLI(t *testing.T) {
+	// Older CLIs send an empty success response with no still_queued field.
+	stream, _, _ := newStreamControlTest(successSDKControlResponse)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	receipt, err := stream.InterruptWithReceipt(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+	assert.Empty(t, receipt.StillQueued)
+}
+
 func TestStreamSetPermissionModeSendsModeField(t *testing.T) {
 	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
 


### PR DESCRIPTION
Part of #154 (parity with TS Agent SDK v0.3.207).

TS SDK v0.3.207: `interrupt()` now resolves to `SDKControlInterruptResponse` (`sdk.d.ts` L3401) carrying `still_queued` — the uuids of async user messages that survive the interrupt and will still run unless cancelled first — on CLIs advertising the `interrupt_receipt_v1` capability (see `SystemMessage.Capabilities`, PR-05). Older CLIs send an empty success response.

Adds `InterruptWithReceipt(ctx) (*InterruptReceipt, error)` returning `StillQueued`. `Interrupt(ctx) error` stays as a thin wrapper that discards the receipt — no breaking signature change. Older CLIs yield a non-nil receipt with an empty `StillQueued`. Tests cover both the populated receipt and the empty-response path.