### PR TITLE
query: add version to PluginInfo

### DIFF
--- a/client_file_plugin_control_test.go
+++ b/client_file_plugin_control_test.go
@@ -301,9 +301,10 @@ func TestStreamReloadPluginsParsesResponse(t *testing.T) {
 				},
 				"plugins": []interface{}{
 					map[string]interface{}{
-						"name":   "local",
-						"path":   "/tmp/plugin",
-						"source": "project",
+						"name":    "local",
+						"path":    "/tmp/plugin",
+						"version": "1.2.3",
+						"source":  "project",
 					},
 				},
 				"mcpServers": []interface{}{
@@ -339,9 +340,10 @@ func TestStreamReloadPluginsParsesResponse(t *testing.T) {
 			Model:       "sonnet",
 		}}, got.Agents)
 		assert.Equal(t, []PluginInfo{{
-			Name:   "local",
-			Path:   "/tmp/plugin",
-			Source: "project",
+			Name:    "local",
+			Path:    "/tmp/plugin",
+			Version: "1.2.3",
+			Source:  "project",
 		}}, got.Plugins)
 		require.Len(t, got.McpServers, 1)
 		assert.Equal(t, "github", got.McpServers[0].Name)

--- a/query_types.go
+++ b/query_types.go
@@ -122,9 +122,14 @@ type SDKControlReloadSkillsResponse struct {
 
 // PluginInfo describes a plugin loaded by the CLI.
 type PluginInfo struct {
-	Name   string `json:"name"`
-	Path   string `json:"path"`
-	Source string `json:"source,omitempty"`
+	Name string `json:"name"`
+	Path string `json:"path"`
+	// Version is the plugin's version as declared in its plugin.json
+	// manifest, emitted verbatim. Plugin-author-controlled — validate before
+	// trusting. Omitted when the manifest declares no version (sdk.d.ts
+	// v0.3.215).
+	Version string `json:"version,omitempty"`
+	Source  string `json:"source,omitempty"`
 }
 
 // APIProvider names the active CLI API backend. Anthropic OAuth login only


### PR DESCRIPTION
## What

TS SDK v0.3.215 adds an optional `version` to the plugin-info shape in two places:

- `SDKControlReloadPluginsResponse.plugins[]` (the `reload_plugins` control response)
- the `initialize` system message `plugins[]`

Both are backed by Go's `PluginInfo`, so a single `omitempty` `Version` field covers both call sites.

The value is the plugin's version as declared in its `plugin.json` manifest, emitted verbatim — **plugin-author-controlled, so validate before trusting**. Omitted when the manifest declares no version.

## Tests

Extended the existing `reload_plugins` round-trip test to carry a `version` on the returned plugin.

Parity: TS SDK v0.3.215. Part of #167.