### PR TITLE
options: add DirectoryAdded hook event

### DIFF
--- a/options.go
+++ b/options.go
@@ -1587,6 +1587,11 @@ const (
 	// HookTypeCwdChanged fires when the current working directory changes.
 	HookTypeCwdChanged HookType = "CwdChanged"
 
+	// HookTypeDirectoryAdded fires when a directory is added as a
+	// working-directory root (via /add-dir or the register_repo_root control
+	// request).
+	HookTypeDirectoryAdded HookType = "DirectoryAdded"
+
 	// HookTypeFileChanged fires when a watched file changes.
 	HookTypeFileChanged HookType = "FileChanged"
 
@@ -1984,6 +1989,24 @@ func (CwdChangedInput) HookType() HookType { return HookTypeCwdChanged }
 
 // Base implements HookInput.
 func (i CwdChangedInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// DirectoryAddedInput contains data for DirectoryAdded hooks. It fires when a
+// directory is registered as a working-directory root. Mirrors
+// DirectoryAddedHookInput in sdk.d.ts v0.3.220 L532.
+type DirectoryAddedInput struct {
+	BaseHookInput
+	// Directory is the absolute path of the directory that was added.
+	Directory string `json:"directory"`
+	// Source is how the directory was added: "slash_command" for /add-dir,
+	// "register_repo_root" for the SDK control_request.
+	Source string `json:"source"`
+}
+
+// HookType implements HookInput.
+func (DirectoryAddedInput) HookType() HookType { return HookTypeDirectoryAdded }
+
+// Base implements HookInput.
+func (i DirectoryAddedInput) Base() BaseHookInput { return i.BaseHookInput }
 
 // FileChangedInput contains data for FileChanged hooks.
 type FileChangedInput struct {

--- a/protocol.go
+++ b/protocol.go
@@ -611,6 +611,12 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 			OldCwd:        getString(inputData, "old_cwd"),
 			NewCwd:        getString(inputData, "new_cwd"),
 		}
+	case HookTypeDirectoryAdded:
+		input = DirectoryAddedInput{
+			BaseHookInput: base,
+			Directory:     getString(inputData, "directory"),
+			Source:        getString(inputData, "source"),
+		}
 	case HookTypeFileChanged:
 		input = FileChangedInput{
 			BaseHookInput: base,
@@ -1121,6 +1127,12 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 			BaseHookInput: base,
 			OldCwd:        getString(hookInput, "old_cwd"),
 			NewCwd:        getString(hookInput, "new_cwd"),
+		}
+	case "DirectoryAdded":
+		input = DirectoryAddedInput{
+			BaseHookInput: base,
+			Directory:     getString(hookInput, "directory"),
+			Source:        getString(hookInput, "source"),
 		}
 	case "FileChanged":
 		input = FileChangedInput{

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -4033,6 +4033,57 @@ func TestHandleHookCallback_RetryWatchPathsEvents(t *testing.T) {
 		assert.Equal(t, "success", resp.Response.Subtype)
 	})
 
+	t.Run("DirectoryAdded via legacy path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(DirectoryAddedInput)
+			require.True(t, ok)
+			assert.Equal(t, "/repo/sub", ev.Directory)
+			assert.Equal(t, "slash_command", ev.Source)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+			RequestID: "r",
+			Payload: map[string]interface{}{
+				"callback_id": "h",
+				"input": map[string]interface{}{
+					"hook_event": "DirectoryAdded",
+					"directory":  "/repo/sub",
+					"source":     "slash_command",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
+	t.Run("DirectoryAdded via SDK path", func(t *testing.T) {
+		runner := NewMockSubprocessRunner()
+		opts := NewOptions()
+		protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+		protocol.hookCallbacks["h"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+			ev, ok := input.(DirectoryAddedInput)
+			require.True(t, ok)
+			assert.Equal(t, "/repo/sub", ev.Directory)
+			assert.Equal(t, "register_repo_root", ev.Source)
+			return HookResult{Continue: true}, nil
+		}
+		resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+			RequestID: "r",
+			Request: SDKControlRequestBody{
+				Subtype:    "hook_callback",
+				CallbackID: "h",
+				Input: map[string]interface{}{
+					"hook_event_name": "DirectoryAdded",
+					"directory":       "/repo/sub",
+					"source":          "register_repo_root",
+				},
+			},
+		})
+		assert.Equal(t, "success", resp.Response.Subtype)
+	})
+
 	t.Run("PermissionDenied via legacy path", func(t *testing.T) {
 		runner := NewMockSubprocessRunner()
 		opts := NewOptions()


### PR DESCRIPTION
Part of #178 (TS SDK v0.3.215 → v0.3.220). See `memory/catchup-v0.3.220/PLAN.md` §"PR 06".

## What
New `DirectoryAdded` hook event (sdk.d.ts v0.3.220 L532, added to `HOOK_EVENTS`/`HookEvent`/`HookInput`). Fires when a directory is registered as a working-directory root — via `/add-dir` (`source: "slash_command"`) or the `register_repo_root` control request (`source: "register_repo_root"`).

- `HookTypeDirectoryAdded` constant.
- `DirectoryAddedInput{ Directory, Source }`.
- Wired into **both** `protocol.go` hook-input builders — the legacy (`handleHookCallback`) and SDK (`handleSDKHookCallback`) paths. A case added to only one builder silently never fires.

## Tests
`TestHandleHookCallback_RetryWatchPathsEvents` extended with `DirectoryAdded` sub-tests exercising both builders. No integration test: like the sibling watch-path hooks (`CwdChanged`/`FileChanged`/`WorktreeCreate`), this session/filesystem event isn't deterministically triggerable in the integration harness — repo precedent is unit-only. `go test ./...`, `go vet`, `gofmt -l` clean.