### PR TITLE
messages: add v0.3.207 TerminalReason values

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -558,6 +558,14 @@ const (
 	// turn was moved to a background task. Added in sdk.d.ts v0.3.195 L6475.
 	TerminalReasonBackgroundRequested TerminalReason = "background_requested"
 	TerminalReasonCompleted           TerminalReason = "completed"
+
+	// Added in sdk.d.ts v0.3.207 L6714.
+	TerminalReasonAPIError                       TerminalReason = "api_error"
+	TerminalReasonMalformedToolUseExhausted      TerminalReason = "malformed_tool_use_exhausted"
+	TerminalReasonBudgetExhausted                TerminalReason = "budget_exhausted"
+	TerminalReasonStructuredOutputRetryExhausted TerminalReason = "structured_output_retry_exhausted"
+	TerminalReasonToolDeferredUnavailable        TerminalReason = "tool_deferred_unavailable"
+	TerminalReasonTurnSetupFailed                TerminalReason = "turn_setup_failed"
 )
 
 // FastModeState is the current state of Claude Code fast mode.

--- a/messages_test.go
+++ b/messages_test.go
@@ -4125,3 +4125,29 @@ func TestV0195EnumWireValues(t *testing.T) {
 	assert.Equal(t, "background_requested", string(TerminalReasonBackgroundRequested))
 	assert.Equal(t, "seven_day_overage_included", string(RateLimitTypeSevenDayOverageIncluded))
 }
+
+func TestV0207TerminalReasonWireValues(t *testing.T) {
+	assert.Equal(t, "api_error", string(TerminalReasonAPIError))
+	assert.Equal(t, "malformed_tool_use_exhausted", string(TerminalReasonMalformedToolUseExhausted))
+	assert.Equal(t, "budget_exhausted", string(TerminalReasonBudgetExhausted))
+	assert.Equal(t, "structured_output_retry_exhausted", string(TerminalReasonStructuredOutputRetryExhausted))
+	assert.Equal(t, "tool_deferred_unavailable", string(TerminalReasonToolDeferredUnavailable))
+	assert.Equal(t, "turn_setup_failed", string(TerminalReasonTurnSetupFailed))
+}
+
+func TestParseMessageResultTerminalReasonV0207(t *testing.T) {
+	input := `{
+		"type": "result",
+		"status": "error",
+		"subtype": "error_during_execution",
+		"terminal_reason": "budget_exhausted"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	resultMsg, ok := msg.(ResultMessage)
+	require.True(t, ok)
+	require.NotNil(t, resultMsg.TerminalReason)
+	assert.Equal(t, TerminalReasonBudgetExhausted, *resultMsg.TerminalReason)
+}


### PR DESCRIPTION
Part of #154 (parity with TS Agent SDK v0.3.207).

TS SDK v0.3.207 extends `TerminalReason` (`sdk.d.ts` L6714) with six new values: `api_error`, `malformed_tool_use_exhausted`, `budget_exhausted`, `structured_output_retry_exhausted`, `tool_deferred_unavailable`, `turn_setup_failed`. Adds the consts + wire-value and a result-parse test.