### PR TITLE
hooks: add UserPromptSubmit source and SessionStart fork

### DIFF
--- a/options.go
+++ b/options.go
@@ -1731,6 +1731,14 @@ func (i PostToolUseInput) Base() BaseHookInput { return i.BaseHookInput }
 type UserPromptSubmitInput struct {
 	BaseHookInput
 	Prompt string `json:"prompt"`
+	// Source names who authored or injected the prompt: "user" (interactive
+	// composer), "sdk" (non-interactive entrypoint, -p / Agent SDK),
+	// "loop_wakeup" (dynamic /loop wakeup), "schedule_wakeup" (scheduled-task
+	// fire), or "system" (other machine-injected turns: peer/channel messages,
+	// task notifications, auto-continuation). Empty when absent — as of
+	// v0.3.215 it is only set for Anthropic-internal sessions while the field
+	// is trialed; external payloads omit it (sdk.d.ts v0.3.215).
+	Source string `json:"source,omitempty"`
 	// SessionTitle is the optional user-facing session label from TS L6094.
 	// Nil means the field was absent on the wire.
 	SessionTitle *string `json:"session_title,omitempty"`
@@ -1880,7 +1888,7 @@ func (i NotificationInput) Base() BaseHookInput { return i.BaseHookInput }
 // SessionStartInput contains data for SessionStart hooks.
 type SessionStartInput struct {
 	BaseHookInput
-	Source string `json:"source"` // "startup", "resume", "clear", or "compact"
+	Source string `json:"source"` // "startup", "resume", "clear", "compact", or "fork" (v0.3.215)
 	// SessionTitle is the optional user-facing session label from TS L3978.
 	// Nil means the field was absent on the wire.
 	SessionTitle *string `json:"session_title,omitempty"`

--- a/protocol.go
+++ b/protocol.go
@@ -520,6 +520,7 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 		input = UserPromptSubmitInput{
 			BaseHookInput: base,
 			Prompt:        getString(inputData, "prompt"),
+			Source:        getString(inputData, "source"),
 			SessionTitle:  getOptionalString(inputData, "session_title"),
 		}
 	case HookTypeStop:
@@ -1030,6 +1031,7 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 		input = UserPromptSubmitInput{
 			BaseHookInput: base,
 			Prompt:        getString(hookInput, "prompt"),
+			Source:        getString(hookInput, "source"),
 			SessionTitle:  getOptionalString(hookInput, "session_title"),
 		}
 	case "Stop":

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -3549,6 +3549,39 @@ func TestGetHookInput_UserPromptSubmit_NoSessionTitle(t *testing.T) {
 	})
 }
 
+func TestGetHookInput_UserPromptSubmit_Source(t *testing.T) {
+	assertSDKHookInput(t, map[string]interface{}{
+		"hook_event_name": "UserPromptSubmit",
+		"prompt":          "hello",
+		"source":          "schedule_wakeup",
+	}, func(input HookInput) {
+		ev, ok := input.(UserPromptSubmitInput)
+		require.True(t, ok)
+		assert.Equal(t, "schedule_wakeup", ev.Source)
+	})
+
+	// Absent source leaves the field empty.
+	assertSDKHookInput(t, map[string]interface{}{
+		"hook_event_name": "UserPromptSubmit",
+		"prompt":          "hello",
+	}, func(input HookInput) {
+		ev, ok := input.(UserPromptSubmitInput)
+		require.True(t, ok)
+		assert.Empty(t, ev.Source)
+	})
+}
+
+func TestGetHookInput_SessionStart_ForkSource(t *testing.T) {
+	assertSDKHookInput(t, map[string]interface{}{
+		"hook_event_name": "SessionStart",
+		"source":          "fork",
+	}, func(input HookInput) {
+		ev, ok := input.(SessionStartInput)
+		require.True(t, ok)
+		assert.Equal(t, "fork", ev.Source)
+	})
+}
+
 func assertLegacyHookInput(t *testing.T, inputData map[string]interface{}, assertInput func(HookInput)) {
 	t.Helper()
 


### PR DESCRIPTION
## What

TS SDK v0.3.215 touches two hook inputs:

- **`UserPromptSubmitHookInput.source`** — new discriminator naming who authored/injected the prompt: `user` (interactive composer), `sdk` (`-p` / Agent SDK), `loop_wakeup` (dynamic /loop), `schedule_wakeup` (scheduled-task fire), `system` (other machine-injected turns). Trial-gated: currently only set for Anthropic-internal sessions, so external payloads omit it — modeled as `omitempty`. Mapped through both the legacy and SDK hook-input builders.
- **`SessionStart` source** — widened with `fork`. `SessionStartInput.Source` is already a plain string mapped in both builders; only the doc comment needed updating.

## Tests

Added `TestGetHookInput_UserPromptSubmit_Source` (present + absent) and `TestGetHookInput_SessionStart_ForkSource`.

Parity: TS SDK v0.3.215. Part of #167.