### PR TITLE
messages: add image content blocks (vision) + Stream.SendWithImages

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package claudeagent
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -528,7 +529,7 @@ func (c *Client) Stream(ctx context.Context) (*Stream, error) {
 		client:    c,
 		ctx:       ctx,
 		sessionID: c.options.SessionOptions.SessionID,
-		sendCh:    make(chan string, 4),
+		sendCh:    make(chan []UserContentBlock, 4),
 		closeCh:   make(chan struct{}),
 	}, nil
 }
@@ -661,7 +662,7 @@ type Stream struct {
 	client    *Client
 	ctx       context.Context
 	sessionID string
-	sendCh    chan string
+	sendCh    chan []UserContentBlock
 	closeCh   chan struct{}
 	closeOnce sync.Once
 }
@@ -671,12 +672,39 @@ type Stream struct {
 // Messages are queued and sent asynchronously. The response will appear
 // in the Messages() iterator.
 func (s *Stream) Send(ctx context.Context, prompt string) error {
+	return s.sendBlocks(ctx, []UserContentBlock{{Type: "text", Text: prompt}})
+}
+
+// ImageInput is an image attachment for SendWithImages.
+type ImageInput struct {
+	Data      []byte // raw image bytes
+	MediaType string // e.g. "image/png"
+}
+
+// SendWithImages submits a user turn with text plus one or more images, as a
+// multi-part content message (Anthropic vision).
+func (s *Stream) SendWithImages(ctx context.Context, prompt string, images []ImageInput) error {
+	blocks := []UserContentBlock{{Type: "text", Text: prompt}}
+	for _, img := range images {
+		blocks = append(blocks, UserContentBlock{
+			Type: "image",
+			Source: &ImageSource{
+				Type:      "base64",
+				MediaType: img.MediaType,
+				Data:      base64.StdEncoding.EncodeToString(img.Data),
+			},
+		})
+	}
+	return s.sendBlocks(ctx, blocks)
+}
+
+func (s *Stream) sendBlocks(ctx context.Context, blocks []UserContentBlock) error {
 	select {
 	case <-s.closeCh:
 		return &ErrTransportClosed{}
 	case <-ctx.Done():
 		return ctx.Err()
-	case s.sendCh <- prompt:
+	case s.sendCh <- blocks:
 		return nil
 	}
 }
@@ -732,15 +760,13 @@ func (s *Stream) handleSends() {
 			return
 		case <-s.ctx.Done():
 			return
-		case prompt := <-s.sendCh:
+		case blocks := <-s.sendCh:
 			userMsg := UserMessage{
 				Type:      "user",
 				SessionID: s.sessionID,
 				Message: APIUserMessage{
-					Role: "user",
-					Content: []UserContentBlock{
-						{Type: "text", Text: prompt},
-					},
+					Role:    "user",
+					Content: blocks,
 				},
 				ParentToolUseID: nil,
 			}

--- a/image_test.go
+++ b/image_test.go
@@ -1,0 +1,57 @@
+package claudeagent
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+// TestImageContentBlockMarshalsToVisionSchema checks the image content block
+// serializes to the exact Anthropic vision shape.
+func TestImageContentBlockMarshalsToVisionSchema(t *testing.T) {
+	block := UserContentBlock{
+		Type:   "image",
+		Source: &ImageSource{Type: "base64", MediaType: "image/png", Data: "aGk="},
+	}
+	got, err := json.Marshal(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGk="}}`
+	if string(got) != want {
+		t.Errorf("image block marshaled to\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+// TestSendWithImagesBuildsMultipartMessage checks a text+image turn produces the
+// right content blocks, with the image base64-encoded.
+func TestSendWithImagesBuildsMultipartMessage(t *testing.T) {
+	s := &Stream{
+		sendCh:  make(chan []UserContentBlock, 1),
+		closeCh: make(chan struct{}),
+	}
+	err := s.SendWithImages(context.Background(), "look", []ImageInput{
+		{Data: []byte("PNGDATA"), MediaType: "image/png"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blocks := <-s.sendCh
+	if len(blocks) != 2 {
+		t.Fatalf("want 2 content blocks (text + image), got %d", len(blocks))
+	}
+	if blocks[0].Type != "text" || blocks[0].Text != "look" {
+		t.Errorf("first block = %+v, want text %q", blocks[0], "look")
+	}
+	if blocks[1].Type != "image" || blocks[1].Source == nil {
+		t.Fatalf("second block = %+v, want image with source", blocks[1])
+	}
+	if blocks[1].Source.MediaType != "image/png" {
+		t.Errorf("media type = %q, want image/png", blocks[1].Source.MediaType)
+	}
+	if want := base64.StdEncoding.EncodeToString([]byte("PNGDATA")); blocks[1].Source.Data != want {
+		t.Errorf("data = %q, want %q", blocks[1].Source.Data, want)
+	}
+}

--- a/messages.go
+++ b/messages.go
@@ -44,8 +44,17 @@ type APIUserMessage struct {
 
 // UserContentBlock represents a content block in a user message.
 type UserContentBlock struct {
-	Type string `json:"type"`           // "text" or other types
-	Text string `json:"text,omitempty"` // Text content
+	Type   string       `json:"type"`             // "text" or "image"
+	Text   string       `json:"text,omitempty"`   // Text content (Type == "text")
+	Source *ImageSource `json:"source,omitempty"` // Image content (Type == "image")
+}
+
+// ImageSource is the source of an image content block, base64-encoded, matching
+// the Anthropic vision content-block schema.
+type ImageSource struct {
+	Type      string `json:"type"`       // "base64"
+	MediaType string `json:"media_type"` // e.g. "image/png"
+	Data      string `json:"data"`       // base64-encoded image bytes
 }
 
 // UserMessageReplay represents a replayed user message during session resume.

--- a/stream_control_test.go
+++ b/stream_control_test.go
@@ -111,7 +111,7 @@ func newStreamControlTest(
 	stream := &Stream{
 		client:  client,
 		ctx:     context.Background(),
-		sendCh:  make(chan string),
+		sendCh:  make(chan []UserContentBlock),
 		closeCh: make(chan struct{}),
 	}
 	return stream, transport, protocol


### PR DESCRIPTION
## Summary

While building an adapter that exposes Claude over a network protocol, I needed
to forward a pasted image to Claude — but the SDK is text-only: `Stream.Send`
takes a `string` and `UserContentBlock` has no image field. Since Claude is a
vision model, this adds first-class image content so a turn can carry images.

## What changed

- `messages.go`: `UserContentBlock` gains a `Source *ImageSource` field, plus a
  new `ImageSource` type, matching the Anthropic vision content-block schema:
  `{"type":"image","source":{"type":"base64","media_type":"…","data":"…"}}`.
- `client.go`: new `Stream.SendWithImages(ctx, prompt string, images []ImageInput)`
  sends a multi-part text+image user message. `Send` keeps its exact signature
  and behavior — it now delegates to a shared `sendBlocks`. The private `sendCh`
  becomes `chan []UserContentBlock` so a turn can carry image blocks.
- `image_test.go`: tests (below).

New exported API:

```go
type ImageInput struct {
    Data      []byte // raw image bytes
    MediaType string // e.g. "image/png"
}

func (s *Stream) SendWithImages(ctx context.Context, prompt string, images []ImageInput) error
```

## Test plan

- `TestImageContentBlockMarshalsToVisionSchema` — the block marshals to the
  exact vision JSON.
- `TestSendWithImagesBuildsMultipartMessage` — a text+image turn produces the
  correct content blocks, with the image base64-encoded.
- Verified empirically against a running Claude (`claude-code`): a solid-blue
  base64 PNG sent via `SendWithImages`; asked for the dominant color, Claude
  answered "blue".
- `go build ./...` and `go vet ./...` pass. Integration tests that need a live
  CLI are unaffected — `Send`'s behavior is unchanged.

## Compatibility

`Send`'s exported signature and behavior are unchanged. The only internal change
is the type of the private `sendCh` field (`chan string` → `chan []UserContentBlock`);
one internal test helper is updated. No exported behavior breaks.
