### PR TITLE
options: add archive marketplace plugin source

### DIFF
--- a/options.go
+++ b/options.go
@@ -357,8 +357,15 @@ type Settings struct {
 	SubagentStatusLine              *SettingsCommand               `json:"subagentStatusLine,omitempty"`
 	EnabledPlugins                  map[string]interface{}         `json:"enabledPlugins,omitempty"`
 	ExtraKnownMarketplaces          map[string]SettingsMarketplace `json:"extraKnownMarketplaces,omitempty"`
-	StrictKnownMarketplaces         []SettingsMarketplaceSource    `json:"strictKnownMarketplaces,omitempty"`
-	BlockedMarketplaces             []SettingsMarketplaceSource    `json:"blockedMarketplaces,omitempty"`
+	// StrictKnownMarketplaces and BlockedMarketplaces are the managed-settings
+	// policy lists, and are the only place a github entry may use the
+	// owner-wildcard form {"source":"github","repo":"owner/*"} to match every
+	// repository under that owner. Everywhere else — marketplace add,
+	// ExtraKnownMarketplaces, known_marketplaces.json — "repo" must name a
+	// single repository, and a wildcard is taken literally and fails to clone
+	// (sdk.d.ts v0.3.226 L5909, L6112).
+	StrictKnownMarketplaces []SettingsMarketplaceSource `json:"strictKnownMarketplaces,omitempty"`
+	BlockedMarketplaces     []SettingsMarketplaceSource `json:"blockedMarketplaces,omitempty"`
 	// DisableSideloadFlags, when true and set in managed settings, rejects the
 	// --plugin-dir, --plugin-url, --agents, and non-sdk --mcp-config CLI flags
 	// at startup, closing the CLI-flag bypass of strictKnownMarketplaces.
@@ -707,7 +714,18 @@ const (
 	SettingsMarketplaceSourceHostPattern SettingsMarketplaceSourceKind = "hostPattern"
 	// SettingsMarketplaceSourcePathPattern identifies a pathPattern marketplace source. Mirrors sdk.d.ts v0.3.150 L4555.
 	SettingsMarketplaceSourcePathPattern SettingsMarketplaceSourceKind = "pathPattern"
+	// SettingsMarketplaceSourceArchive identifies a zip-archive plugin source.
+	// Honors "url": string (HTTPS URL of the archive; the plugin root may sit at
+	// the top or one directory deep, as a single wrapping directory is stripped)
+	// and optional "sha256": string. When the digest is set every download is
+	// verified against it and a mismatch refuses the install; it also serves as
+	// the version identity when neither plugin.json nor the marketplace entry
+	// declares a version. Note the update signal is the version string, so
+	// changing only the digest while a version is declared does not trigger an
+	// update. Mirrors sdk.d.ts v0.3.226 L5869.
+	SettingsMarketplaceSourceArchive SettingsMarketplaceSourceKind = "archive"
 	// SettingsMarketplaceSourceUnsupported identifies a bare-tag unsupported marketplace source. Mirrors sdk.d.ts v0.3.150 L4619.
+	// Honors optional "error": string carrying why the source was rejected, per sdk.d.ts v0.3.226 L5871.
 	SettingsMarketplaceSourceUnsupported SettingsMarketplaceSourceKind = "unsupported"
 )
 

--- a/options_test.go
+++ b/options_test.go
@@ -1264,6 +1264,91 @@ func TestSettingsMarketplaceSourceVariants(t *testing.T) {
 		assert.Len(t, got, 1)
 	})
 
