### PR TITLE
options: add v0.3.220 settings parity fields

### DIFF
--- a/options.go
+++ b/options.go
@@ -434,6 +434,10 @@ type Settings struct {
 	Verbose               *bool                  `json:"verbose,omitempty"`
 	PreferredNotifChannel string                 `json:"preferredNotifChannel,omitempty"`
 	AutoCompactEnabled    *bool                  `json:"autoCompactEnabled,omitempty"`
+	// PrecomputeCompactionEnabled precomputes the compaction summary in the
+	// background before it is needed. Only applies when auto-compact is on.
+	// Mirrors sdk.d.ts v0.3.220 L6545.
+	PrecomputeCompactionEnabled *bool `json:"precomputeCompactionEnabled,omitempty"`
 	// SwitchModelsOnFlag switches models automatically when safety measures flag a message. Mirrors sdk.d.ts v0.3.168 L5620.
 	SwitchModelsOnFlag         *bool `json:"switchModelsOnFlag,omitempty"`
 	AutoScrollEnabled          *bool `json:"autoScrollEnabled,omitempty"`
@@ -442,6 +446,18 @@ type Settings struct {
 	ShowMessageTimestamps      *bool `json:"showMessageTimestamps,omitempty"`
 	TerminalProgressBarEnabled *bool `json:"terminalProgressBarEnabled,omitempty"`
 	TodoFeatureEnabled         *bool `json:"todoFeatureEnabled,omitempty"`
+	// WorkflowSizeGuideline is the advisory size guideline for the dynamic
+	// workflows Claude writes: "small" (<5 agents), "medium" (<15, the
+	// default), "large" (<50), or "unrestricted" (no guideline). A value here
+	// takes precedence over the /config choice. Mirrors sdk.d.ts v0.3.220 L5396.
+	WorkflowSizeGuideline string `json:"workflowSizeGuideline,omitempty"`
+	// EmojiCompletionEnabled toggles the :emoji: shortcode typeahead (the
+	// suggestion popup and :name: inline replacement). Enabled when absent or
+	// true. Mirrors sdk.d.ts v0.3.220 L6342.
+	EmojiCompletionEnabled *bool `json:"emojiCompletionEnabled,omitempty"`
+	// VoiceEnabled enables voice mode (hold-to-talk dictation). Mirrors
+	// sdk.d.ts v0.3.220 L6612.
+	VoiceEnabled *bool `json:"voiceEnabled,omitempty"`
 	// TeammateMode controls how spawned teammates execute: "auto", "tmux",
 	// "iterm2", or "in-process" ("iterm2" added in sdk.d.ts v0.3.195 L6162).
 	TeammateMode            string `json:"teammateMode,omitempty"`

--- a/options_test.go
+++ b/options_test.go
@@ -332,6 +332,37 @@ func TestSettingsManagedOrgFieldsJSON(t *testing.T) {
 		assert.Equal(t, "<Esc>", out.VimInsertModeRemaps["jj"])
 	})
 
+	t.Run("v0.3.220 fields round-trip and omit when zero", func(t *testing.T) {
+		empty, err := json.Marshal(Settings{})
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(empty, &got))
+		assert.NotContains(t, got, "workflowSizeGuideline")
+		assert.NotContains(t, got, "emojiCompletionEnabled")
+		assert.NotContains(t, got, "precomputeCompactionEnabled")
+		assert.NotContains(t, got, "voiceEnabled")
+
+		enabled := true
+		in := Settings{
+			WorkflowSizeGuideline:       "large",
+			EmojiCompletionEnabled:      &enabled,
+			PrecomputeCompactionEnabled: &enabled,
+			VoiceEnabled:                &enabled,
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, "large", out.WorkflowSizeGuideline)
+		require.NotNil(t, out.EmojiCompletionEnabled)
+		assert.True(t, *out.EmojiCompletionEnabled)
+		require.NotNil(t, out.PrecomputeCompactionEnabled)
+		assert.True(t, *out.PrecomputeCompactionEnabled)
+		require.NotNil(t, out.VoiceEnabled)
+		assert.True(t, *out.VoiceEnabled)
+	})
+
 	t.Run("all managed-org fields round-trip together", func(t *testing.T) {
 		v := true
 		timeout := 5000


### PR DESCRIPTION
Part of #178 (TS SDK v0.3.215 → v0.3.220). See `memory/catchup-v0.3.220/PLAN.md` §"PR 09".

## What
Four optional `Settings` fields from sdk.d.ts v0.3.220:
- `workflowSizeGuideline` (L5396) — advisory size guideline for the dynamic workflows Claude writes: `unrestricted` / `small` (<5 agents) / `medium` (<15, default) / `large` (<50). Modeled as `string`.
- `emojiCompletionEnabled` (L6342) — toggles the `:emoji:` shortcode typeahead.
- `precomputeCompactionEnabled` (L6545) — precompute the compaction summary in the background; only applies with auto-compact on.
- `voiceEnabled` (L6612) — hold-to-talk dictation.

All omitempty.

## Tests
`TestSettingsFieldsJSON` gains a v0.3.220 subtest round-tripping all four and asserting omitempty. `go test ./...`, `go vet`, `gofmt -l` clean.