### PR TITLE
messages: add context_usage to the assistant message

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2360,3 +2360,80 @@ func TestIntegrationResumeDropsTurn(t *testing.T) {
 	// unattributable entry sits in the discarded range.
 	t.Skip("not triggerable from CLI: installed CLI 2.1.222 does not implement --resume-drops-turn; tracked in INTEGRATION-FOLLOWUPS.md")
 }
+
+// TestIntegrationAssistantContextUsage drives /context against the live CLI and
+// checks the structured sibling on the assistant message that carries the
+// markdown table. CLIs older than 2.1.233 answer /context with the table alone,
+// so the assertions are conditional on the field being attached at all.
+func TestIntegrationAssistantContextUsage(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	client, err := NewClient(isolatedClientOptions(t)...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	var usage *AssistantContextUsage
+	for msg := range client.Query(ctx, "/context") {
+		assistant, ok := msg.(AssistantMessage)
+		if !ok || assistant.ContextUsage == nil {
+			continue
+		}
+		usage = assistant.ContextUsage
+		break
+	}
+
+	if usage == nil {
+		t.Skip("CLI did not attach context_usage to the /context result; " +
+			"needs a CLI at 2.1.233 or newer")
+	}
+
+	assert.NotEmpty(t, usage.Model)
+	assert.Positive(t, usage.TotalTokens)
+	assert.Positive(t, usage.RawMaxTokens)
+	require.NotEmpty(t, usage.Categories)
+
+	// Every row must classify, and the rows that count toward the window have
+	// to add up to the reported total. Deferred rows are out-of-window tool
+	// schemas, so they are excluded from that sum.
+	var inWindow int
+	for _, cat := range usage.Categories {
+		assert.Contains(t, []ContextUsageCategoryKind{
+			ContextUsageUsed,
+			ContextUsageFree,
+			ContextUsageBuffer,
+			ContextUsageDeferred,
+		}, cat.Kind, "unclassified category row %q", cat.Name)
+
+		if cat.Kind == ContextUsageUsed {
+			inWindow += cat.Tokens
+		}
+	}
+	assert.Equal(t, usage.TotalTokens, inWindow,
+		"used rows should sum to total_tokens")
+
+	if usage.OverLimit != nil {
+		assert.Positive(t, usage.OverLimit.TokensOver)
+		assert.Contains(t, []ContextWindowKind{
+			ContextWindowHardLimit,
+			ContextWindowCompaction,
+		}, usage.OverLimit.Kind)
+		assert.Greater(t, usage.TotalTokens, usage.RawMaxTokens,
+			"over_limit set while within the window")
+	}
+
+	for _, tool := range usage.McpTools {
+		assert.NotEmpty(t, tool.Name)
+		assert.NotEmpty(t, tool.ServerName)
+	}
+	for _, file := range usage.MemoryFiles {
+		assert.NotEmpty(t, file.Path)
+	}
+	for _, agent := range usage.Agents {
+		assert.NotEmpty(t, agent.AgentType)
+		assert.NotEmpty(t, agent.Source)
+	}
+}

--- a/messages.go
+++ b/messages.go
@@ -140,6 +140,140 @@ type AssistantMessage struct {
 	// Empty for a successful turn. See AssistantMessageError for known
 	// variants.
 	Error AssistantMessageError `json:"error,omitempty"`
+
+	// ContextUsage is the structured twin of the /context report, carried on
+	// the synthetic assistant message that delivers the markdown table. Set
+	// only on /context results from CLIs new enough to attach it; the markdown
+	// in Message.Content stays the canonical fallback. A wrapper-level sibling
+	// — never inside message.content — so it is not replayed to the model
+	// (sdk.d.ts v0.3.233 L3058).
+	ContextUsage *AssistantContextUsage `json:"context_usage,omitempty"`
+}
+
+// AssistantContextUsage is the structured twin of the /context report: the data
+// a client needs to render the context-usage card without parsing the markdown
+// table.
+//
+// This is a deliberately smaller and more stable shape than
+// SDKControlGetContextUsageResponse, which mirrors the camelCase /context
+// *control response*. They are separate wire shapes — this one is snake_case and
+// rides on the assistant message. It evolves additively (new optional fields); a
+// breaking reshape would ship as a sibling field, so consumers can trust the
+// fields they know (sdk.d.ts v0.3.233 L3152).
+type AssistantContextUsage struct {
+	// Model is the main-loop model the usage was computed for.
+	Model string `json:"model"`
+
+	// TotalTokens is the estimated tokens in use, unclamped — it may exceed
+	// RawMaxTokens when over limit.
+	TotalTokens int `json:"total_tokens"`
+
+	// RawMaxTokens is the window usage is measured against: the resolved
+	// autocompact window — the model's believed limit, or a smaller
+	// compaction-policy window (a configured value, or e.g. the 200K boundary
+	// on 1M-window models).
+	RawMaxTokens int `json:"raw_max_tokens"`
+
+	// Percentage is the rounded TotalTokens / RawMaxTokens, 0-100+.
+	Percentage float64 `json:"percentage"`
+
+	// OverLimit is set when TotalTokens exceeds RawMaxTokens.
+	OverLimit *ContextUsageOverLimit `json:"over_limit,omitempty"`
+
+	Categories  []AssistantContextUsageCategory `json:"categories"`
+	McpTools    []ContextUsageReportMcpTool     `json:"mcp_tools"`
+	MemoryFiles []ContextUsageReportMemoryFile  `json:"memory_files"`
+	Agents      []ContextUsageReportAgent       `json:"agents"`
+
+	// Skills is omitted when no skills contribute tokens.
+	Skills []ContextUsageReportSkill `json:"skills,omitempty"`
+}
+
+// ContextUsageOverLimit describes by how much a context window was overrun.
+type ContextUsageOverLimit struct {
+	TokensOver int `json:"tokens_over"`
+
+	// Kind says how the window was resolved, not whether the API will accept
+	// the next request: ContextWindowHardLimit means the window is the model's
+	// believed limit, so the API will refuse past it; ContextWindowCompaction
+	// means a compaction-policy window, which may or may not coincide with the
+	// model's hard limit.
+	Kind ContextWindowKind `json:"kind"`
+}
+
+// ContextWindowKind identifies how a context window limit was resolved.
+type ContextWindowKind string
+
+const (
+	// ContextWindowHardLimit is the model's believed limit — the API refuses
+	// requests past it.
+	ContextWindowHardLimit ContextWindowKind = "hard_limit"
+	// ContextWindowCompaction is a compaction-policy window, which may or may
+	// not coincide with the model's hard limit.
+	ContextWindowCompaction ContextWindowKind = "compaction_window"
+)
+
+// AssistantContextUsageCategory is one row of the /context usage-by-category
+// breakdown. Rows may carry zero tokens; renderers typically hide those.
+type AssistantContextUsageCategory struct {
+	// Name is the display name of the row as the CLI renders it, e.g.
+	// "Messages" or "MCP tools (deferred)". Classify rows on Kind, not on this.
+	Name   string `json:"name"`
+	Tokens int    `json:"tokens"`
+
+	Kind ContextUsageCategoryKind `json:"kind"`
+}
+
+// ContextUsageCategoryKind classifies a context-usage category row.
+type ContextUsageCategoryKind string
+
+const (
+	// ContextUsageUsed marks content that occupies the window.
+	ContextUsageUsed ContextUsageCategoryKind = "used"
+	// ContextUsageFree marks the remaining window.
+	ContextUsageFree ContextUsageCategoryKind = "free"
+	// ContextUsageBuffer marks the compaction reserve (autocompact or manual).
+	ContextUsageBuffer ContextUsageCategoryKind = "buffer"
+	// ContextUsageDeferred marks out-of-window tool schemas — listed for
+	// awareness, excluded from usage math.
+	ContextUsageDeferred ContextUsageCategoryKind = "deferred"
+)
+
+// ContextUsageReportMcpTool is one MCP tool's contribution to the context.
+type ContextUsageReportMcpTool struct {
+	// Name is the wire name, e.g. "mcp__linear__create_issue".
+	Name       string `json:"name"`
+	ServerName string `json:"server_name"`
+	Tokens     int    `json:"tokens"`
+}
+
+// ContextUsageReportMemoryFile is one memory file's contribution to the context.
+type ContextUsageReportMemoryFile struct {
+	Path string `json:"path"`
+	// Type is the display label of the memory-file source, e.g. "Project" or
+	// "User".
+	Type   string `json:"type"`
+	Tokens int    `json:"tokens"`
+}
+
+// ContextUsageReportAgent is one agent definition's contribution to the context.
+type ContextUsageReportAgent struct {
+	AgentType string `json:"agent_type"`
+	// Source is the raw source identifier, e.g. "projectSettings",
+	// "userSettings", "plugin". Built-in agents are excluded by the producer;
+	// display labels are the renderer's concern.
+	Source string `json:"source"`
+	Tokens int    `json:"tokens"`
+}
+
+// ContextUsageReportSkill is one skill's contribution to the context.
+type ContextUsageReportSkill struct {
+	Name string `json:"name"`
+	// Source is the raw source identifier, e.g. "userSettings", "plugin",
+	// "syncedSkills".
+	Source     string `json:"source"`
+	PluginName string `json:"plugin_name,omitempty"`
+	Tokens     int    `json:"tokens"`
 }
 
 // MessageType implements Message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -511,6 +511,141 @@ func TestAssistantMessageFieldsOmitEmpty(t *testing.T) {
 	assert.NotContains(t, got, "subagent_type")
 	assert.NotContains(t, got, "task_description")
 	assert.NotContains(t, got, "timestamp")
+	assert.NotContains(t, got, "context_usage")
+}
+
+func TestParseMessageAssistantContextUsage(t *testing.T) {
+	input := `{
+		"type": "assistant",
+		"message": {
+			"role": "assistant",
+			"content": [{"type": "text", "text": "| Category | Tokens |"}]
+		},
+		"context_usage": {
+			"model": "claude-opus-4-8",
+			"total_tokens": 214000,
+			"raw_max_tokens": 200000,
+			"percentage": 107,
+			"over_limit": {
+				"tokens_over": 14000,
+				"kind": "compaction_window"
+			},
+			"categories": [
+				{"name": "Messages", "tokens": 180000, "kind": "used"},
+				{"name": "Free space", "tokens": 0, "kind": "free"},
+				{"name": "Autocompact buffer", "tokens": 20000, "kind": "buffer"},
+				{"name": "MCP tools (deferred)", "tokens": 9000, "kind": "deferred"}
+			],
+			"mcp_tools": [
+				{"name": "mcp__linear__create_issue", "server_name": "linear", "tokens": 900}
+			],
+			"memory_files": [
+				{"path": "/repo/CLAUDE.md", "type": "Project", "tokens": 1200}
+			],
+			"agents": [
+				{"agent_type": "code-reviewer", "source": "projectSettings", "tokens": 800}
+			],
+			"skills": [
+				{"name": "roasbeef-prose", "source": "plugin", "plugin_name": "openclaw-skills", "tokens": 400}
+			]
+		}
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	assistantMsg, ok := msg.(AssistantMessage)
+	require.True(t, ok, "expected AssistantMessage")
+
+	usage := assistantMsg.ContextUsage
+	require.NotNil(t, usage)
+	assert.Equal(t, "claude-opus-4-8", usage.Model)
+	assert.Equal(t, 214000, usage.TotalTokens)
+	assert.Equal(t, 200000, usage.RawMaxTokens)
+	assert.Equal(t, float64(107), usage.Percentage)
+
+	require.NotNil(t, usage.OverLimit)
+	assert.Equal(t, 14000, usage.OverLimit.TokensOver)
+	assert.Equal(t, ContextWindowCompaction, usage.OverLimit.Kind)
+
+	require.Len(t, usage.Categories, 4)
+	assert.Equal(t, "Messages", usage.Categories[0].Name)
+	assert.Equal(t, 180000, usage.Categories[0].Tokens)
+	assert.Equal(t, ContextUsageUsed, usage.Categories[0].Kind)
+	assert.Equal(t, ContextUsageFree, usage.Categories[1].Kind)
+	assert.Equal(t, ContextUsageBuffer, usage.Categories[2].Kind)
+	assert.Equal(t, ContextUsageDeferred, usage.Categories[3].Kind)
+
+	require.Len(t, usage.McpTools, 1)
+	assert.Equal(t, "mcp__linear__create_issue", usage.McpTools[0].Name)
+	assert.Equal(t, "linear", usage.McpTools[0].ServerName)
+	assert.Equal(t, 900, usage.McpTools[0].Tokens)
+
+	require.Len(t, usage.MemoryFiles, 1)
+	assert.Equal(t, "/repo/CLAUDE.md", usage.MemoryFiles[0].Path)
+	assert.Equal(t, "Project", usage.MemoryFiles[0].Type)
+
+	require.Len(t, usage.Agents, 1)
+	assert.Equal(t, "code-reviewer", usage.Agents[0].AgentType)
+	assert.Equal(t, "projectSettings", usage.Agents[0].Source)
+
+	require.Len(t, usage.Skills, 1)
+	assert.Equal(t, "roasbeef-prose", usage.Skills[0].Name)
+	assert.Equal(t, "openclaw-skills", usage.Skills[0].PluginName)
+	assert.Equal(t, 400, usage.Skills[0].Tokens)
+}
+
+// Older CLIs attach no context_usage at all, and a within-limit report carries
+// neither over_limit nor skills.
+func TestParseMessageAssistantContextUsageOptionalFields(t *testing.T) {
+	t.Run("absent", func(t *testing.T) {
+		msg, err := ParseMessage([]byte(`{
+			"type": "assistant",
+			"message": {"role": "assistant", "content": []}
+		}`))
+		require.NoError(t, err)
+
+		assistantMsg, ok := msg.(AssistantMessage)
+		require.True(t, ok)
+		assert.Nil(t, assistantMsg.ContextUsage)
+	})
+
+	t.Run("within limit", func(t *testing.T) {
+		msg, err := ParseMessage([]byte(`{
+			"type": "assistant",
+			"message": {"role": "assistant", "content": []},
+			"context_usage": {
+				"model": "claude-sonnet-4-6",
+				"total_tokens": 42000,
+				"raw_max_tokens": 200000,
+				"percentage": 21,
+				"categories": [{"name": "Messages", "tokens": 42000, "kind": "used"}],
+				"mcp_tools": [],
+				"memory_files": [],
+				"agents": []
+			}
+		}`))
+		require.NoError(t, err)
+
+		assistantMsg, ok := msg.(AssistantMessage)
+		require.True(t, ok)
+		require.NotNil(t, assistantMsg.ContextUsage)
+		assert.Nil(t, assistantMsg.ContextUsage.OverLimit)
+		assert.Empty(t, assistantMsg.ContextUsage.Skills)
+	})
+}
+
+func TestAssistantContextUsageOmitEmpty(t *testing.T) {
+	usage := AssistantContextUsage{Model: "claude-opus-4-8"}
+
+	data, err := json.Marshal(usage)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.NotContains(t, got, "over_limit")
+	assert.NotContains(t, got, "skills")
 }
 
 func TestAssistantMessageErrorOmitEmpty(t *testing.T) {


### PR DESCRIPTION
In this PR, we teach `AssistantMessage` about `context_usage`, the structured twin of the `/context` report that TS SDK v0.3.233 added at `sdk.d.ts` L3058. When a user runs `/context`, the CLI answers with a synthetic assistant message carrying a markdown table; from CLI 2.1.233 on it also attaches this field alongside, so a consumer can render the usage card without parsing markdown out of the text block. The markdown stays the canonical fallback for older CLIs.

Like `resumed_from_incomplete_thinking`, it's a wrapper-level sibling and never lands inside `message.content`, so it isn't replayed to the model.

## Why not the existing context-usage type

We already have `SDKControlGetContextUsageResponse` in `query_types.go`, and it would be tempting to reuse it. It's a different wire shape: camelCase, the answer to the `/context` **control request**, and it carries the full internal breakdown (`gridRows`, `systemPromptSections`, `messageBreakdown`, `apiUsage`). The new one is snake_case, rides on the message, and is a deliberately smaller subset that upstream commits to evolving additively (a breaking reshape would ship as a sibling field). So we add `AssistantContextUsage` next to it rather than trying to unify the two, and the doc comment on each says which is which.

The two discriminators (`over_limit.kind`, `categories[].kind`) get named string types with consts instead of bare strings. The TS docs are explicit that rows must be classified on `kind` and never on the display `name`, so that warning is carried into the Go comment where someone reading `Name` will actually see it.

## Testing

Unit coverage in `messages_test.go` parses a full report (over-limit, all four category kinds, MCP tools, memory files, agents, skills with a plugin name), plus a table for the optional-field cases: absent entirely on older CLIs, and present-but-within-limit where `over_limit` and `skills` are both omitted. Round-trip omitempty is asserted on both the message field and the report itself.

`TestIntegrationAssistantContextUsage` drives a real `/context` query and checks the invariants when the field shows up: every row classifies, the `used` rows sum to `total_tokens` (deferred rows are out-of-window tool schemas and excluded from the math), and `over_limit` only appears when the total actually exceeds the window. The CLI installed in CI is 2.1.222, which answers with the table alone, so the test currently skips with that reason after doing the live round trip. It'll start asserting for real the moment the binary catches up, no code change needed.

Part of #199. See `memory/catchup-v0.3.233/PLAN.md` §"PR 1".