### PR TITLE
messages: add scope to model refusal fallback

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -1085,16 +1085,36 @@ type APIRetryMessage struct {
 // MessageType implements Message.
 func (m APIRetryMessage) MessageType() string { return "system" }
 
+// ModelRefusalFallbackScope says how far a refusal fallback reached.
+type ModelRefusalFallbackScope string
+
+const (
+	// ModelRefusalFallbackScopeSession means the main thread fell back and the
+	// session model is swapped for good.
+	ModelRefusalFallbackScopeSession ModelRefusalFallbackScope = "session"
+	// ModelRefusalFallbackScopeLocal means a subagent, side question (/btw), or
+	// background fork fell back: only that response came from the fallback
+	// model and the session model is unchanged.
+	ModelRefusalFallbackScopeLocal ModelRefusalFallbackScope = "local"
+)
+
 // ModelRefusalFallbackMessage is emitted when the primary model ends the stream
 // with stop_reason "refusal" and the turn is retried once on a fallback model
-// with the swap made persistent for the session (Direction "retry"). "revert"
+// (Direction "retry"). Scope says whether the swap outlives the turn. "revert"
 // and "sticky" are retained in the Direction enum for SDK-consumer compat and
 // are no longer emitted.
 type ModelRefusalFallbackMessage struct {
-	Type          string  `json:"type"`           // Always "system"
-	Subtype       string  `json:"subtype"`        // "model_refusal_fallback"
-	Trigger       string  `json:"trigger"`        // Always "refusal"
-	Direction     string  `json:"direction"`      // "retry" | "revert" | "sticky"
+	Type      string `json:"type"`      // Always "system"
+	Subtype   string `json:"subtype"`   // "model_refusal_fallback"
+	Trigger   string `json:"trigger"`   // Always "refusal"
+	Direction string `json:"direction"` // "retry" | "revert" | "sticky"
+
+	// Scope distinguishes a session-wide swap from a one-off local fallback.
+	// Absent from older CLIs, which only ever emitted the session-wide form —
+	// treat empty as ModelRefusalFallbackScopeSession (sdk.d.ts v0.3.226
+	// L4265).
+	Scope ModelRefusalFallbackScope `json:"scope,omitempty"`
+
 	OriginalModel string  `json:"original_model"` // Model that refused
 	FallbackModel string  `json:"fallback_model"` // Model the turn retried on
 	RequestID     *string `json:"request_id"`     // Upstream request id; nil for JSON null

--- a/messages_test.go
+++ b/messages_test.go
@@ -2951,6 +2951,7 @@ func TestParseMessageModelRefusalFallback(t *testing.T) {
 			"subtype": "model_refusal_fallback",
 			"trigger": "refusal",
 			"direction": "retry",
+			"scope": "session",
 			"original_model": "claude-opus-4-8",
 			"fallback_model": "claude-sonnet-4-6",
 			"request_id": "req_01HXYZ",
@@ -2972,6 +2973,7 @@ func TestParseMessageModelRefusalFallback(t *testing.T) {
 		assert.Equal(t, "model_refusal_fallback", fb.Subtype)
 		assert.Equal(t, "refusal", fb.Trigger)
 		assert.Equal(t, "retry", fb.Direction)
+		assert.Equal(t, ModelRefusalFallbackScopeSession, fb.Scope)
 		assert.Equal(t, "claude-opus-4-8", fb.OriginalModel)
 		assert.Equal(t, "claude-sonnet-4-6", fb.FallbackModel)
 		require.NotNil(t, fb.RequestID)
@@ -3009,6 +3011,30 @@ func TestParseMessageModelRefusalFallback(t *testing.T) {
 		assert.Nil(t, fb.APIRefusalExplanation)
 		assert.Nil(t, fb.RetractedMessageUUIDs)
 		assert.Nil(t, fb.RefusedUserMessageUUID)
+		assert.Empty(t, fb.Scope, "absent scope must stay empty so callers can apply the session default")
+	})
+
+	t.Run("local scope: subagent fallback leaves the session model alone", func(t *testing.T) {
+		input := `{
+			"type": "system",
+			"subtype": "model_refusal_fallback",
+			"trigger": "refusal",
+			"direction": "retry",
+			"scope": "local",
+			"original_model": "claude-opus-4-8",
+			"fallback_model": "claude-sonnet-4-6",
+			"request_id": "req_01HXYZ2",
+			"content": "Retried on a fallback model.",
+			"uuid": "550e8400-e29b-41d4-a716-446655440303",
+			"session_id": "sess_refusal_003"
+		}`
+
+		msg, err := ParseMessage([]byte(input))
+		require.NoError(t, err)
+
+		fb, ok := msg.(ModelRefusalFallbackMessage)
+		require.True(t, ok, "expected ModelRefusalFallbackMessage")
+		assert.Equal(t, ModelRefusalFallbackScopeLocal, fb.Scope)
 	})
 }
 


### PR DESCRIPTION
Part of #189 (TypeScript SDK v0.3.226 parity). See `memory/catchup-v0.3.226/PLAN.md` §"PR 3".

`SDKModelRefusalFallbackMessage` gained `scope` (`sdk.d.ts` L4265). Until now the message implied one thing: the primary model refused, the turn was retried on the fallback, and the swap stuck for the session. That is no longer the only shape — a subagent, side question (`/btw`), or background fork can fall back locally, with the session model unchanged.

- `ModelRefusalFallbackScope` with `Session` / `Local` consts, and `ModelRefusalFallbackMessage.Scope` (omitempty).
- Older CLIs omit the field and only ever emitted the session-wide form, so an empty `Scope` means `session`. The field doc says so rather than leaving callers to guess.
- The type doc no longer asserts the swap is always session-persistent.
- Unit coverage: `session` and `local` payloads plus an explicit assertion that an absent `scope` stays empty.
- No integration test: `model_refusal_fallback` needs the model to end a turn with `stop_reason: "refusal"` while a fallback model is configured — the same server-side condition that keeps `TestIntegrationModelRefusalNoFallback` skipped.