### PR TITLE
options: add dialogExpiry and crossSessionInbound settings

### DIFF
--- a/options.go
+++ b/options.go
@@ -396,13 +396,24 @@ type Settings struct {
 	// auto-continue with any answers selected so far. Defaults to never —
 	// auto-continue only runs when explicitly set to "60s", "5m", or "10m".
 	// Mirrors sdk.d.ts v0.3.201.
-	AskUserQuestionTimeout string                          `json:"askUserQuestionTimeout,omitempty"`
-	Agent                  string                          `json:"agent,omitempty"`
-	CompanyAnnouncements   []string                        `json:"companyAnnouncements,omitempty"`
-	PluginConfigs          map[string]SettingsPluginConfig `json:"pluginConfigs,omitempty"`
-	Remote                 *SettingsRemote                 `json:"remote,omitempty"`
-	AutoUpdatesChannel     string                          `json:"autoUpdatesChannel,omitempty"`
-	MinimumVersion         string                          `json:"minimumVersion,omitempty"`
+	AskUserQuestionTimeout string `json:"askUserQuestionTimeout,omitempty"`
+	// DialogExpiry caps how long a permission or user dialog forwarded to a
+	// remote client stays parked awaiting an answer, and how long a HELD
+	// cross-session message awaits approval, before either resolves to its safe
+	// no-action default (cancelled / dropped-with-denial). "60s", "5m", "10m",
+	// or "never" to disable the deadline; defaults to 5m, matching the
+	// long-standing remote-dialog deadline. Local-only permission prompts are
+	// unaffected. CLAUDE_CODE_USER_DIALOG_TIMEOUT_MS overrides it. Read from
+	// trusted sources only, never a checked-in repo settings file (sdk.d.ts
+	// v0.3.226 L6654).
+	DialogExpiry string `json:"dialogExpiry,omitempty"`
+
+	Agent                string                          `json:"agent,omitempty"`
+	CompanyAnnouncements []string                        `json:"companyAnnouncements,omitempty"`
+	PluginConfigs        map[string]SettingsPluginConfig `json:"pluginConfigs,omitempty"`
+	Remote               *SettingsRemote                 `json:"remote,omitempty"`
+	AutoUpdatesChannel   string                          `json:"autoUpdatesChannel,omitempty"`
+	MinimumVersion       string                          `json:"minimumVersion,omitempty"`
 	// RequiredMinimumVersion prevents startup below the managed minimum version. Honored only from managed (policy) settings. Mirrors sdk.d.ts v0.3.168 L5488.
 	RequiredMinimumVersion string `json:"requiredMinimumVersion,omitempty"`
 	// RequiredMaximumVersion prevents startup above the managed maximum version. Honored only from managed (policy) settings. Mirrors sdk.d.ts v0.3.168 L5492.
@@ -484,6 +495,16 @@ type Settings struct {
 	IsolatePeerMachines *bool `json:"isolatePeerMachines,omitempty"`
 	// DaemonColdStart controls daemon behavior when no background service is running. Mirrors sdk.d.ts v0.3.150 L5411.
 	DaemonColdStart string `json:"daemonColdStart,omitempty"`
+	// CrossSessionInbound governs inbound cross-session peer messages
+	// (SendMessage from the user's other sessions): "accept" delivers them,
+	// "hold" parks them for review without letting Claude act, "refuse" opts
+	// this session out. An explicit value always wins. Unset means mode parity:
+	// a message auto-delivers only when the sending session's permission-mode
+	// class matches this one (bypass<->bypass or prompting<->prompting), a
+	// mismatched sender is held for approval, and a sender that asserts no
+	// class is held only while this session bypasses permission prompts
+	// (sdk.d.ts v0.3.226 L6899).
+	CrossSessionInbound string `json:"crossSessionInbound,omitempty"`
 	// DisableDeepLinkRegistration prevents claude-cli:// protocol handler registration when set to "disable". Mirrors sdk.d.ts v0.3.150 L5427.
 	DisableDeepLinkRegistration string `json:"disableDeepLinkRegistration,omitempty"`
 	// DefaultView controls the default transcript view. Mirrors sdk.d.ts v0.3.150 L5431.

--- a/options_test.go
+++ b/options_test.go
@@ -363,6 +363,30 @@ func TestSettingsManagedOrgFieldsJSON(t *testing.T) {
 		assert.True(t, *out.VoiceEnabled)
 	})
 
+	t.Run("v0.3.226 fields round-trip and omit when zero", func(t *testing.T) {
+		empty, err := json.Marshal(Settings{})
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(empty, &got))
+		assert.NotContains(t, got, "dialogExpiry")
+		assert.NotContains(t, got, "crossSessionInbound")
+
+		in := Settings{
+			DialogExpiry:        "never",
+			CrossSessionInbound: "hold",
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, "never", got["dialogExpiry"])
+		assert.Equal(t, "hold", got["crossSessionInbound"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, "never", out.DialogExpiry)
+		assert.Equal(t, "hold", out.CrossSessionInbound)
+	})
+
 	t.Run("all managed-org fields round-trip together", func(t *testing.T) {
 		v := true
 		timeout := 5000


### PR DESCRIPTION
Part of #189 (TypeScript SDK v0.3.226 parity). See `memory/catchup-v0.3.226/PLAN.md` §"PR 6".

- `DialogExpiry` (`sdk.d.ts` L6654) — `60s` / `5m` / `10m` / `never`. Caps how long a permission or user dialog forwarded to a remote client stays parked awaiting an answer, and how long a HELD cross-session message waits on approval, before each resolves to its safe no-action default (cancelled, dropped-with-denial). Defaults to 5m, matching the deadline that used to be fixed. Local-only prompts are unaffected; `CLAUDE_CODE_USER_DIALOG_TIMEOUT_MS` overrides it, and it is read from trusted sources only — the field doc says so, since a checked-in repo settings file setting `never` would be a denial-of-service on the host.
- `CrossSessionInbound` (`sdk.d.ts` L6899) — `accept` / `hold` / `refuse` for inbound peer `SendMessage` traffic. This is the other half of the `peer-send-message` subkind from #191: the subkind exists so this setting can apply to those deliveries. Unset means mode parity — auto-deliver only when the sender's permission-mode class matches this session's, hold a mismatched sender, and hold a class-less sender only while this session bypasses prompts. The doc spells that out because "unset" is not "accept".

Unit coverage extends the existing settings-parity table: round-trip plus omit-when-zero for both.

Struct realignment in the diff is `gofmt` widening the field block for the new names, not a functional change.