+	t.Run("archive source round-trips with url and sha256", func(t *testing.T) {
+		in := Settings{
+			ExtraKnownMarketplaces: map[string]SettingsMarketplace{
+				"vendor-bundle": {
+					Source: SettingsMarketplaceSource{
+						"source": string(SettingsMarketplaceSourceArchive),
+						"url":    "https://example.com/plugins/bundle.zip",
+						"sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		got := out.ExtraKnownMarketplaces["vendor-bundle"].Source
+		assert.Equal(t, "archive", got["source"])
+		assert.Equal(t, "https://example.com/plugins/bundle.zip", got["url"])
+		assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", got["sha256"])
+	})
+
+	t.Run("archive source round-trips without sha256", func(t *testing.T) {
+		in := Settings{
+			ExtraKnownMarketplaces: map[string]SettingsMarketplace{
+				"vendor-bundle": {
+					Source: SettingsMarketplaceSource{
+						"source": string(SettingsMarketplaceSourceArchive),
+						"url":    "https://example.com/plugins/bundle.zip",
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		got := out.ExtraKnownMarketplaces["vendor-bundle"].Source
+		assert.Len(t, got, 2)
+		assert.NotContains(t, got, "sha256")
+	})
+
+	t.Run("unsupported source carries an error string", func(t *testing.T) {
+		in := Settings{
+			ExtraKnownMarketplaces: map[string]SettingsMarketplace{
+				"legacy": {
+					Source: SettingsMarketplaceSource{
+						"source": string(SettingsMarketplaceSourceUnsupported),
+						"error":  "archive digest mismatch",
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		got := out.ExtraKnownMarketplaces["legacy"].Source
+		assert.Equal(t, "unsupported", got["source"])
+		assert.Equal(t, "archive digest mismatch", got["error"])
+	})
+
+	t.Run("github owner wildcard round-trips in policy lists", func(t *testing.T) {
+		in := Settings{
+			StrictKnownMarketplaces: []SettingsMarketplaceSource{
+				{"source": string(SettingsMarketplaceSourceGithub), "repo": "anthropics/*"},
+			},
+			BlockedMarketplaces: []SettingsMarketplaceSource{
+				{"source": string(SettingsMarketplaceSourceGithub), "repo": "untrusted/*"},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.Len(t, out.StrictKnownMarketplaces, 1)
+		assert.Equal(t, "anthropics/*", out.StrictKnownMarketplaces[0]["repo"])
+		require.Len(t, out.BlockedMarketplaces, 1)
+		assert.Equal(t, "untrusted/*", out.BlockedMarketplaces[0]["repo"])
+	})
+
 	t.Run("github variant still round-trips alongside", func(t *testing.T) {
 		in := Settings{
 			ExtraKnownMarketplaces: map[string]SettingsMarketplace{


### PR DESCRIPTION
Part of #189 (TypeScript SDK v0.3.226 parity). See `memory/catchup-v0.3.226/PLAN.md` §"PR 7".

- `SettingsMarketplaceSourceArchive` (`sdk.d.ts` L5869) — a plugin served as a zip archive over HTTPS. `SettingsMarketplaceSource` is an opaque map, so the wire contract lives in the const's doc: `url` (the plugin root may sit at the top of the archive or one directory deep — a single wrapping directory is stripped) and optional `sha256`, which verifies every download, refuses the install on mismatch, and doubles as version identity when neither `plugin.json` nor the marketplace entry declares a version. The doc keeps upstream's trap: the update signal is the version string, so changing only the digest while a version is declared does not trigger an update.
- `unsupported` sources may now carry an `error` string saying why the source was rejected (L5871).
- Documented the owner-wildcard form on `StrictKnownMarketplaces` / `BlockedMarketplaces`: `{"source":"github","repo":"owner/*"}` matches every repo under that owner, but **only** in those two managed-settings policy lists. In `marketplace add`, `ExtraKnownMarketplaces`, or `known_marketplaces.json` the wildcard is taken literally and fails to clone (L5909, L6112). Worth spelling out — an admin who assumes it works everywhere gets a silently broken registration rather than an error.

Unit coverage: archive source with and without `sha256`, `unsupported` carrying `error`, and the wildcard round-tripping through both policy lists.