### PR TITLE
messages: add unclassified origin kind and peer-send-message subkind

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -248,6 +248,10 @@ const (
 	// MessageOriginKindObserverActivity marks an activity digest routed to
 	// the observer. It carries no additional fields.
 	MessageOriginKindObserverActivity MessageOriginKind = "observer-activity"
+	// MessageOriginKindUnclassified marks a delivery the harness could not
+	// attribute to any of the other kinds. It carries no additional fields
+	// (sdk.d.ts v0.3.226 L4227).
+	MessageOriginKindUnclassified MessageOriginKind = "unclassified"
 )
 
 // MessageOrigin describes the originating actor for a message.
@@ -278,13 +282,10 @@ type MessageOrigin struct {
 	// only when the turn is exactly one harness-formed envelope; render it
 	// instead of re-parsing the message text (sdk.d.ts v0.3.207).
 	Body string `json:"body,omitempty"`
-	// Subkind refines the "task-notification" kind. It is set to
-	// MessageOriginSubkindScheduledTrigger when the delivery is the fired
-	// stored prompt of a scheduled task/routine (stamped from server-asserted
-	// provenance; the schedule attests storage, not authorship). The harness
-	// then frames the message as the session's assigned task instead of the
-	// generic background-notification frame. Absent on webhook, PR-steward,
-	// plugin, and background-event deliveries (sdk.d.ts v0.3.215).
+	// Subkind refines the "task-notification" kind: a scheduled trigger or a
+	// coordinator co-member SendMessage delivery. Absent on webhook,
+	// PR-steward, plugin, and background-event deliveries (sdk.d.ts v0.3.226
+	// L4223).
 	Subkind MessageOriginSubkind `json:"subkind,omitempty"`
 }
 
@@ -293,8 +294,18 @@ type MessageOriginSubkind string
 
 const (
 	// MessageOriginSubkindScheduledTrigger marks a "task-notification" origin
-	// whose delivery is the fired stored prompt of a scheduled task/routine.
+	// whose delivery is the fired stored prompt of a scheduled task/routine
+	// (stamped from server-asserted provenance; the schedule attests storage,
+	// not authorship). The harness frames it as the session's assigned task
+	// instead of the generic background-notification frame.
 	MessageOriginSubkindScheduledTrigger MessageOriginSubkind = "scheduled-trigger"
+	// MessageOriginSubkindPeerSendMessage marks a "task-notification" origin
+	// whose delivery is a coordinator co-member SendMessage: model-authored
+	// text from another of the same user's sessions, verified by the
+	// server-stamped receiver co-membership. It carries task-notification
+	// prompt authority but stays distinguishable so the receive-side
+	// crossSessionInbound setting can apply to it (sdk.d.ts v0.3.226 L4223).
+	MessageOriginSubkindPeerSendMessage MessageOriginSubkind = "peer-send-message"
 )
 
 // StreamEvent represents a progressive delta update during streaming.

--- a/messages_test.go
+++ b/messages_test.go
@@ -1660,6 +1660,57 @@ func TestMessageOriginObserverActivityRoundTrip(t *testing.T) {
 	assert.Empty(t, decoded.Origin.SenderTaskID)
 }
 
+func TestMessageOriginPeerSendMessageRoundTrip(t *testing.T) {
+	msg := ResultMessage{
+		Type:    "result",
+		Subtype: "success",
+		Origin: &MessageOrigin{
+			Kind:    MessageOriginKindTaskNotification,
+			Subkind: MessageOriginSubkindPeerSendMessage,
+		},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	origin, ok := raw["origin"].(map[string]interface{})
+	require.True(t, ok, "origin must marshal to an object")
+	assert.Equal(t, "task-notification", origin["kind"])
+	assert.Equal(t, "peer-send-message", origin["subkind"])
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Origin)
+	assert.Equal(t, MessageOriginKindTaskNotification, decoded.Origin.Kind)
+	assert.Equal(t, MessageOriginSubkindPeerSendMessage, decoded.Origin.Subkind)
+}
+
+func TestMessageOriginUnclassifiedRoundTrip(t *testing.T) {
+	msg := ResultMessage{
+		Type:    "result",
+		Subtype: "success",
+		Origin:  &MessageOrigin{Kind: MessageOriginKindUnclassified},
+	}
+
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+	origin, ok := raw["origin"].(map[string]interface{})
+	require.True(t, ok, "origin must marshal to an object")
+	assert.Equal(t, "unclassified", origin["kind"])
+	assert.NotContains(t, origin, "from")
+	assert.NotContains(t, origin, "subkind")
+
+	var decoded ResultMessage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Origin)
+	assert.Equal(t, MessageOriginKindUnclassified, decoded.Origin.Kind)
+}
+
 func TestResultMessageFieldAdditionsBackwardCompat(t *testing.T) {
 	input := []byte(`{
 		"type": "result",


### PR DESCRIPTION
Part of #189 (TypeScript SDK v0.3.226 parity). See `memory/catchup-v0.3.226/PLAN.md` §"PR 2".

- `MessageOriginSubkindPeerSendMessage` (`sdk.d.ts` L4223) — a coordinator co-member SendMessage delivery: model-authored text from another of the same user's sessions, verified by server-stamped receiver co-membership. It lands as a `task-notification` for prompt-authority purposes but stays distinguishable, because the receive-side `crossSessionInbound` setting applies to it and not to a scheduled trigger. Without the subkind a consumer cannot tell the two apart.
- `MessageOriginKindUnclassified` (`sdk.d.ts` L4227) — a delivery the harness could not attribute to any other kind; carries no additional fields.
- The `Subkind` doc no longer claims the field means "scheduled trigger"; it now names both members.
- Unit coverage: round-trip tests for both values in `messages_test.go`, including that `unclassified` carries no `from`/`subkind`.
- No integration test: neither value is triggerable from a local CLI run — both require a live coordinator/cross-session delivery. The existing origin-parity slots stay as-is.