### PR TITLE
options: add sandbox credential SigV4 re-signing config

### DIFF
--- a/options.go
+++ b/options.go
@@ -802,6 +802,58 @@ type SettingsSandboxCredentials struct {
 	// from user, managed/policy, or CLI (--settings) settings — project
 	// settings are ignored (sdk.d.ts v0.3.201).
 	AllowPlaintextInject *bool `json:"allowPlaintextInject,omitempty"`
+	// AWSPairs groups masked env vars into AWS credential pairs for SigV4
+	// re-signing when the variable names are non-standard; the conventional
+	// AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_SESSION_TOKEN trio pairs
+	// automatically when masked. Only honored from user, managed/policy, or
+	// CLI (--settings) settings — project settings are ignored (sdk.d.ts
+	// v0.3.226 L6510).
+	AWSPairs []SettingsSandboxCredentialAWSPair `json:"awsPairs,omitempty"`
+	// SigV4 sets the policy for AWS SigV4 request shapes the proxy cannot
+	// re-sign when they reference a masked credential pair. Only honored from
+	// user, managed/policy, or CLI (--settings) settings — project settings are
+	// ignored (sdk.d.ts v0.3.226 L6527).
+	SigV4 *SettingsSandboxCredentialSigV4 `json:"sigv4,omitempty"`
+}
+
+// SettingsSandboxCredentialAWSPair names the masked env vars that make up one
+// AWS credential pair, so the proxy can re-sign SigV4 requests that were signed
+// inside the sandbox with sentinel values.
+//
+// A member is only usable when its variable is forwarded as a whole-value
+// "mask" entry: an entry carrying Extract or Decode does not qualify, since
+// re-signing needs the whole real value. A pair whose key id or secret member
+// is unusable never re-signs — it is dropped, unless it names a conventional
+// AWS variable, in which case it is forwarded as an inert suppressor so
+// implicit auto-pairing stays overridden. A pair whose only unusable member is
+// the session token still re-signs, without an x-amz-security-token.
+type SettingsSandboxCredentialAWSPair struct {
+	// AccessKeyIDVar is the masked env var holding the AWS access key id.
+	AccessKeyIDVar string `json:"accessKeyIdVar"`
+	// SecretAccessKeyVar is the masked env var holding the AWS secret access
+	// key.
+	SecretAccessKeyVar string `json:"secretAccessKeyVar"`
+	// SessionTokenVar is the masked env var holding the AWS session token, for
+	// temporary credentials. When set, the proxy sends the real token as
+	// x-amz-security-token on re-signed requests and adds it to the signed
+	// header set if the client did not.
+	SessionTokenVar string `json:"sessionTokenVar,omitempty"`
+}
+
+// SettingsSandboxCredentialSigV4 holds the per-shape policies for SigV4
+// requests the proxy cannot re-sign. Each is "deny" (the default, fail closed)
+// or "passthrough" (forward unre-signed, which the upstream will reject).
+type SettingsSandboxCredentialSigV4 struct {
+	// Streaming covers aws-chunked uploads (x-amz-content-sha256:
+	// STREAMING-*): per-chunk signatures chain off the seed signature, so
+	// re-signing would mean rewriting the body. "deny" fails closed with a 403.
+	Streaming string `json:"streaming,omitempty"`
+	// Presigned covers presigned URLs (X-Amz-Algorithm/X-Amz-Signature in the
+	// query, no Authorization header) — the signature lives in the URL itself.
+	Presigned string `json:"presigned,omitempty"`
+	// SigV4A covers SigV4A (AWS4-ECDSA-P256-SHA256) asymmetric signatures:
+	// there is no shared-key HMAC to recompute.
+	SigV4A string `json:"sigv4a,omitempty"`
 }
 
 // SettingsSandboxCredentialFile protects a single credential file or directory.

--- a/options_test.go
+++ b/options_test.go
@@ -855,6 +855,82 @@ func TestSettingsSandboxFieldsJSON(t *testing.T) {
 		assert.NotContains(t, env, "injectHosts")
 	})
 
