### PR TITLE
protocol: parse ask-rule fields on permission requests

### DIFF
--- a/options.go
+++ b/options.go
@@ -1429,6 +1429,21 @@ type ToolPermissionRequest struct {
 	Context   PermissionContext
 }
 
+// MatchedAskRule describes the user-configured ask rule (permissions.ask) that
+// forced a permission prompt whose ask nonetheless carries the tool's own
+// decision reason. When set, the ask-rule substitution kept the richer
+// tool-minted ask, so the rule rides here instead of a "rule"
+// decision_reason_type. Hosts making policy on the decision reason (e.g.
+// auto-deny a safetyCheck) or running host-side auto-approval should treat asks
+// carrying this as rule-forced: the user's stated intent is a human prompt. The
+// values are producer-authored and render-unsafe like a decision reason —
+// sanitize before display (sdk.d.ts v0.3.215).
+type MatchedAskRule struct {
+	Source      string `json:"source"`
+	ToolName    string `json:"tool_name"`
+	RuleContent string `json:"rule_content,omitempty"`
+}
+
 // PermissionContext provides additional context for permission decisions.
 type PermissionContext struct {
 	SessionID string
@@ -1438,9 +1453,22 @@ type PermissionContext struct {
 	// itself the user-interaction surface (Tool.requiresUserInteraction()).
 	// SDK hosts must not offer a one-tap allow/deny for these — the user has
 	// to open the session and respond on the card itself (sdk.d.ts
-	// v0.3.201).
+	// v0.3.201). As of v0.3.215 it is also set when the pending ask is
+	// localDisplayOnly: its consent disclosure cannot ride this wire and only
+	// the local dialog renders it. Either way the user must open the session
+	// to answer.
 	RequiresUserInteraction bool
-	Metadata                map[string]interface{}
+	// SuppressAlwaysAllowRule is true when the dialog must not offer the
+	// persistent "don't ask again" affordance for this ask: accepting it would
+	// write a whole-tool allow rule broader than the ask's own verb. Hosts
+	// rendering approve options should omit any persistent-rule row when set
+	// (sdk.d.ts v0.3.215).
+	SuppressAlwaysAllowRule bool
+	// MatchedAskRule is set when a user-configured ask rule forced this prompt
+	// while the ask still carries the tool's own decision reason. Nil when no
+	// such rule applied. See MatchedAskRule (sdk.d.ts v0.3.215).
+	MatchedAskRule *MatchedAskRule
+	Metadata       map[string]interface{}
 }
 
 // PermissionDecisionClassification labels how a permission decision was reached

--- a/protocol.go
+++ b/protocol.go
@@ -250,6 +250,23 @@ func (p *Protocol) handleControlRequest(ctx context.Context, req ControlRequest)
 	return p.transport.Write(ctx, resp)
 }
 
