### PR TITLE
query_types: add ModelInfo pricing fields

### DIFF
--- a/client_introspection_test.go
+++ b/client_introspection_test.go
@@ -109,6 +109,21 @@ func TestModelInfoResolvedModelRoundTrip(t *testing.T) {
 	assert.NotContains(t, string(out), "resolvedModel")
 }
 
+func TestModelInfoPricingFieldsRoundTrip(t *testing.T) {
+	raw := []byte(`{"value":"opus","displayName":"Opus","description":"deep","canonicalModel":"claude-opus-4-7","provider":"anthropicGoogleCloud"}`)
+
+	var info ModelInfo
+	require.NoError(t, json.Unmarshal(raw, &info))
+	assert.Equal(t, "claude-opus-4-7", info.CanonicalModel)
+	assert.Equal(t, "anthropicGoogleCloud", info.Provider)
+
+	// Both are omitempty: rows without pricing metadata drop them.
+	out, err := json.Marshal(ModelInfo{Value: "sonnet", DisplayName: "Sonnet", Description: "balanced"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "canonicalModel")
+	assert.NotContains(t, string(out), "provider")
+}
+
 func TestStreamSupportedAgentsReadsCachedInit(t *testing.T) {
 	stream, _, protocol := newStreamControlTest(nil)
 	storeInitResponse(protocol, canonicalInitResponse())

--- a/query_types.go
+++ b/query_types.go
@@ -18,6 +18,14 @@ type ModelInfo struct {
 	// persisted explicit id against the alias row that covers it. Present
 	// only for alias rows (sdk.d.ts v0.3.201).
 	ResolvedModel string `json:"resolvedModel,omitempty"`
+	// CanonicalModel is the canonical model id used for the pricing lookup
+	// (e.g. "claude-opus-4-7"). May differ from the raw Value this row is
+	// keyed by (provider-specific ids, aliases). sdk.d.ts v0.3.220 L1274.
+	CanonicalModel string `json:"canonicalModel,omitempty"`
+	// Provider is the API provider that served this model: one of
+	// "firstParty", "bedrock", "vertex", "foundry", "anthropicAws",
+	// "anthropicGoogleCloud", "mantle", "gateway". sdk.d.ts v0.3.220 L1278.
+	Provider string `json:"provider,omitempty"`
 }
 
 // AgentInfo describes a subagent available to the Task tool.


### PR DESCRIPTION
Part of #178 (TS SDK v0.3.215 → v0.3.220). See `memory/catchup-v0.3.220/PLAN.md` §"PR 02".

## What
`ModelInfo` gains two optional fields from sdk.d.ts v0.3.220 L1274-1281:
- `canonicalModel` — canonical model id used for the pricing lookup (e.g. `claude-opus-4-7`); may differ from the raw `value` this row is keyed by.
- `provider` — API provider that served the model (`firstParty`, `bedrock`, `vertex`, `foundry`, `anthropicAws`, `anthropicGoogleCloud`, `mantle`, `gateway`).

Both `omitempty`; additive.

## Tests
`TestModelInfoPricingFieldsRoundTrip` — decode + omitempty assertions. `go test ./...`, `go vet`, `gofmt -l` clean.