### PR TITLE
messages: add MessageOrigin peer body field (v0.3.207)

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -230,6 +230,11 @@ type MessageOrigin struct {
 	// SenderTaskID is the observer's task id; set only for the
 	// "observer" kind (sdk.d.ts v0.3.201).
 	SenderTaskID string `json:"senderTaskId,omitempty"`
+	// Body is the decoded message body with the peer envelope stripped —
+	// byte-exact with what the model sees. Set only for the "peer" kind, and
+	// only when the turn is exactly one harness-formed envelope; render it
+	// instead of re-parsing the message text (sdk.d.ts v0.3.207).
+	Body string `json:"body,omitempty"`
 }
 
 // StreamEvent represents a progressive delta update during streaming.

--- a/messages_test.go
+++ b/messages_test.go
@@ -669,7 +669,8 @@ func TestParseMessageResultMessageOriginPeer(t *testing.T) {
 		"origin": {
 			"kind": "peer",
 			"from": "agent-42",
-			"name": "reviewer"
+			"name": "reviewer",
+			"body": "please take a look"
 		}
 	}`)
 
@@ -682,6 +683,7 @@ func TestParseMessageResultMessageOriginPeer(t *testing.T) {
 	assert.Equal(t, MessageOriginKindPeer, resultMsg.Origin.Kind)
 	assert.Equal(t, "agent-42", resultMsg.Origin.From)
 	assert.Equal(t, "reviewer", resultMsg.Origin.Name)
+	assert.Equal(t, "please take a look", resultMsg.Origin.Body)
 }
 
 func TestParseMessageResultMessageOriginHuman(t *testing.T) {


### PR DESCRIPTION
Part of #154 (parity with TS Agent SDK v0.3.207).

TS SDK v0.3.207 adds `body?: string` to the peer `MessageOrigin` kind (`sdk.d.ts` ~L3920) — the decoded message body with the peer envelope stripped, byte-exact with what the model sees, present only when the turn is exactly one harness-formed envelope. (`name` on peer is already modeled as `MessageOrigin.Name`.)

Adds `MessageOrigin.Body` (omitempty) and extends the origin-peer parse test.