+// parseMatchedAskRule extracts the matched_ask_rule object from a permission
+// request payload. It returns nil when the field is absent or malformed.
+func parseMatchedAskRule(v interface{}) *MatchedAskRule {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	source, _ := m["source"].(string)
+	toolName, _ := m["tool_name"].(string)
+	ruleContent, _ := m["rule_content"].(string)
+	return &MatchedAskRule{
+		Source:      source,
+		ToolName:    toolName,
+		RuleContent: ruleContent,
+	}
+}
+
 // handlePermissionRequest processes a permission check request.
 func (p *Protocol) handlePermissionRequest(ctx context.Context, req ControlRequest) SDKControlResponse {
 	// Extract request details (per TypeScript SDK: tool_name, input).
@@ -258,6 +275,8 @@ func (p *Protocol) handlePermissionRequest(ctx context.Context, req ControlReque
 	toolUseID, _ := req.Payload["tool_use_id"].(string)
 	agentID, _ := req.Payload["agent_id"].(string)
 	requiresUserInteraction, _ := req.Payload["requires_user_interaction"].(bool)
+	suppressAlwaysAllowRule, _ := req.Payload["suppress_always_allow_rule"].(bool)
+	matchedAskRule := parseMatchedAskRule(req.Payload["matched_ask_rule"])
 
 	// Build permission request.
 	permReq := ToolPermissionRequest{
@@ -267,6 +286,8 @@ func (p *Protocol) handlePermissionRequest(ctx context.Context, req ControlReque
 			ToolUseID:               toolUseID,
 			AgentID:                 agentID,
 			RequiresUserInteraction: requiresUserInteraction,
+			SuppressAlwaysAllowRule: suppressAlwaysAllowRule,
+			MatchedAskRule:          matchedAskRule,
 		},
 	}
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -793,6 +793,67 @@ func TestProtocolHandlePermissionRequestRequiresUserInteraction(t *testing.T) {
 	}
 }
 
+func TestProtocolHandlePermissionRequestAskRule(t *testing.T) {
+	t.Run("fields parsed into context", func(t *testing.T) {
+		var captured PermissionContext
+		opts := NewOptions()
+		opts.CanUseTool = func(ctx context.Context, req ToolPermissionRequest) PermissionResult {
+			captured = req.Context
+			return PermissionAllow{}
+		}
+		protocol := NewProtocol(nil, opts)
+
+		resp := protocol.handlePermissionRequest(context.Background(), ControlRequest{
+			Type:      "control",
+			Subtype:   "can_use_tool",
+			RequestID: "req_1",
+			Payload: map[string]interface{}{
+				"tool_name":                  "Bash",
+				"tool_use_id":                "tool_1",
+				"input":                      map[string]interface{}{},
+				"suppress_always_allow_rule": true,
+				"matched_ask_rule": map[string]interface{}{
+					"source":       "settings",
+					"tool_name":    "Bash",
+					"rule_content": "Bash(rm:*)",
+				},
+			},
+		})
+
+		require.Equal(t, "success", resp.Response.Subtype)
+		assert.True(t, captured.SuppressAlwaysAllowRule)
+		require.NotNil(t, captured.MatchedAskRule)
+		assert.Equal(t, "settings", captured.MatchedAskRule.Source)
+		assert.Equal(t, "Bash", captured.MatchedAskRule.ToolName)
+		assert.Equal(t, "Bash(rm:*)", captured.MatchedAskRule.RuleContent)
+	})
+
+	t.Run("absent fields leave zero values", func(t *testing.T) {
+		var captured PermissionContext
+		opts := NewOptions()
+		opts.CanUseTool = func(ctx context.Context, req ToolPermissionRequest) PermissionResult {
+			captured = req.Context
+			return PermissionAllow{}
+		}
+		protocol := NewProtocol(nil, opts)
+
+		resp := protocol.handlePermissionRequest(context.Background(), ControlRequest{
+			Type:      "control",
+			Subtype:   "can_use_tool",
+			RequestID: "req_1",
+			Payload: map[string]interface{}{
+				"tool_name":   "fetch_quote",
+				"tool_use_id": "tool_1",
+				"input":       map[string]interface{}{},
+			},
+		})
+
+		require.Equal(t, "success", resp.Response.Subtype)
+		assert.False(t, captured.SuppressAlwaysAllowRule)
+		assert.Nil(t, captured.MatchedAskRule)
+	})
+}
+
 func TestProtocolHandleSDKPermissionRequestClassification(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## What

TS SDK v0.3.215 adds two fields to the `can_use_tool` control request (`SDKControlPermissionRequest`). Surface both on `PermissionContext` and parse them in `handlePermissionRequest`:

- **`suppress_always_allow_rule`** — the dialog must not offer the persistent "don't ask again" affordance for this ask, because accepting it would write a whole-tool allow rule broader than the ask's own verb. Hosts rendering approve options should omit any persistent-rule row when set.
- **`matched_ask_rule`** (`{source, tool_name, rule_content?}`) — a user-configured ask rule (`permissions.ask`) forced this prompt, but the ask still carries the tool's own decision reason, so the rule rides here instead of a `"rule"` `decision_reason_type`. Hosts making policy on the decision reason (auto-deny a safetyCheck) or running host-side auto-approval should treat asks carrying this as rule-forced. **Producer-authored and render-unsafe** like a decision reason — sanitize before display.

Also widened the `RequiresUserInteraction` doc to cover the v0.3.215 `localDisplayOnly` case (its consent disclosure cannot ride the wire; only the local dialog renders it).

## Tests

Added `TestProtocolHandlePermissionRequestAskRule` (fields parsed into context; absent fields leave zero values).

Parity: TS SDK v0.3.215. Part of #167.