### PR TITLE
options: add v0.3.215 settings fields

### DIFF
--- a/options.go
+++ b/options.go
@@ -421,14 +421,19 @@ type Settings struct {
 	DisableAutoMode                   string                  `json:"disableAutoMode,omitempty"`
 	SSHConfigs                        []SettingsSSHConfig     `json:"sshConfigs,omitempty"`
 	// ClaudeMD is CLAUDE.md-style instructions injected as organization-managed memory. Honored only from managed / policy settings. Mirrors sdk.d.ts v0.3.150 L5343.
-	ClaudeMD              string   `json:"claudeMd,omitempty"`
-	ClaudeMDExcludes      []string `json:"claudeMdExcludes,omitempty"`
-	PluginTrustMessage    string   `json:"pluginTrustMessage,omitempty"`
-	Theme                 string   `json:"theme,omitempty"`
-	EditorMode            string   `json:"editorMode,omitempty"`
-	Verbose               *bool    `json:"verbose,omitempty"`
-	PreferredNotifChannel string   `json:"preferredNotifChannel,omitempty"`
-	AutoCompactEnabled    *bool    `json:"autoCompactEnabled,omitempty"`
+	ClaudeMD           string   `json:"claudeMd,omitempty"`
+	ClaudeMDExcludes   []string `json:"claudeMdExcludes,omitempty"`
+	PluginTrustMessage string   `json:"pluginTrustMessage,omitempty"`
+	Theme              string   `json:"theme,omitempty"`
+	EditorMode         string   `json:"editorMode,omitempty"`
+	// VimInsertModeRemaps holds vim INSERT-mode key-sequence remaps, e.g.
+	// {"jj": "<Esc>"}. Each key is exactly two printable characters typed in
+	// sequence; "<Esc>" (return to NORMAL mode) is the only supported target.
+	// Applies when EditorMode is "vim" (sdk.d.ts v0.3.215).
+	VimInsertModeRemaps   map[string]interface{} `json:"vimInsertModeRemaps,omitempty"`
+	Verbose               *bool                  `json:"verbose,omitempty"`
+	PreferredNotifChannel string                 `json:"preferredNotifChannel,omitempty"`
+	AutoCompactEnabled    *bool                  `json:"autoCompactEnabled,omitempty"`
 	// SwitchModelsOnFlag switches models automatically when safety measures flag a message. Mirrors sdk.d.ts v0.3.168 L5620.
 	SwitchModelsOnFlag         *bool `json:"switchModelsOnFlag,omitempty"`
 	AutoScrollEnabled          *bool `json:"autoScrollEnabled,omitempty"`
@@ -483,6 +488,19 @@ type Settings struct {
 	WheelScrollAccelerationEnabled *bool `json:"wheelScrollAccelerationEnabled,omitempty"`
 	// DisableClaudeAiConnectors, when true in any settings source, prevents claude.ai MCP cloud connectors from being auto-fetched or connected. Only gates auto-fetched connectors — a claudeai-proxy server passed explicitly (via --mcp-config or the SDK mcpServers option) still follows the normal MCP config trust flow. Any-source-true wins: a project can opt out, but a project-level false cannot override a user-level true. Mirrors sdk.d.ts v0.3.185 L4629.
 	DisableClaudeAiConnectors *bool `json:"disableClaudeAiConnectors,omitempty"`
+	// ProcessWrapper is the corporate launcher argv prefix for the
+	// background-agent supervisor, the sessions and workers it hosts, and the
+	// other covered background processes. Equivalent to the
+	// CLAUDE_CODE_PROCESS_WRAPPER environment variable, which takes precedence
+	// when set. Honored from managed settings, a --settings/SDK-supplied
+	// settings file, and user settings, in that precedence order; project and
+	// local settings are ignored (sdk.d.ts v0.3.215).
+	ProcessWrapper string `json:"processWrapper,omitempty"`
+	// FeedbackDrafts controls the model-drafted feedback tool (SendFeedback):
+	// "notify" (default) shows a one-line notice when a draft is queued,
+	// "quiet" shows only the footer counter, and "off" disables the tool
+	// entirely so drafts are never queued (sdk.d.ts v0.3.215).
+	FeedbackDrafts string `json:"feedbackDrafts,omitempty"`
 }
 
 // SettingsFooterLinkRegex is a footer-badge rule: when Pattern matches turn

--- a/options_test.go
+++ b/options_test.go
@@ -308,6 +308,30 @@ func TestSettingsManagedOrgFieldsJSON(t *testing.T) {
 		assert.Equal(t, "chat", out.DefaultView)
 	})
 
+	t.Run("v0.3.215 fields round-trip and omit when zero", func(t *testing.T) {
+		empty, err := json.Marshal(Settings{})
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(empty, &got))
+		assert.NotContains(t, got, "processWrapper")
+		assert.NotContains(t, got, "feedbackDrafts")
+		assert.NotContains(t, got, "vimInsertModeRemaps")
+
+		in := Settings{
+			ProcessWrapper:      "/usr/bin/corp-launch --",
+			FeedbackDrafts:      "quiet",
+			VimInsertModeRemaps: map[string]interface{}{"jj": "<Esc>"},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, "/usr/bin/corp-launch --", out.ProcessWrapper)
+		assert.Equal(t, "quiet", out.FeedbackDrafts)
+		assert.Equal(t, "<Esc>", out.VimInsertModeRemaps["jj"])
+	})
+
 	t.Run("all managed-org fields round-trip together", func(t *testing.T) {
 		v := true
 		timeout := 5000


### PR DESCRIPTION
## What

TS SDK v0.3.215 adds three `Settings` fields:

- **`processWrapper`** — corporate launcher argv prefix for the background-agent supervisor, the sessions/workers it hosts, and other covered background processes. Equivalent to `CLAUDE_CODE_PROCESS_WRAPPER` (env takes precedence). Honored from managed, `--settings`/SDK-supplied, and user settings, in that precedence order; project/local ignored.
- **`feedbackDrafts`** — `'notify'` (default) | `'quiet'` | `'off'`, controlling the model-drafted `SendFeedback` tool (`off` disables it entirely).
- **`vimInsertModeRemaps`** — vim INSERT-mode two-char key remaps to `<Esc>` (e.g. `{"jj": "<Esc>"}`); applies when `editorMode` is `"vim"`.

All `omitempty`, modeled as plain `string` / `map[string]interface{}` to match the surrounding Settings style.

## Tests

Added a round-trip + omitempty subtest for the three fields.

## Deferred (no struct change)

- `effortLevel: 'max'` session-scoped value and the `PartialSettings` conditional typing — `EffortLevel` is already a string alias, so `max` is representable without a change.

Parity: TS SDK v0.3.215. Part of #167.