### PR TITLE
client: add interrupt cancel_queued support

### DIFF
--- a/client.go
+++ b/client.go
@@ -771,7 +771,16 @@ type InterruptReceipt struct {
 	// interrupt: queued commands plus any batch already dequeued for the
 	// imminent turn but not yet reachable by the abort. They will run unless
 	// cancelled first. Empty on older CLIs, which do not report a receipt.
+	// Always empty when the interrupt requested cancel_queued (see
+	// InterruptCancelQueued) — the survivors move to Cancelled instead.
 	StillQueued []string `json:"still_queued"`
+	// Cancelled is populated only when the interrupt set cancel_queued:true
+	// (InterruptCancelQueued) on a CLI advertising "interrupt_cancel_queued_v1":
+	// the uuids of main-thread commands cancelled by this interrupt — every
+	// survivor that would otherwise have appeared in StillQueued. Each emitted a
+	// terminal "cancelled" lifecycle and none will run. Absent on a plain
+	// interrupt and on older CLIs.
+	Cancelled []string `json:"cancelled,omitempty"`
 }
 
 // InterruptWithReceipt sends an interrupt and returns its receipt. It blocks
@@ -782,9 +791,29 @@ type InterruptReceipt struct {
 // cancelled first. Older CLIs report no receipt, so the receipt is non-nil with
 // an empty StillQueued.
 func (s *Stream) InterruptWithReceipt(ctx context.Context) (*InterruptReceipt, error) {
-	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
-		Subtype: "interrupt",
-	})
+	return s.interrupt(ctx, false)
+}
+
+// InterruptCancelQueued sends an interrupt that also cancels every uuid-stamped
+// main-thread command still queued or pending dispatch for the imminent turn,
+// rather than leaving them to run after the abort. The cancelled uuids are
+// returned in the receipt's Cancelled field and StillQueued is always empty.
+//
+// This is the "Stop means stop everything" behavior a remote UI's Stop button
+// wants: one round-trip halts the running turn and drops the queue. It requires
+// a CLI advertising the "interrupt_cancel_queued_v1" capability (see
+// SystemMessage.Capabilities); older CLIs ignore the flag and behave like
+// InterruptWithReceipt, leaving queued commands to run.
+func (s *Stream) InterruptCancelQueued(ctx context.Context) (*InterruptReceipt, error) {
+	return s.interrupt(ctx, true)
+}
+
+func (s *Stream) interrupt(ctx context.Context, cancelQueued bool) (*InterruptReceipt, error) {
+	body := SDKControlRequestBody{Subtype: "interrupt"}
+	if cancelQueued {
+		body.CancelQueued = &cancelQueued
+	}
+	resp, err := s.sendSDKControlRequest(ctx, body)
 	if err != nil {
 		return nil, err
 	}

--- a/messages.go
+++ b/messages.go
@@ -440,6 +440,7 @@ type SDKControlRequestBody struct {
 	ReloadSkills           *bool                               `json:"reload_skills,omitempty"`          // For register_repo_root
 	UserMessageID          string                              `json:"user_message_id,omitempty"`        // For rewind_files
 	DryRun                 *bool                               `json:"dry_run,omitempty"`                // For rewind_files
+	CancelQueued           *bool                               `json:"cancel_queued,omitempty"`          // For interrupt (interrupt_cancel_queued_v1)
 	Path                   string                              `json:"path,omitempty"`                   // For read_file/seed_read_state
 	MaxBytes               *int                                `json:"max_bytes,omitempty"`              // For read_file
 	Encoding               string                              `json:"encoding,omitempty"`               // For read_file ("utf-8"|"base64")
@@ -828,7 +829,10 @@ type SystemMessage struct {
 	// can feature-detect instead of version-sniffing. Open set — ignore unknown
 	// values and check each capability for exactly the behavior used.
 	// "interrupt_receipt_v1" means the interrupt control response carries
-	// still_queued. Absent on older CLIs.
+	// still_queued. "interrupt_cancel_queued_v1" means the interrupt honors
+	// cancel_queued:true — queued and pending-dispatch commands are cancelled
+	// alongside the abort and listed on the response's cancelled field (see
+	// Stream.InterruptCancelQueued). Absent on older CLIs.
 	Capabilities []string `json:"capabilities,omitempty"`
 }
 

--- a/stream_control_test.go
+++ b/stream_control_test.go
@@ -184,6 +184,8 @@ func TestStreamInterruptSendsControlRequest(t *testing.T) {
 	assert.NotContains(t, body, "mode")
 	assert.NotContains(t, body, "model")
 	assert.NotContains(t, body, "max_thinking_tokens")
+	// A plain interrupt must not set cancel_queued.
+	assert.NotContains(t, body, "cancel_queued")
 }
 
 func TestStreamInterruptWithReceiptStillQueued(t *testing.T) {
@@ -211,6 +213,29 @@ func TestStreamInterruptWithReceiptOlderCLI(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, receipt)
 	assert.Empty(t, receipt.StillQueued)
+}
+
+func TestStreamInterruptCancelQueued(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{
+			"still_queued": []string{},
+			"cancelled":    []string{"uuid-a", "uuid-b"},
+		}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	receipt, err := stream.InterruptCancelQueued(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, receipt)
+	assert.Empty(t, receipt.StillQueued)
+	assert.Equal(t, []string{"uuid-a", "uuid-b"}, receipt.Cancelled)
+
+	// cancel_queued:true must be on the wire.
+	_, generic := decodeWrittenSDKControlRequest(t, transport)
+	body := genericRequestBody(t, generic)
+	assert.Equal(t, "interrupt", body["subtype"])
+	assert.Equal(t, true, body["cancel_queued"])
 }
 
 func TestStreamSetPermissionModeSendsModeField(t *testing.T) {


### PR DESCRIPTION
Part of #178 (TS SDK v0.3.215 → v0.3.220). See `memory/catchup-v0.3.220/PLAN.md` §"PR 07".

## What
TS SDK v0.3.220 extends the interrupt control request/response:
- request `cancel_queued?: boolean` (sdk.d.ts L3479) — also cancel every uuid-stamped main-thread command still queued or pending dispatch, rather than leaving them to run after the abort.
- response `cancelled?: string[]` (L3490) — the uuids so cancelled; `still_queued` is then always empty.
- capability `interrupt_cancel_queued_v1` — gates the behavior; older CLIs ignore the flag.

New surface:
- `Stream.InterruptCancelQueued(ctx)` — sends the interrupt with `cancel_queued:true`. "Stop means stop everything" for a remote UI's Stop button.
- `InterruptReceipt.Cancelled []string`.
- `SDKControlRequestBody.CancelQueued` + capability doc on `SystemMessage.Capabilities`.

`InterruptWithReceipt` keeps its existing leave-queued semantics.

## Tests
`TestStreamInterruptCancelQueued` (wire flag + `cancelled` decode + empty `still_queued`); `TestStreamInterruptSendsControlRequest` now asserts a plain interrupt omits `cancel_queued`. No integration test — interrupt (like `InterruptWithReceipt`/`still_queued` in v0.3.207) needs an in-flight turn plus queued async messages, not deterministically reproducible in the harness; repo precedent is unit-only. `go test ./...`, `go vet`, `gofmt -l` clean.