+	t.Run("credentials awsPairs and sigv4 round-trip", func(t *testing.T) {
+		in := Settings{
+			Sandbox: &SettingsSandbox{
+				Credentials: &SettingsSandboxCredentials{
+					EnvVars: []SettingsSandboxCredentialEnvVar{
+						{Name: "CORP_AWS_KEY_ID", Mode: "mask"},
+						{Name: "CORP_AWS_SECRET", Mode: "mask"},
+					},
+					AWSPairs: []SettingsSandboxCredentialAWSPair{
+						{
+							AccessKeyIDVar:     "CORP_AWS_KEY_ID",
+							SecretAccessKeyVar: "CORP_AWS_SECRET",
+						},
+						{
+							AccessKeyIDVar:     "TMP_KEY_ID",
+							SecretAccessKeyVar: "TMP_SECRET",
+							SessionTokenVar:    "TMP_SESSION_TOKEN",
+						},
+					},
+					SigV4: &SettingsSandboxCredentialSigV4{
+						Streaming: "passthrough",
+						Presigned: "deny",
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		creds := got["sandbox"].(map[string]interface{})["credentials"].(map[string]interface{})
+		pairs := creds["awsPairs"].([]interface{})
+		require.Len(t, pairs, 2)
+		first := pairs[0].(map[string]interface{})
+		assert.Equal(t, "CORP_AWS_KEY_ID", first["accessKeyIdVar"])
+		assert.Equal(t, "CORP_AWS_SECRET", first["secretAccessKeyVar"])
+		assert.NotContains(t, first, "sessionTokenVar")
+		assert.Equal(t, "TMP_SESSION_TOKEN", pairs[1].(map[string]interface{})["sessionTokenVar"])
+		sigv4 := creds["sigv4"].(map[string]interface{})
+		assert.Equal(t, "passthrough", sigv4["streaming"])
+		assert.Equal(t, "deny", sigv4["presigned"])
+		assert.NotContains(t, sigv4, "sigv4a")
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.Len(t, out.Sandbox.Credentials.AWSPairs, 2)
+		assert.Equal(t, "CORP_AWS_KEY_ID", out.Sandbox.Credentials.AWSPairs[0].AccessKeyIDVar)
+		assert.Empty(t, out.Sandbox.Credentials.AWSPairs[0].SessionTokenVar)
+		assert.Equal(t, "TMP_SESSION_TOKEN", out.Sandbox.Credentials.AWSPairs[1].SessionTokenVar)
+		require.NotNil(t, out.Sandbox.Credentials.SigV4)
+		assert.Equal(t, "passthrough", out.Sandbox.Credentials.SigV4.Streaming)
+		assert.Equal(t, "deny", out.Sandbox.Credentials.SigV4.Presigned)
+		assert.Empty(t, out.Sandbox.Credentials.SigV4.SigV4A)
+	})
+
+	t.Run("credentials without awsPairs or sigv4 omit both keys", func(t *testing.T) {
+		in := Settings{
+			Sandbox: &SettingsSandbox{
+				Credentials: &SettingsSandboxCredentials{
+					EnvVars: []SettingsSandboxCredentialEnvVar{
+						{Name: "AWS_SECRET_ACCESS_KEY", Mode: "mask"},
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		creds := got["sandbox"].(map[string]interface{})["credentials"].(map[string]interface{})
+		assert.NotContains(t, creds, "awsPairs")
+		assert.NotContains(t, creds, "sigv4")
+	})
+
 	t.Run("nil credentials omits key", func(t *testing.T) {
 		data, err := json.Marshal(Settings{Sandbox: &SettingsSandbox{}})
 		require.NoError(t, err)


### PR DESCRIPTION
Part of #189 (TypeScript SDK v0.3.226 parity). See `memory/catchup-v0.3.226/PLAN.md` §"PR 5".

Masking an AWS credential breaks SigV4: the client inside the sandbox signs the request with the sentinel, so the proxy has to recompute the signature with the real key on egress. Two new `sandbox.credentials` members configure that (`sdk.d.ts` L6510, L6527).

- `AWSPairs` (`SettingsSandboxCredentialAWSPair`) — explicit groupings of masked env vars into key-id / secret / optional session-token trios, for deployments whose variables aren't named `AWS_ACCESS_KEY_ID` & co. The conventional trio auto-pairs when masked. The type doc records upstream's usability rules: a member only counts when forwarded as a whole-value `mask` entry (an `Extract`/`Decode` entry doesn't qualify — re-signing needs the whole real value), an unusable key-id or secret drops the pair unless it names a conventional AWS variable, in which case it stays as an inert suppressor so auto-pairing remains overridden, and an unusable session token alone still re-signs without `x-amz-security-token`.
- `SigV4` (`SettingsSandboxCredentialSigV4`) — per-shape policy, `deny` (default, fail closed) or `passthrough`, for the three shapes the proxy cannot re-sign: `Streaming` (aws-chunked, per-chunk signatures chain off the seed so re-signing means rewriting the body), `Presigned` (signature lives in the URL), `SigV4A` (ECDSA — no shared-key HMAC to recompute).

Both are managed/user/CLI-settings only; project settings are ignored.

Unit coverage: round-trip with and without `sessionTokenVar`, partial `sigv4` (asserting the unset member stays off the wire), and an omit-both case.

No integration test — same reason as PR #193: `TestIntegrationSettingsSandboxFields` is an existing skip stub because the CLI fixture cannot inject these through managed settings for the SDK to observe.