### PR TITLE
messages: add peer origin session + verified pid

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -257,6 +257,20 @@ type MessageOrigin struct {
 	// SenderTaskID is the observer's task id; set only for the
 	// "observer" kind (sdk.d.ts v0.3.201).
 	SenderTaskID string `json:"senderTaskId,omitempty"`
+	// FromSession is the sender's host-openable session id (the envelope's
+	// from-session attribute), set by the sender's host so a receiving UI can
+	// link this message back to the sending session. Sender-asserted like
+	// From: a navigation target only, never authority. Set only for the
+	// "peer" kind; absent when the sender's host provides none and on messages
+	// from older senders (sdk.d.ts v0.3.220 L4039).
+	FromSession string `json:"fromSession,omitempty"`
+	// VerifiedPeerPid is the kernel-verified pid of the process that connected
+	// to this session's cross-session messaging socket (SO_PEERCRED /
+	// LOCAL_PEERPID) — never read from the payload. Key sender identity on
+	// this, never on From, which is sender-authored and forgeable. Absent when
+	// unverifiable (Windows, non-UDS ingress); pids are recyclable, so treat
+	// it as provenance, not an authentication token (sdk.d.ts v0.3.220 L4052).
+	VerifiedPeerPid *int `json:"verifiedPeerPid,omitempty"`
 	// Body is the decoded message body with the peer envelope stripped —
 	// byte-exact with what the model sees. Set only for the "peer" kind, and
 	// only when the turn is exactly one harness-formed envelope; render it

--- a/messages_test.go
+++ b/messages_test.go
@@ -685,7 +685,9 @@ func TestParseMessageResultMessageOriginPeer(t *testing.T) {
 			"kind": "peer",
 			"from": "agent-42",
 			"name": "reviewer",
-			"body": "please take a look"
+			"body": "please take a look",
+			"fromSession": "local_abc",
+			"verifiedPeerPid": 4242
 		}
 	}`)
 
@@ -699,6 +701,15 @@ func TestParseMessageResultMessageOriginPeer(t *testing.T) {
 	assert.Equal(t, "agent-42", resultMsg.Origin.From)
 	assert.Equal(t, "reviewer", resultMsg.Origin.Name)
 	assert.Equal(t, "please take a look", resultMsg.Origin.Body)
+	assert.Equal(t, "local_abc", resultMsg.Origin.FromSession)
+	require.NotNil(t, resultMsg.Origin.VerifiedPeerPid)
+	assert.Equal(t, 4242, *resultMsg.Origin.VerifiedPeerPid)
+
+	// Both are omitempty; a peer origin without them stays lean on the wire.
+	out, err := json.Marshal(MessageOrigin{Kind: MessageOriginKindPeer, From: "a"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "fromSession")
+	assert.NotContains(t, string(out), "verifiedPeerPid")
 }
 
 func TestParseMessageResultMessageOriginHuman(t *testing.T) {


### PR DESCRIPTION
Part of #178 (TS SDK v0.3.215 → v0.3.220). See `memory/catchup-v0.3.220/PLAN.md` §"PR 03".

## What
`MessageOrigin` (peer variant) gains two optional fields from sdk.d.ts v0.3.220:
- `fromSession` (L4039) — the sender's host-openable session id from the envelope's `from-session` attribute. Sender-asserted like `from`: a navigation target for a receiving UI, never authority.
- `verifiedPeerPid` (L4052) — kernel-verified pid of the process that connected to the cross-session messaging socket (`SO_PEERCRED` / `LOCAL_PEERPID`), read from the connection, never the payload. This is the field to key sender identity on; `from` is sender-authored and forgeable. Modeled as `*int` (absent when unverifiable — Windows / non-UDS ingress).

## Tests
Extended `TestParseMessageResultMessageOriginPeer` to assert both fields decode and are omitempty. `go test ./...`, `go vet`, `gofmt -l` clean.