### PR TITLE
messages: add subagent fields to tool_progress

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -499,8 +499,28 @@ type ToolProgressMessage struct {
 	ParentToolUseID    *string `json:"parent_tool_use_id"`   // Parent tool if nested
 	ElapsedTimeSeconds float64 `json:"elapsed_time_seconds"` // Time elapsed
 	TaskID             *string `json:"task_id,omitempty"`    // Task ID if associated with a task
-	UUID               string  `json:"uuid"`                 // Message UUID
-	SessionID          string  `json:"session_id"`           // Session ID
+	// Heartbeat is true when this frame is a liveness heartbeat rather than a
+	// content-bearing progress update (sdk.d.ts v0.3.215).
+	Heartbeat bool `json:"heartbeat,omitempty"`
+	// SubagentType is the subagent type driving the tool, when the progress
+	// originates from a Task-tool subagent (sdk.d.ts v0.3.215).
+	SubagentType string `json:"subagent_type,omitempty"`
+	// SubagentRetry describes an in-flight subagent retry, when the progress
+	// frame marks a retry attempt. Nil otherwise (sdk.d.ts v0.3.215).
+	SubagentRetry *SubagentRetry `json:"subagent_retry,omitempty"`
+	UUID          string         `json:"uuid"`       // Message UUID
+	SessionID     string         `json:"session_id"` // Session ID
+}
+
+// SubagentRetry describes a subagent retry attempt reported on a
+// ToolProgressMessage (sdk.d.ts v0.3.215).
+type SubagentRetry struct {
+	AgentID       string `json:"agent_id"`
+	Attempt       int    `json:"attempt"`
+	MaxRetries    int    `json:"max_retries"`
+	RetryDelayMs  int    `json:"retry_delay_ms"`
+	ErrorStatus   *int   `json:"error_status"` // null for connection errors with no HTTP response
+	ErrorCategory string `json:"error_category"`
 }
 
 // MessageType implements Message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -1290,6 +1290,93 @@ func TestToolProgressMessageTaskIDRoundTrip(t *testing.T) {
 	})
 }
 
+func TestToolProgressMessageSubagentFieldsRoundTrip(t *testing.T) {
+	t.Run("with retry", func(t *testing.T) {
+		input := `{
+			"type": "tool_progress",
+			"tool_use_id": "toolu_child",
+			"tool_name": "Task",
+			"parent_tool_use_id": null,
+			"elapsed_time_seconds": 2.5,
+			"heartbeat": true,
+			"subagent_type": "code-reviewer",
+			"subagent_retry": {
+				"agent_id": "agent_7",
+				"attempt": 2,
+				"max_retries": 3,
+				"retry_delay_ms": 500,
+				"error_status": 529,
+				"error_category": "overloaded"
+			},
+			"uuid": "550e8400-e29b-41d4-a716-446655440037",
+			"session_id": "sess_top_123"
+		}`
+
+		parsed, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+		progressMsg, ok := parsed.(ToolProgressMessage)
+		require.True(t, ok, "expected ToolProgressMessage")
+		assert.True(t, progressMsg.Heartbeat)
+		assert.Equal(t, "code-reviewer", progressMsg.SubagentType)
+		require.NotNil(t, progressMsg.SubagentRetry)
+		assert.Equal(t, "agent_7", progressMsg.SubagentRetry.AgentID)
+		assert.Equal(t, 2, progressMsg.SubagentRetry.Attempt)
+		assert.Equal(t, 3, progressMsg.SubagentRetry.MaxRetries)
+		assert.Equal(t, 500, progressMsg.SubagentRetry.RetryDelayMs)
+		require.NotNil(t, progressMsg.SubagentRetry.ErrorStatus)
+		assert.Equal(t, 529, *progressMsg.SubagentRetry.ErrorStatus)
+		assert.Equal(t, "overloaded", progressMsg.SubagentRetry.ErrorCategory)
+	})
+
+	t.Run("connection error has null error_status", func(t *testing.T) {
+		input := `{
+			"type": "tool_progress",
+			"tool_use_id": "toolu_child",
+			"tool_name": "Task",
+			"parent_tool_use_id": null,
+			"elapsed_time_seconds": 2.5,
+			"subagent_retry": {
+				"agent_id": "agent_7",
+				"attempt": 1,
+				"max_retries": 3,
+				"retry_delay_ms": 500,
+				"error_status": null,
+				"error_category": "connection"
+			},
+			"uuid": "550e8400-e29b-41d4-a716-446655440038",
+			"session_id": "sess_top_123"
+		}`
+
+		parsed, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+		progressMsg, ok := parsed.(ToolProgressMessage)
+		require.True(t, ok, "expected ToolProgressMessage")
+		require.NotNil(t, progressMsg.SubagentRetry)
+		assert.Nil(t, progressMsg.SubagentRetry.ErrorStatus)
+		assert.Equal(t, "connection", progressMsg.SubagentRetry.ErrorCategory)
+	})
+
+	t.Run("subagent fields omitted", func(t *testing.T) {
+		msg := ToolProgressMessage{
+			Type:               "tool_progress",
+			ToolUseID:          "toolu_child",
+			ToolName:           "Bash",
+			ElapsedTimeSeconds: 1.0,
+			UUID:               "550e8400-e29b-41d4-a716-446655440039",
+			SessionID:          "sess_top_123",
+		}
+
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "heartbeat")
+		assert.NotContains(t, got, "subagent_type")
+		assert.NotContains(t, got, "subagent_retry")
+	})
+}
+
 func TestResultMessageFieldAdditionsRoundTrip(t *testing.T) {
 	stopReason := "stop_sequence"
 	msg := ResultMessage{


### PR DESCRIPTION
## What

TS SDK v0.3.215 adds three fields to `SDKToolProgressMessage`:

- **`heartbeat`** — this frame is a liveness heartbeat rather than a content-bearing progress update.
- **`subagent_type`** — the Task-tool subagent driving the tool.
- **`subagent_retry`** — an in-flight subagent retry: `{agent_id, attempt, max_retries, retry_delay_ms, error_status, error_category}`. `error_status` is `number | null` (null for connection errors with no HTTP response), modeled as `*int` to preserve the explicit null.

Adds the three fields on `ToolProgressMessage` plus a `SubagentRetry` struct.

## Tests

Added `TestToolProgressMessageSubagentFieldsRoundTrip` (retry with HTTP status, connection error with null status, and omitempty when absent).

Parity: TS SDK v0.3.215. Part of #167.