### PR TITLE
options: add sandbox strictAllowlist and filesystem disabled

### DIFF
--- a/options.go
+++ b/options.go
@@ -844,6 +844,12 @@ type SettingsSandboxNetwork struct {
 	AllowMachLookup         []string `json:"allowMachLookup,omitempty"`
 	HTTPProxyPort           *int     `json:"httpProxyPort,omitempty"`
 	SocksProxyPort          *int     `json:"socksProxyPort,omitempty"`
+	// StrictAllowlist, when true, makes the sandbox runtime deterministically
+	// deny hosts not in AllowedDomains instead of prompting. Enforced for
+	// sandboxed commands only — in-process tools such as WebFetch are not gated.
+	// Honored only from user, managed/policy, or CLI (--settings) settings;
+	// project settings are ignored. Mirrors sdk.d.ts v0.3.220 L6154.
+	StrictAllowlist *bool `json:"strictAllowlist,omitempty"`
 	// TLSTerminate enables in-process TLS termination so the per-request
 	// filter can inspect HTTPS request bodies. Provide a CA cert+key, or
 	// leave both empty so sandbox-runtime generates an ephemeral pair for
@@ -857,6 +863,14 @@ type SettingsSandboxFilesystem struct {
 	DenyRead                  []string `json:"denyRead,omitempty"`
 	AllowRead                 []string `json:"allowRead,omitempty"`
 	AllowManagedReadPathsOnly *bool    `json:"allowManagedReadPathsOnly,omitempty"`
+	// Disabled (macOS and Linux/WSL only), when true, skips filesystem
+	// isolation entirely while keeping network and seccomp isolation — sandboxed
+	// commands get unrestricted host filesystem access; egress stays confined to
+	// network.allowedDomains. Ignored on native Windows. Intended for egress-
+	// control deployments. Honored only from user, managed/policy, or CLI
+	// (--settings) settings; project settings are ignored. Mirrors sdk.d.ts
+	// v0.3.220 L6205.
+	Disabled *bool `json:"disabled,omitempty"`
 }
 
 type SettingsSandboxRipgrep struct {

--- a/options_test.go
+++ b/options_test.go
@@ -699,6 +699,35 @@ func TestSettingsSandboxFieldsJSON(t *testing.T) {
 		assert.Equal(t, "/etc/claude/ca.key", out.Sandbox.Network.TLSTerminate.CAKeyPath)
 	})
 
+	t.Run("network strictAllowlist and filesystem disabled round-trip", func(t *testing.T) {
+		trueVal := true
+		in := Settings{
+			Sandbox: &SettingsSandbox{
+				Network:    &SettingsSandboxNetwork{StrictAllowlist: &trueVal},
+				Filesystem: &SettingsSandboxFilesystem{Disabled: &trueVal},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"strictAllowlist":true`)
+		assert.Contains(t, string(data), `"disabled":true`)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.NotNil(t, out.Sandbox.Network.StrictAllowlist)
+		assert.True(t, *out.Sandbox.Network.StrictAllowlist)
+		require.NotNil(t, out.Sandbox.Filesystem.Disabled)
+		assert.True(t, *out.Sandbox.Filesystem.Disabled)
+
+		// Both omitempty when unset.
+		bare, err := json.Marshal(Settings{Sandbox: &SettingsSandbox{
+			Network: &SettingsSandboxNetwork{}, Filesystem: &SettingsSandboxFilesystem{},
+		}})
+		require.NoError(t, err)
+		assert.NotContains(t, string(bare), "strictAllowlist")
+		assert.NotContains(t, string(bare), "disabled")
+	})
+
 	t.Run("credentials round-trip files and envVars", func(t *testing.T) {
 		in := Settings{
 			Sandbox: &SettingsSandbox{


### PR DESCRIPTION
Part of #178 (TS SDK v0.3.215 → v0.3.220). See `memory/catchup-v0.3.220/PLAN.md` §"PR 08".

## What
Two optional sandbox settings from sdk.d.ts v0.3.220:
- `SettingsSandboxNetwork.strictAllowlist` (L6154) — sandbox runtime deterministically denies hosts not in `allowedDomains` instead of prompting. Sandboxed commands only (in-process tools like WebFetch aren't gated).
- `SettingsSandboxFilesystem.disabled` (L6205) — macOS/Linux/WSL only: skip filesystem isolation while keeping network + seccomp isolation. For egress-control deployments; ignored on native Windows.

Both honored only from user/managed/CLI settings (not project settings). `*bool`, omitempty.

## Tests
Added a subtest to `TestSettingsSandboxFieldsJSON` round-tripping both fields and asserting omitempty. `go test ./...`, `go vet`, `gofmt -l` clean.