### PR TITLE
sessions: add SessionMessage parent_agent_id (v0.3.207)

### DIFF
--- a/sessions.go
+++ b/sessions.go
@@ -36,6 +36,11 @@ type SessionMessage struct {
 	SessionID       string          `json:"session_id"`
 	Message         json.RawMessage `json:"message"`
 	ParentToolUseID *string         `json:"parent_tool_use_id"`
+	// ParentAgentID is the agentId of the subagent that spawned this
+	// subagent, or nil for a depth-1 subagent (spawned by the main loop), the
+	// main session itself, or sessions whose metadata lacks the field
+	// (sdk.d.ts v0.3.207).
+	ParentAgentID *string `json:"parent_agent_id"`
 }
 
 // ListSessionsOptions controls ListSessions.
@@ -510,12 +515,17 @@ func readSessionMessages(path string, includeSystem bool) ([]SessionMessage, err
 		if v := sessionGetString(entry, "parent_tool_use_id"); v != "" {
 			parent = &v
 		}
+		var parentAgent *string
+		if v := sessionGetString(entry, "parent_agent_id"); v != "" {
+			parentAgent = &v
+		}
 		out = append(out, SessionMessage{
 			Type:            typ,
 			UUID:            sessionGetString(entry, "uuid"),
 			SessionID:       firstNonEmpty(sessionGetString(entry, "session_id"), sessionGetString(entry, "sessionId")),
 			Message:         json.RawMessage(msgBytes),
 			ParentToolUseID: parent,
+			ParentAgentID:   parentAgent,
 		})
 	}
 	return out, nil

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -105,6 +105,23 @@ func TestGetSessionMessages(t *testing.T) {
 	assert.Equal(t, "assistant", decoded["role"])
 }
 
+func TestReadSessionMessagesParentAgentID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	transcript := `{"type":"user","uuid":"u1","session_id":"s1","message":{"role":"user"},"parent_tool_use_id":null,"parent_agent_id":"agent-parent"}
+{"type":"assistant","uuid":"a1","session_id":"s1","message":{"role":"assistant"},"parent_tool_use_id":null,"parent_agent_id":null}
+`
+	require.NoError(t, os.WriteFile(path, []byte(transcript), 0600))
+
+	msgs, err := readSessionMessages(path, false)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	require.NotNil(t, msgs[0].ParentAgentID)
+	assert.Equal(t, "agent-parent", *msgs[0].ParentAgentID)
+	assert.Nil(t, msgs[1].ParentAgentID, "null parent_agent_id decodes to nil")
+}
+
 func TestSubagentHelpers(t *testing.T) {
 	baseDir, cwd := makeSessionFixture(t)
 


### PR DESCRIPTION
Part of #154 (parity with TS Agent SDK v0.3.207).

TS SDK v0.3.207 adds `parent_agent_id: string | null` to session transcript messages (`sdk.d.ts` L4593, `SessionMessage`) — the agentId of the subagent that spawned this subagent, nil for a depth-1 subagent (spawned by the main loop), the main session, or sessions whose metadata lacks the field.

Adds `SessionMessage.ParentAgentID *string`, populated in `readSessionMessages` mirroring `parent_tool_use_id`. Test covers both a set value and the null case.