### PR TITLE
messages: add assistant wrapper fields for v0.3.215

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -103,6 +103,22 @@ type AssistantMessage struct {
 	// audit record for the turn. Absent when emitted by an older CLI.
 	Supersedes []string `json:"supersedes,omitempty"`
 
+	// ResumedFromIncompleteThinking is true when this turn continued the
+	// preceding truncated assistant turn inside its trailing signed thinking
+	// block (max-output-tokens recovery). The thinking signatures are
+	// cumulative over that preceding thinking-only turn, so history replayed
+	// through the bridge must carry this flag back for the normalizer to keep
+	// the run's prefix on the wire. A wrapper-level sibling — never inside
+	// message.content — so it is not replayed to the model (sdk.d.ts
+	// v0.3.215).
+	ResumedFromIncompleteThinking bool `json:"resumed_from_incomplete_thinking,omitempty"`
+
+	// Aborted is true when this assistant message was truncated by an
+	// interrupt/abort before the stream completed: stop_reason was never
+	// received and the content may end mid-word. Absent on normally completed
+	// messages (sdk.d.ts v0.3.215).
+	Aborted bool `json:"aborted,omitempty"`
+
 	// SubagentType is the subagent type that produced this message, when
 	// the message originated from a subagent task. Empty for top-level
 	// assistant turns.
@@ -111,6 +127,14 @@ type AssistantMessage struct {
 	// TaskDescription is a short description of the subagent task that
 	// produced this message. Set alongside SubagentType.
 	TaskDescription string `json:"task_description,omitempty"`
+
+	// Timestamp is the ISO-8601 time at which this content block finished on
+	// the originating process. One API assistant turn may produce several
+	// assistant messages sharing a message.id, each with its own timestamp.
+	// It uses the originating host's clock, so it is for display only — do not
+	// order messages by this field. Older emitters omit it; consumers should
+	// fall back to receive time (sdk.d.ts v0.3.215).
+	Timestamp string `json:"timestamp,omitempty"`
 
 	// Error is the upstream API error code, if the assistant turn failed.
 	// Empty for a successful turn. See AssistantMessageError for known

--- a/messages_test.go
+++ b/messages_test.go
@@ -450,8 +450,11 @@ func TestParseMessageAssistantMessageSubagentFields(t *testing.T) {
 			"total_tokens": 20
 		},
 		"request_id": "req_123",
+		"resumed_from_incomplete_thinking": true,
+		"aborted": true,
 		"subagent_type": "general-purpose",
-		"task_description": "Inspect repository state"
+		"task_description": "Inspect repository state",
+		"timestamp": "2026-07-20T16:07:00.000Z"
 	}`
 
 	msg, err := ParseMessage([]byte(input))
@@ -461,8 +464,11 @@ func TestParseMessageAssistantMessageSubagentFields(t *testing.T) {
 	require.True(t, ok, "expected AssistantMessage")
 
 	assert.Equal(t, "req_123", assistantMsg.RequestID)
+	assert.True(t, assistantMsg.ResumedFromIncompleteThinking)
+	assert.True(t, assistantMsg.Aborted)
 	assert.Equal(t, "general-purpose", assistantMsg.SubagentType)
 	assert.Equal(t, "Inspect repository state", assistantMsg.TaskDescription)
+	assert.Equal(t, "2026-07-20T16:07:00.000Z", assistantMsg.Timestamp)
 }
 
 func TestParseMessageAssistantMessageError(t *testing.T) {
@@ -500,8 +506,11 @@ func TestAssistantMessageFieldsOmitEmpty(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &got))
 
 	assert.NotContains(t, got, "request_id")
+	assert.NotContains(t, got, "resumed_from_incomplete_thinking")
+	assert.NotContains(t, got, "aborted")
 	assert.NotContains(t, got, "subagent_type")
 	assert.NotContains(t, got, "task_description")
+	assert.NotContains(t, got, "timestamp")
 }
 
 func TestAssistantMessageErrorOmitEmpty(t *testing.T) {
@@ -519,10 +528,13 @@ func TestAssistantMessageErrorOmitEmpty(t *testing.T) {
 
 func TestAssistantMessageJSONRoundTrip(t *testing.T) {
 	msg := AssistantMessage{
-		Type:            "assistant",
-		RequestID:       "req_456",
-		SubagentType:    "code-reviewer",
-		TaskDescription: "Review assistant message fields",
+		Type:                          "assistant",
+		RequestID:                     "req_456",
+		ResumedFromIncompleteThinking: true,
+		Aborted:                       true,
+		SubagentType:                  "code-reviewer",
+		TaskDescription:               "Review assistant message fields",
+		Timestamp:                     "2026-07-20T16:07:00.000Z",
 	}
 	msg.Message.Role = "assistant"
 	msg.Message.Content = []ContentBlock{{Type: "text", Text: "Done."}}
@@ -534,8 +546,11 @@ func TestAssistantMessageJSONRoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &got))
 
 	assert.Equal(t, msg.RequestID, got.RequestID)
+	assert.Equal(t, msg.ResumedFromIncompleteThinking, got.ResumedFromIncompleteThinking)
+	assert.Equal(t, msg.Aborted, got.Aborted)
 	assert.Equal(t, msg.SubagentType, got.SubagentType)
 	assert.Equal(t, msg.TaskDescription, got.TaskDescription)
+	assert.Equal(t, msg.Timestamp, got.Timestamp)
 }
 
 func TestAssistantMessageErrorRoundTrip(t *testing.T) {


### PR DESCRIPTION
## What

TS SDK v0.3.215 adds three wrapper-level fields to `SDKAssistantMessage`. Mirror them on `AssistantMessage`:

- **`resumed_from_incomplete_thinking`** — this turn continued the preceding truncated assistant turn inside its trailing signed thinking block (max-output-tokens recovery). Thinking signatures are cumulative over that preceding thinking-only turn, so history replayed through the bridge must carry this flag back for the normalizer to keep the run's prefix on the wire. Wrapper-level sibling — never inside `message.content` — so it is not replayed to the model.
- **`aborted`** — the message was truncated by an interrupt/abort before the stream completed; `stop_reason` was never received and content may end mid-word.
- **`timestamp`** — ISO-8601 completion time of this content block on the originating process. Display-only (originating host clock); not an ordering key. Older emitters omit it.

All three are additive, `omitempty`, and populated by standard unmarshal — no parse-path change.

## Tests

Extended the existing `TestParseMessageAssistantMessageSubagentFields`, `TestAssistantMessageFieldsOmitEmpty`, and `TestAssistantMessageJSONRoundTrip` to cover the new fields (parse, omitempty, round-trip).

Parity: TS SDK v0.3.215. Part of #167.