### PR TITLE
messages: add scheduled-trigger subkind to MessageOrigin

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -259,7 +259,24 @@ type MessageOrigin struct {
 	// only when the turn is exactly one harness-formed envelope; render it
 	// instead of re-parsing the message text (sdk.d.ts v0.3.207).
 	Body string `json:"body,omitempty"`
+	// Subkind refines the "task-notification" kind. It is set to
+	// MessageOriginSubkindScheduledTrigger when the delivery is the fired
+	// stored prompt of a scheduled task/routine (stamped from server-asserted
+	// provenance; the schedule attests storage, not authorship). The harness
+	// then frames the message as the session's assigned task instead of the
+	// generic background-notification frame. Absent on webhook, PR-steward,
+	// plugin, and background-event deliveries (sdk.d.ts v0.3.215).
+	Subkind MessageOriginSubkind `json:"subkind,omitempty"`
 }
+
+// MessageOriginSubkind refines a MessageOrigin's kind.
+type MessageOriginSubkind string
+
+const (
+	// MessageOriginSubkindScheduledTrigger marks a "task-notification" origin
+	// whose delivery is the fired stored prompt of a scheduled task/routine.
+	MessageOriginSubkindScheduledTrigger MessageOriginSubkind = "scheduled-trigger"
+)
 
 // StreamEvent represents a progressive delta update during streaming.
 //

--- a/messages_test.go
+++ b/messages_test.go
@@ -1434,6 +1434,51 @@ func TestMessageOriginObserverRoundTrip(t *testing.T) {
 	assert.Equal(t, "task-abc123", decoded.Origin.SenderTaskID)
 }
 
+func TestMessageOriginScheduledTriggerRoundTrip(t *testing.T) {
+	msg := ResultMessage{
+		Type:    "result",
+		Subtype: "success",
+		Origin: &MessageOrigin{
+			Kind:    MessageOriginKindTaskNotification,
+			Subkind: MessageOriginSubkindScheduledTrigger,
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	origin, ok := raw["origin"].(map[string]interface{})
+	require.True(t, ok, "origin must marshal to an object")
+	assert.Equal(t, "task-notification", origin["kind"])
+	assert.Equal(t, "scheduled-trigger", origin["subkind"])
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Origin)
+	assert.Equal(t, MessageOriginKindTaskNotification, decoded.Origin.Kind)
+	assert.Equal(t, MessageOriginSubkindScheduledTrigger, decoded.Origin.Subkind)
+}
+
+// A plain task-notification origin (no scheduled prompt) must omit subkind.
+func TestMessageOriginTaskNotificationSubkindOmitEmpty(t *testing.T) {
+	msg := ResultMessage{
+		Type:    "result",
+		Subtype: "success",
+		Origin:  &MessageOrigin{Kind: MessageOriginKindTaskNotification},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	origin, ok := raw["origin"].(map[string]interface{})
+	require.True(t, ok, "origin must marshal to an object")
+	assert.NotContains(t, origin, "subkind")
+}
+
 func TestMessageOriginObserverActivityRoundTrip(t *testing.T) {
 	msg := ResultMessage{
 		Type:    "result",


### PR DESCRIPTION
## What

TS SDK v0.3.215 adds an optional `subkind` to the `task-notification` variant of `SDKMessageOrigin`, with a single value `'scheduled-trigger'`:

> Present when the delivery is the fired stored prompt of a scheduled task/routine (stamped from server-asserted provenance; the schedule attests storage, not authorship). The harness frames it as the session's assigned task instead of the generic background-notification frame. Absent on webhook, PR-steward, plugin, and background-event deliveries.

Adds `MessageOrigin.Subkind` (omitempty) and the `MessageOriginSubkind` type with the `MessageOriginSubkindScheduledTrigger` constant.

## Tests

Added round-trip coverage for a scheduled-trigger origin and an omitempty check for a plain task-notification origin.

Parity: TS SDK v0.3.215. Part of #167.