### PR TITLE
messages: add fast_mode_disabled_reason parity field

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -221,6 +221,9 @@ type ResultMessage struct {
 	TerminalReason    *TerminalReason    `json:"terminal_reason,omitempty"`    // Terminal completion reason
 	Origin            *MessageOrigin     `json:"origin,omitempty"`             // Originating actor for this result
 	FastModeState     *FastModeState     `json:"fast_mode_state,omitempty"`    // Fast mode state at completion
+	// FastModeDisabledReason explains why fast mode could not serve, when
+	// fast_mode_state is not "on". Absent when nothing blocks it.
+	FastModeDisabledReason *FastModeDisabledReason `json:"fast_mode_disabled_reason,omitempty"`
 }
 
 // MessageType implements Message.
@@ -643,6 +646,25 @@ const (
 	FastModeStateOn       FastModeState = "on"
 )
 
+// FastModeDisabledReason explains why fast mode cannot serve a request right
+// now. Absent when nothing blocks it (a request may still choose standard
+// speed). A paused-after-rate-limit run is not reported here; it rides
+// FastModeState as "cooldown". Mirrors sdk.d.ts v0.3.220 L633.
+type FastModeDisabledReason string
+
+const (
+	FastModeDisabledReasonFree               FastModeDisabledReason = "free"
+	FastModeDisabledReasonPreference         FastModeDisabledReason = "preference"
+	FastModeDisabledReasonExtraUsageDisabled FastModeDisabledReason = "extra_usage_disabled"
+	FastModeDisabledReasonNetworkError       FastModeDisabledReason = "network_error"
+	FastModeDisabledReasonUnknown            FastModeDisabledReason = "unknown"
+	FastModeDisabledReasonNotFirstParty      FastModeDisabledReason = "not_first_party"
+	FastModeDisabledReasonDisabledByEnv      FastModeDisabledReason = "disabled_by_env"
+	FastModeDisabledReasonModelNotAllowed    FastModeDisabledReason = "model_not_allowed"
+	FastModeDisabledReasonSDKOptInRequired   FastModeDisabledReason = "sdk_opt_in_required"
+	FastModeDisabledReasonPending            FastModeDisabledReason = "pending"
+)
+
 // RateLimitType identifies the quota window or overage bucket.
 type RateLimitType string
 
@@ -783,6 +805,9 @@ type SystemMessage struct {
 	Agents            []string        `json:"agents,omitempty"`          // Available agents
 	Betas             []string        `json:"betas,omitempty"`           // Enabled beta flags
 	FastModeState     *FastModeState  `json:"fast_mode_state,omitempty"` // Fast mode state
+	// FastModeDisabledReason explains why fast mode could not serve, when
+	// FastModeState is not "on". Absent when nothing blocks it.
+	FastModeDisabledReason *FastModeDisabledReason `json:"fast_mode_disabled_reason,omitempty"`
 	// Capabilities lists protocol capabilities this CLI supports, so consumers
 	// can feature-detect instead of version-sniffing. Open set — ignore unknown
 	// values and check each capability for exactly the behavior used.

--- a/messages_test.go
+++ b/messages_test.go
@@ -1405,6 +1405,54 @@ func TestResultMessageFieldAdditionsRoundTrip(t *testing.T) {
 	assert.Equal(t, FastModeStateCooldown, *decoded.FastModeState)
 }
 
+func TestFastModeDisabledReasonRoundTrip(t *testing.T) {
+	t.Run("result", func(t *testing.T) {
+		var decoded ResultMessage
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"type": "result",
+			"subtype": "success",
+			"session_id": "sess_1",
+			"fast_mode_state": "off",
+			"fast_mode_disabled_reason": "model_not_allowed"
+		}`), &decoded))
+		require.NotNil(t, decoded.FastModeDisabledReason)
+		assert.Equal(t, FastModeDisabledReasonModelNotAllowed, *decoded.FastModeDisabledReason)
+	})
+
+	t.Run("system", func(t *testing.T) {
+		var decoded SystemMessage
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"type": "system",
+			"subtype": "init",
+			"session_id": "sess_1",
+			"fast_mode_state": "off",
+			"fast_mode_disabled_reason": "sdk_opt_in_required"
+		}`), &decoded))
+		require.NotNil(t, decoded.FastModeDisabledReason)
+		assert.Equal(t, FastModeDisabledReasonSDKOptInRequired, *decoded.FastModeDisabledReason)
+	})
+
+	t.Run("initialize", func(t *testing.T) {
+		var decoded SDKControlInitializeResponse
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"commands": [], "agents": [], "output_style": "", "available_output_styles": [],
+			"models": [], "account": {}, "fast_mode_state": "off",
+			"fast_mode_disabled_reason": "extra_usage_disabled"
+		}`), &decoded))
+		assert.Equal(t, FastModeDisabledReasonExtraUsageDisabled, decoded.FastModeDisabledReason)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		var decoded ResultMessage
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"result","subtype":"success","session_id":"s"}`), &decoded))
+		assert.Nil(t, decoded.FastModeDisabledReason)
+
+		out, err := json.Marshal(ResultMessage{Type: "result", SessionID: "s"})
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "fast_mode_disabled_reason")
+	})
+}
+
 func TestResultMessageStopReasonNullRoundTrip(t *testing.T) {
 	msg := ResultMessage{
 		Type:       "result",

--- a/query_types.go
+++ b/query_types.go
@@ -36,6 +36,9 @@ type SDKControlInitializeResponse struct {
 	Models                []ModelInfo    `json:"models"`
 	Account               AccountInfo    `json:"account"`
 	FastModeState         string         `json:"fast_mode_state,omitempty"`
+	// FastModeDisabledReason explains why fast mode could not serve, when
+	// FastModeState is not "on". Absent when nothing blocks it.
+	FastModeDisabledReason FastModeDisabledReason `json:"fast_mode_disabled_reason,omitempty"`
 }
 
 // McpServerStatus reports the connection status of an MCP server.


### PR DESCRIPTION
Part of #178 (TS SDK v0.3.215 → v0.3.220). See `memory/catchup-v0.3.220/PLAN.md` §"PR 01".

## What

- New `FastModeDisabledReason` enum (`messages.go`) mirroring sdk.d.ts v0.3.220 L633 — the ten reasons fast mode can be unavailable (`free`, `preference`, `extra_usage_disabled`, `network_error`, `unknown`, `not_first_party`, `disabled_by_env`, `model_not_allowed`, `sdk_opt_in_required`, `pending`).
- Optional `fast_mode_disabled_reason` field added everywhere `fast_mode_state` already lives:
  - `ResultMessage` (SDKResultSuccess L4318 / SDKResultError L4284)
  - `SystemMessage` (SDKSystemMessage L4446)
  - `SDKControlInitializeResponse` (L3463)

## Why

Upstream reports *why* fast mode declined a turn alongside the on/off/cooldown state. Additive optional field — absent on older CLIs, omitempty on the wire.

## Tests

`TestFastModeDisabledReasonRoundTrip` — unmarshal on result/system/initialize plus an absent+omitempty assertion. `go test ./...`, `go vet ./...`, `gofmt -l` all clean.