### PR TITLE
query_types: add RewindFilesResult skippedLinks

### DIFF
--- a/client_file_plugin_control_test.go
+++ b/client_file_plugin_control_test.go
@@ -29,6 +29,7 @@ func TestStreamRewindFilesNoOpts(t *testing.T) {
 				"canRewind":    true,
 				"filesChanged": []interface{}{"a", "b"},
 				"insertions":   float64(3),
+				"skippedLinks": float64(2),
 			}),
 		)
 
@@ -43,6 +44,7 @@ func TestStreamRewindFilesNoOpts(t *testing.T) {
 		assert.True(t, got.CanRewind)
 		assert.Equal(t, []string{"a", "b"}, got.FilesChanged)
 		assert.Equal(t, 3, got.Insertions)
+		assert.Equal(t, 2, got.SkippedLinks)
 
 		assert.JSONEq(t,
 			`{"type":"control_request","request_id":"req_1","request":{"subtype":"rewind_files","user_message_id":"user-msg-1"}}`,

--- a/query_types.go
+++ b/query_types.go
@@ -95,6 +95,13 @@ type RewindFilesResult struct {
 	FilesChanged []string `json:"filesChanged,omitempty"`
 	Insertions   int      `json:"insertions,omitempty"`
 	Deletions    int      `json:"deletions,omitempty"`
+	// SkippedLinks counts tracked files NOT restored or deleted because a
+	// symlink, hard link, or other non-regular file was detected at the tracked
+	// path (or its parent no longer resolves where it pointed at checkpoint
+	// time, or its backup could not be safely read). Populated only by a real
+	// (non-dryRun) rewind; absent or 0 means no link-safety refusals occurred.
+	// sdk.d.ts v0.3.220 L2699.
+	SkippedLinks int `json:"skippedLinks,omitempty"`
 }
 
 // ReadFileOptions controls Stream.ReadFile.


### PR DESCRIPTION
Part of #178 (TS SDK v0.3.215 → v0.3.220). See `memory/catchup-v0.3.220/PLAN.md` §"PR 05".

## What
`RewindFilesResult` gains `skippedLinks` (sdk.d.ts v0.3.220 L2699) — count of tracked files not restored or deleted because a symlink, hard link, or other non-regular file was detected at the tracked path (or its parent no longer resolves where it pointed at checkpoint time, or its backup could not be safely read). Populated only by a real (non-dryRun) rewind. Optional/omitempty.

## Tests
Extended `TestStreamRewindFilesNoOpts/success` to decode `skippedLinks`. `go test ./...`, `go vet`, `gofmt -l` clean.