### PR TITLE
Add Stream.SendSync + control-dispatch/init-race/tool-result-fidelity fixes

### DIFF
--- a/client.go
+++ b/client.go
@@ -149,8 +149,28 @@ func (c *Client) messagePump() {
 			continue
 		}
 		// Route control messages to protocol handler.
+		//
+		// CPN VENDOR PATCH B1 (design §9.2, review finding B1). A control
+		// REQUEST (can_use_tool / hook_callback) invokes the user's CanUseTool
+		// or hook callback INLINE inside HandleControlMessage. Those callbacks
+		// block for a CPN approval / stop-decision round-trip. Running them on
+		// this sole transport-reader goroutine froze ALL reads for the callback's
+		// full latency: output events, the terminal ResultMessage, and even a
+		// concurrent Interrupt's own control_response (also routed here) could
+		// not arrive. Dispatch control REQUESTS to a per-request goroutine so the
+		// pump keeps reading; the handler writes its own correlated response
+		// (transport.Write is mutex-serialized, so concurrent responses are
+		// safe). Control RESPONSES / cancels / keep-alives are fast, non-blocking
+		// channel deliveries with no user callback, so they stay inline to
+		// preserve their prompt, in-order handling.
 		if isControlMessage(msg) {
-			_ = c.protocol.HandleControlMessage(c.msgCtx, msg)
+			if isControlRequestMessage(msg) {
+				go func(m Message) {
+					_ = c.protocol.HandleControlMessage(c.msgCtx, m)
+				}(msg)
+			} else {
+				_ = c.protocol.HandleControlMessage(c.msgCtx, msg)
+			}
 			continue
 		}
 		// Send non-control messages to consumer channel.
@@ -559,6 +579,15 @@ func (c *Client) Close() error {
 	return nil
 }
 
+// Protocol exposes the session's protocol handler. CPN VENDOR PATCH M2 (design
+// §4.3, review finding M2): the never-drop FIFO needs a synchronous send whose
+// write error is observable at call time. Stream.Send enqueues to the cap-4
+// sendCh and handleSends swallows the write error, so a delivery to a dead CLI
+// returns nil and the loss is invisible. Protocol.SendMessage returns the
+// underlying transport.Write error directly; exposing the Protocol lets the
+// host use that path. Returns nil before Connect.
+func (c *Client) Protocol() *Protocol { return c.protocol }
+
 // ListSkills returns all loaded Skills (user + project).
 //
 // Skills are loaded during client creation based on SkillsConfig.
@@ -676,6 +705,29 @@ func (s *Stream) Send(ctx context.Context, prompt string) error {
 	case s.sendCh <- prompt:
 		return nil
 	}
+}
+
+// SendSync delivers a user message synchronously via Protocol.SendMessage and
+// returns the underlying transport write error. CPN VENDOR PATCH M2 (design
+// §4.3, review finding M2): unlike Send (async enqueue to the cap-4 sendCh,
+// whose real write error handleSends swallows), SendSync performs the protocol
+// write on the caller goroutine, so a write to a dead/closed CLI surfaces the
+// error at call time. This is the never-drop send path: the FIFO re-buffers at
+// head and raises AGENT_PROCESS_FAILED on this error. It builds the same
+// UserMessage shape handleSends uses.
+func (s *Stream) SendSync(ctx context.Context, prompt string) error {
+	userMsg := UserMessage{
+		Type:      "user",
+		SessionID: s.sessionID,
+		Message: APIUserMessage{
+			Role: "user",
+			Content: []UserContentBlock{
+				{Type: "text", Text: prompt},
+			},
+		},
+		ParentToolUseID: nil,
+	}
+	return s.client.protocol.SendMessage(ctx, userMsg)
 }
 
 // Messages returns an iterator over response messages.
