### PR TITLE
messages: add result user message uuid + request wall time

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -204,6 +204,8 @@ type ResultMessage struct {
 	*/
 	TTFTStreamMs             *int64 `json:"ttft_stream_ms,omitempty"`                // Streaming time-to-first-token in milliseconds
 	TimeToRequestMs          *int64 `json:"time_to_request_ms,omitempty"`            // Time to request in milliseconds
+	UserMessageUUID          string `json:"user_message_uuid,omitempty"`             // UUID of the user message that drove this turn (success only; sdk.d.ts v0.3.220 L4300)
+	RequestSentWallMs        *int64 `json:"request_sent_wall_ms,omitempty"`          // Wall-clock time the request was sent, ms since epoch (success only; sdk.d.ts v0.3.220 L4301)
 	TimeToRequestFromSpawnMs *int64 `json:"time_to_request_from_spawn_ms,omitempty"` // Time to request from spawn in milliseconds
 	WarmSpareClaimed         *bool  `json:"warm_spare_claimed,omitempty"`            // Whether a warm spare was claimed
 	TimeOriginMs             *int64 `json:"time_origin_ms,omitempty"`                // Wall-clock origin for the above timings, in milliseconds (success only)

--- a/messages_test.go
+++ b/messages_test.go
@@ -1391,16 +1391,18 @@ func TestToolProgressMessageSubagentFieldsRoundTrip(t *testing.T) {
 func TestResultMessageFieldAdditionsRoundTrip(t *testing.T) {
 	stopReason := "stop_sequence"
 	msg := ResultMessage{
-		Type:             "result",
-		Status:           "success",
-		Subtype:          "success",
-		UUID:             "550e8400-e29b-41d4-a716-446655440040",
-		SessionID:        "sess_result_123",
-		Result:           "done",
-		StructuredOutput: map[string]interface{}{"ok": true},
-		StopReason:       &stopReason,
-		TerminalReason:   terminalReasonPtr(TerminalReasonHookStopped),
-		FastModeState:    fastModeStatePtr(FastModeStateCooldown),
+		Type:              "result",
+		Status:            "success",
+		Subtype:           "success",
+		UUID:              "550e8400-e29b-41d4-a716-446655440040",
+		SessionID:         "sess_result_123",
+		Result:            "done",
+		StructuredOutput:  map[string]interface{}{"ok": true},
+		StopReason:        &stopReason,
+		TerminalReason:    terminalReasonPtr(TerminalReasonHookStopped),
+		FastModeState:     fastModeStatePtr(FastModeStateCooldown),
+		UserMessageUUID:   "550e8400-e29b-41d4-a716-446655440099",
+		RequestSentWallMs: int64Ptr(1753632000000),
 	}
 
 	data, err := json.Marshal(msg)
@@ -1414,6 +1416,15 @@ func TestResultMessageFieldAdditionsRoundTrip(t *testing.T) {
 	assert.Equal(t, TerminalReasonHookStopped, *decoded.TerminalReason)
 	require.NotNil(t, decoded.FastModeState)
 	assert.Equal(t, FastModeStateCooldown, *decoded.FastModeState)
+	assert.Equal(t, "550e8400-e29b-41d4-a716-446655440099", decoded.UserMessageUUID)
+	require.NotNil(t, decoded.RequestSentWallMs)
+	assert.Equal(t, int64(1753632000000), *decoded.RequestSentWallMs)
+
+	// Both are omitempty; a result without them stays lean on the wire.
+	out, err := json.Marshal(ResultMessage{Type: "result", SessionID: "s"})
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "user_message_uuid")
+	assert.NotContains(t, string(out), "request_sent_wall_ms")
 }
 
 func TestFastModeDisabledReasonRoundTrip(t *testing.T) {


### PR DESCRIPTION
Part of #178 (TS SDK v0.3.215 → v0.3.220). See `memory/catchup-v0.3.220/PLAN.md` §"PR 04".

## What
`ResultMessage` gains two optional success-result fields from sdk.d.ts v0.3.220 `SDKResultSuccess`:
- `user_message_uuid` (L4300) — uuid of the user message that drove this turn.
- `request_sent_wall_ms` (L4301) — wall-clock time the request was sent, ms since epoch (`*int64`).

Both `omitempty`; additive.

## Tests
Extended `TestResultMessageFieldAdditionsRoundTrip` to round-trip both and assert omitempty. `go test ./...`, `go vet`, `gofmt -l` clean.