### PR TITLE
options: add structured sandbox credential masking

### DIFF
--- a/options.go
+++ b/options.go
@@ -789,7 +789,9 @@ type SettingsSandbox struct {
 // sandbox.
 type SettingsSandboxCredentials struct {
 	// Files are credential files or directories to protect. "deny" blocks
-	// reads inside the sandbox.
+	// reads inside the sandbox; "mask" substitutes a sentinel inside the
+	// sandbox (whole-file, or per-Extract capture) and injects the real value
+	// at the proxy. On macOS and Windows "mask" degrades to "deny".
 	Files []SettingsSandboxCredentialFile `json:"files,omitempty"`
 	// EnvVars are environment variables to protect. "deny" unsets the
 	// variable for sandboxed commands; "mask" substitutes a sentinel inside
@@ -810,8 +812,44 @@ type SettingsSandboxCredentialFile struct {
 	// sandbox.filesystem.* paths: absolute, ~ expanded, or relative to the
 	// settings file root.
 	Path string `json:"path"`
-	// Mode is the access mode for this path. Only "deny" is supported.
+	// Mode is the access mode for this path. "deny" blocks reads inside the
+	// sandbox; "mask" shows sandboxed commands a sentinel-substituted copy
+	// (whole-file, or only the spans captured by Extract) and the host proxy
+	// swaps sentinel->real on egress to InjectHosts. On macOS and Windows
+	// "mask" currently degrades to "deny" (sdk.d.ts v0.3.226 L6444).
 	Mode string `json:"mode"`
+	// Extract is an optional regex for structured masking. Applied globally to
+	// the file; capture group 1 of each match is a credential value and only
+	// those spans become sentinels, so a tool that parses the file (.netrc,
+	// JSON, YAML) still succeeds. Without it the whole file content becomes one
+	// sentinel. Accepted but ignored for "deny".
+	Extract string `json:"extract,omitempty"`
+	// OnExtractNoMatch governs the case where Extract matches nothing — or,
+	// with Decode, where no candidate verifies. "warn" (default) leaves the
+	// file readable as-is (fail-open, for credentials that may legitimately be
+	// absent); "deny" degrades the entry to mode "deny" (fail-closed), and is
+	// treated as "error" under sandbox.filesystem.disabled since read-denies
+	// are dropped there; "error" aborts at sandbox setup.
+	OnExtractNoMatch string `json:"onExtractNoMatch,omitempty"`
+	// Decode names an encoded-credential format for "mask" mode. "jwt" locates
+	// candidates with a built-in JWT regex (or Extract, if set), verifies they
+	// really are JWTs, and swaps in a structurally valid fake so client-side
+	// token parsing inside the sandbox keeps working.
+	Decode string `json:"decode,omitempty"`
+	// MaskClaims names top-level payload claims to mask inside each decoded
+	// value instead of replacing the whole token; the token is rebuilt around
+	// the modified payload so non-secret claims keep reading. Requires Decode.
+	MaskClaims []string `json:"maskClaims,omitempty"`
+	// MaskDuplicates also replaces verbatim occurrences of each captured value
+	// outside the matched spans — for a secret repeated where the regex does
+	// not reach. Matches raw substrings, so short or common values can corrupt
+	// unrelated content; meant for long, high-entropy secrets. Defaults false.
+	MaskDuplicates *bool `json:"maskDuplicates,omitempty"`
+	// InjectHosts optionally narrows where the proxy substitutes this
+	// credential. Only meaningful for "mask". If unset, defaults to
+	// network.allowedDomains — injected at every reachable host. Each entry
+	// must be reachable via network.allowedDomains.
+	InjectHosts []string `json:"injectHosts,omitempty"`
 }
 
 // SettingsSandboxCredentialEnvVar protects a single environment variable.
@@ -823,6 +861,32 @@ type SettingsSandboxCredentialEnvVar struct {
 	// value and the host proxy swaps sentinel->real on egress to
 	// InjectHosts (sdk.d.ts v0.3.201).
 	Mode string `json:"mode"`
+	// Extract is an optional regex for structured masking. Applied globally to
+	// the value; capture group 1 of each match is a credential value and only
+	// those spans become sentinels, so a composite value (a DATABASE_URL
+	// connection string, a KEY:SECRET pair) still parses inside the sandbox.
+	// Without it the whole value becomes one sentinel. Cannot be combined with
+	// Decode — the decode path never consults it.
+	Extract string `json:"extract,omitempty"`
+	// OnExtractNoMatch governs the case where Extract matches nothing. "warn"
+	// (default) lets the variable through unmasked (fail-open); "deny" unsets
+	// it inside the sandbox (fail-closed); "error" aborts at sandbox setup.
+	// Only meaningful when Mode is "mask" and Extract is set without Decode: a
+	// mask entry carrying Decode takes the decode path and never consults this
+	// field, so "deny" and "error" are rejected there and only "warn" is
+	// accepted.
+	OnExtractNoMatch string `json:"onExtractNoMatch,omitempty"`
+	// Decode names an encoded-credential format for "mask" mode. "jwt"
+	// verifies the whole value really is a JWT and swaps in a structurally
+	// valid fake so client-side token parsing inside the sandbox keeps
+	// working; a value that does not verify is left unmasked with a stderr
+	// warning. Cannot be combined with Extract.
+	Decode string `json:"decode,omitempty"`
+	// MaskClaims names top-level payload claims to mask inside the decoded
+	// value instead of replacing the whole token; the token is rebuilt around
+	// the modified payload so claim-reading clients keep working. Requires
+	// Decode.
+	MaskClaims []string `json:"maskClaims,omitempty"`
 	// InjectHosts optionally narrows where the proxy substitutes this
 	// credential. Only meaningful when Mode is "mask"; accepted but ignored
 	// for "deny". If unset, defaults to network.allowedDomains — the

--- a/options_test.go
+++ b/options_test.go
@@ -855,6 +855,129 @@ func TestSettingsSandboxFieldsJSON(t *testing.T) {
 		assert.NotContains(t, env, "injectHosts")
 	})
 
+	t.Run("credential file mask with extract round-trips", func(t *testing.T) {
+		maskDuplicates := true
+		in := Settings{
+			Sandbox: &SettingsSandbox{
+				Credentials: &SettingsSandboxCredentials{
+					Files: []SettingsSandboxCredentialFile{
+						{
+							Path:             "~/.netrc",
+							Mode:             "mask",
+							Extract:          `password\s+(\S+)`,
+							OnExtractNoMatch: "deny",
+							MaskDuplicates:   &maskDuplicates,
+							InjectHosts:      []string{"api.example.com"},
+						},
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		creds := got["sandbox"].(map[string]interface{})["credentials"].(map[string]interface{})
+		file := creds["files"].([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, "mask", file["mode"])
+		assert.Equal(t, `password\s+(\S+)`, file["extract"])
+		assert.Equal(t, "deny", file["onExtractNoMatch"])
+		assert.Equal(t, true, file["maskDuplicates"])
+		assert.Equal(t, []interface{}{"api.example.com"}, file["injectHosts"])
+		assert.NotContains(t, file, "decode")
+		assert.NotContains(t, file, "maskClaims")
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.Len(t, out.Sandbox.Credentials.Files, 1)
+		gotFile := out.Sandbox.Credentials.Files[0]
+		assert.Equal(t, "mask", gotFile.Mode)
+		assert.Equal(t, `password\s+(\S+)`, gotFile.Extract)
+		assert.Equal(t, "deny", gotFile.OnExtractNoMatch)
+		require.NotNil(t, gotFile.MaskDuplicates)
+		assert.True(t, *gotFile.MaskDuplicates)
+		assert.Equal(t, []string{"api.example.com"}, gotFile.InjectHosts)
+	})
+
+	t.Run("credential jwt decode round-trips on files and envVars", func(t *testing.T) {
+		in := Settings{
+			Sandbox: &SettingsSandbox{
+				Credentials: &SettingsSandboxCredentials{
+					Files: []SettingsSandboxCredentialFile{
+						{
+							Path:       "~/.config/token.json",
+							Mode:       "mask",
+							Decode:     "jwt",
+							MaskClaims: []string{"sub", "email"},
+						},
+					},
+					EnvVars: []SettingsSandboxCredentialEnvVar{
+						{
+							Name:             "SERVICE_JWT",
+							Mode:             "mask",
+							Decode:           "jwt",
+							MaskClaims:       []string{"sub"},
+							OnExtractNoMatch: "warn",
+						},
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		creds := got["sandbox"].(map[string]interface{})["credentials"].(map[string]interface{})
+		file := creds["files"].([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, "jwt", file["decode"])
+		assert.Equal(t, []interface{}{"sub", "email"}, file["maskClaims"])
+		env := creds["envVars"].([]interface{})[0].(map[string]interface{})
+		assert.Equal(t, "jwt", env["decode"])
+		assert.Equal(t, []interface{}{"sub"}, env["maskClaims"])
+		assert.Equal(t, "warn", env["onExtractNoMatch"])
+		assert.NotContains(t, env, "extract")
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, []string{"sub", "email"}, out.Sandbox.Credentials.Files[0].MaskClaims)
+		assert.Equal(t, "jwt", out.Sandbox.Credentials.EnvVars[0].Decode)
+		assert.Equal(t, []string{"sub"}, out.Sandbox.Credentials.EnvVars[0].MaskClaims)
+	})
+
+	t.Run("deny entries omit every masking knob", func(t *testing.T) {
+		in := Settings{
+			Sandbox: &SettingsSandbox{
+				Credentials: &SettingsSandboxCredentials{
+					Files: []SettingsSandboxCredentialFile{
+						{Path: "~/.ssh/id_ed25519", Mode: "deny"},
+					},
+					EnvVars: []SettingsSandboxCredentialEnvVar{
+						{Name: "AWS_SECRET_ACCESS_KEY", Mode: "deny"},
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		creds := got["sandbox"].(map[string]interface{})["credentials"].(map[string]interface{})
+		for _, entry := range []map[string]interface{}{
+			creds["files"].([]interface{})[0].(map[string]interface{}),
+			creds["envVars"].([]interface{})[0].(map[string]interface{}),
+		} {
+			for _, k := range []string{
+				"extract", "onExtractNoMatch", "decode", "maskClaims",
+				"maskDuplicates", "injectHosts",
+			} {
+				assert.NotContains(t, entry, k)
+			}
+		}
+	})
+
 	t.Run("nil credentials omits key", func(t *testing.T) {
 		data, err := json.Marshal(Settings{Sandbox: &SettingsSandbox{}})
 		require.NoError(t, err)


### PR DESCRIPTION
Part of #189 (TypeScript SDK v0.3.226 parity). See `memory/catchup-v0.3.226/PLAN.md` §"PR 4".

`sandbox.credentials` grew the biggest surface in this release (`sdk.d.ts` L6436–L6500). Credential *files* were `deny`-only — all-or-nothing, so protecting a `.netrc` meant no tool inside the sandbox could read it. They now support `mask`, and both files and env vars gained the knobs that make masking work on a value something still has to parse:

- `Mode` on files widens to `deny | mask`; `mask` shows sandboxed commands a sentinel-substituted copy and the proxy swaps sentinel→real on egress to `InjectHosts`. Degrades to `deny` on macOS and Windows.
- `Extract` — regex whose capture group 1 marks the credential spans; everything else is preserved, so `.netrc` / JSON / YAML still parse. Without it the whole file (or value) becomes one sentinel.
- `OnExtractNoMatch` — `warn` (default, fail-open) / `deny` (fail-closed) / `error` (abort at setup). The env-var doc records upstream's asymmetry: on a mask entry carrying `Decode` the runtime takes the decode path and never consults it, so only `warn` is accepted there.
- `Decode: "jwt"` + `MaskClaims` — verify the value really is a JWT, then swap in a structurally valid fake, optionally masking only named payload claims so claim-reading clients keep working.
- `MaskDuplicates` (files only, matching upstream) and `InjectHosts` on files (env vars already had it).

Unit coverage: file mask with `extract` + `maskDuplicates` + `injectHosts`, JWT decode across both carriers, and a `deny`-entry test asserting every masking knob stays off the wire.

No integration test: `TestIntegrationSettingsSandboxFields` is already a skip stub — these fields are consumed by sandbox-runtime, and the CLI fixture cannot deterministically inject them through managed settings for the SDK to observe.