@@ -1249,6 +1301,21 @@ func isControlMessage(msg Message) bool {
 	case ControlRequest, ControlResponse,
 		SDKControlRequest, SDKControlResponse, SDKControlCancelRequest,
 		KeepAliveMessage:
+		return true
+	default:
+		return false
+	}
+}
+
+// isControlRequestMessage reports whether msg is a control REQUEST from the CLI
+// whose handling (HandleControlMessage) may invoke a blocking user callback —
+// a permission (can_use_tool) or hook (hook_callback) request. CPN VENDOR PATCH
+// B1: these are the only control messages that must be dispatched OFF the
+// messagePump reader goroutine; responses/cancels/keep-alives are fast and stay
+// inline. See the patch note in messagePump above.
+func isControlRequestMessage(msg Message) bool {
+	switch msg.(type) {
+	case ControlRequest, SDKControlRequest:
 		return true
 	default:
 		return false

--- a/messages.go
+++ b/messages.go
@@ -41,6 +41,22 @@ type APIUserMessage struct {
 type UserContentBlock struct {
 	Type string `json:"type"`           // "text" or other types
 	Text string `json:"text,omitempty"` // Text content
+
+	// CPN VENDOR PATCH TOOLRESULT-FIDELITY (review finding CC-20). A "user" line
+	// from the CLI can carry a tool_result content block echoing a tool's output:
+	// {"type":"tool_result","tool_use_id":"…","content":…,"is_error":true}. The
+	// upstream struct modeled only Type+Text, so ParseMessage decoded — and any
+	// re-marshal (the agent-runner session host forwards each SDK message by
+	// re-serializing it) SILENTLY DROPPED content/is_error/tool_use_id. The
+	// driver's ClaudeToolResultEvent then surfaced empty Content and
+	// IsError=false. These fields (all omitempty, so text blocks and the
+	// send-side that only sets Type/Text marshal byte-identically) make the
+	// decode→re-marshal round trip lossless. Content is json.RawMessage because a
+	// tool_result content is either a JSON string or an array of blocks; verbatim
+	// bytes preserve both without a lossy typed decode.
+	ToolUseID string          `json:"tool_use_id,omitempty"` // tool_result -> originating tool_use
+	Content   json.RawMessage `json:"content,omitempty"`     // tool_result content (verbatim)
+	IsError   bool            `json:"is_error,omitempty"`    // tool_result error flag
 }
 
 // UserMessageReplay represents a replayed user message during session resume.

--- a/protocol.go
+++ b/protocol.go
@@ -123,15 +123,32 @@ func (p *Protocol) Initialize(ctx context.Context) error {
 		},
 	}
 
+	// CPN VENDOR PATCH INIT-RACE (issue #1494). Register the response waiter
+	// BEFORE writing the request. The CLI answers `initialize` immediately, so
+	// under the 2-core -race envelope messagePump can read that control_response
+	// and run handleSDKControlResponse (pendingReqs.LoadAndDelete) before this
+	// goroutine resumes to register the waiter. With the previous ordering
+	// (waitForSDKResponse registered AFTER the write) that fast response found no
+	// pending entry, was dropped, and Connect then blocked on ctx for the full
+	// init deadline — a ~40% flake reported as "initialization failed: context
+	// deadline exceeded". The Interrupt/Set* path (sendSDKControlRequest) already
+	// registers first with the same rationale; this makes init match it.
+	ch := make(chan SDKControlResponse, 1)
+	p.pendingReqs.Store(requestID, ch)
+
 	// Send request.
 	if err := p.transport.Write(ctx, req); err != nil {
+		p.pendingReqs.Delete(requestID)
 		return fmt.Errorf("failed to send initialize request: %w", err)
 	}
 
 	// Wait for response.
-	resp, err := p.waitForSDKResponse(ctx, requestID)
-	if err != nil {
-		return fmt.Errorf("initialization failed: %w", err)
+	var resp SDKControlResponse
+	select {
+	case <-ctx.Done():
+		p.pendingReqs.Delete(requestID)
+		return fmt.Errorf("initialization failed: %w", ctx.Err())
+	case resp = <-ch:
 	}
 
 	if resp.Response.Subtype == "error" {
@@ -1314,20 +1331,6 @@ func (p *Protocol) handleSDKControlResponse(resp SDKControlResponse) error {
 	}
 
 	return nil
-}
-
-// waitForSDKResponse waits for an SDK control response with the given request ID.
-func (p *Protocol) waitForSDKResponse(ctx context.Context, requestID string) (SDKControlResponse, error) {
-	ch := make(chan SDKControlResponse, 1)
-	p.pendingReqs.Store(requestID, ch)
-
-	select {
-	case <-ctx.Done():
-		p.pendingReqs.Delete(requestID)
-		return SDKControlResponse{}, ctx.Err()
-	case resp := <-ch:
-		return resp, nil
-	}
 }
 
 // nextRequestID generates a unique request ID.


### PR DESCRIPTION
Four related fixes needed by a downstream consumer (CPN) that were being carried as local patches on a vendored copy; upstreaming so a clean re-vendor keeps them.

**client.go**
- `Stream.SendSync(ctx, prompt)`: a synchronous send via `Protocol.SendMessage` that returns the underlying transport write error **at call time**. The async `Send` enqueues to a cap-4 channel and `handleSends` swallows the write error, so a delivery to a dead CLI returns nil and the loss is invisible. Consumers that need a never-drop send path (re-buffer + surface the error) need the synchronous variant.
- `Client.Protocol()` accessor exposing the protocol handler for that path.
- `messagePump` dispatches control **requests** (`can_use_tool` / `hook_callback`), whose handlers invoke blocking user callbacks, onto per-request goroutines so the sole transport-reader goroutine is not frozen for the callback full latency (which also stalled output events, the terminal ResultMessage, and a concurrent Interrupt own control_response). Fast responses/cancels/keep-alives stay inline. Adds `isControlRequestMessage`. `transport.Write` is mutex-serialized, so concurrent correlated responses are safe.

**protocol.go**
- `Connect` registers the `initialize` response waiter **before** writing the request, matching the existing `Interrupt`/`Set*` ordering, to close a race where the CLI immediate `control_response` was read and dropped before the waiter registered (observed as a ~40% `-race` init flake: "initialization failed: context deadline exceeded"). Removes the now-unused `waitForSDKResponse`.

**messages.go**
- `UserContentBlock` carries `tool_result` fields (`tool_use_id`, `content`, `is_error`, all `omitempty`) so a decode->re-marshal round trip of a `"user"` line carrying a `tool_result` block is lossless. Previously the struct modeled only Type+Text, so any re-serialization silently dropped `content`/`is_error`/`tool_use_id`. `content` is `json.RawMessage` because a tool_result content is either a JSON string or an array of blocks - verbatim bytes preserve both.

Builds and vets clean.