### PR TITLE
messages: add terminal_slash_commands to the init message

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2360,3 +2360,39 @@ func TestIntegrationResumeDropsTurn(t *testing.T) {
 	// unattributable entry sits in the discarded range.
 	t.Skip("not triggerable from CLI: installed CLI 2.1.222 does not implement --resume-drops-turn; tracked in INTEGRATION-FOLLOWUPS.md")
 }
+
+// TestIntegrationInitTerminalSlashCommands checks the terminal-bound subset of
+// the init message's advertised slash commands. CLIs older than 2.1.233 tag
+// nothing, in which case the field is absent and a remote UI showing every
+// command is the correct fallback.
+func TestIntegrationInitTerminalSlashCommands(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	client, err := NewClient(isolatedClientOptions(t)...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var init *SystemMessage
+	for msg := range client.Query(ctx, "Say hi") {
+		system, ok := msg.(SystemMessage)
+		if !ok || system.Subtype != "init" {
+			continue
+		}
+		init = &system
+		break
+	}
+	require.NotNil(t, init, "expected an init system message")
+	require.NotEmpty(t, init.SlashCommands)
+
+	if len(init.TerminalSlashCommands) == 0 {
+		t.Skip("CLI advertised no terminal-bound slash commands; " +
+			"needs a CLI at 2.1.233 or newer")
+	}
+
+	assert.Subset(t, init.SlashCommands, init.TerminalSlashCommands,
+		"every terminal command must also appear in slash_commands")
+}

--- a/messages.go
+++ b/messages.go
@@ -832,24 +832,32 @@ type Usage struct {
 // This message is sent at the start of a session and contains information
 // about available tools, MCP servers, models, and permissions.
 type SystemMessage struct {
-	Type              string          `json:"type"`                      // Always "system"
-	Subtype           string          `json:"subtype"`                   // "init" or "compact_boundary"
-	UUID              string          `json:"uuid"`                      // Unique message ID
-	SessionID         string          `json:"session_id"`                // Session identifier
-	APIKeySource      string          `json:"apiKeySource"`              // Where the API key comes from
-	Cwd               string          `json:"cwd"`                       // Current working directory
-	Tools             []string        `json:"tools"`                     // Available tools
-	MCPServers        []MCPServerInfo `json:"mcp_servers"`               // MCP server status
-	Model             string          `json:"model"`                     // Active model
-	PermissionMode    PermissionMode  `json:"permissionMode"`            // Current permission mode
-	SlashCommands     []string        `json:"slash_commands"`            // Available slash commands
-	OutputStyle       string          `json:"output_style"`              // Output formatting style
-	ClaudeCodeVersion string          `json:"claude_code_version"`       // Claude Code version
-	Skills            []string        `json:"skills"`                    // Available skills
-	Plugins           []SystemPlugin  `json:"plugins"`                   // Available plugins
-	Agents            []string        `json:"agents,omitempty"`          // Available agents
-	Betas             []string        `json:"betas,omitempty"`           // Enabled beta flags
-	FastModeState     *FastModeState  `json:"fast_mode_state,omitempty"` // Fast mode state
+	Type           string          `json:"type"`           // Always "system"
+	Subtype        string          `json:"subtype"`        // "init" or "compact_boundary"
+	UUID           string          `json:"uuid"`           // Unique message ID
+	SessionID      string          `json:"session_id"`     // Session identifier
+	APIKeySource   string          `json:"apiKeySource"`   // Where the API key comes from
+	Cwd            string          `json:"cwd"`            // Current working directory
+	Tools          []string        `json:"tools"`          // Available tools
+	MCPServers     []MCPServerInfo `json:"mcp_servers"`    // MCP server status
+	Model          string          `json:"model"`          // Active model
+	PermissionMode PermissionMode  `json:"permissionMode"` // Current permission mode
+	SlashCommands  []string        `json:"slash_commands"` // Available slash commands
+	// TerminalSlashCommands is the subset of SlashCommands whose UX is bound
+	// to the local terminal, e.g. exit and statusline. Phone and other remote
+	// UIs should hide these from command menus; desktop surfaces may keep
+	// them. Set only when non-empty, so an empty slice means either an older
+	// CLI or a session where no advertised command carries the tag — in both
+	// cases, showing everything is the safe fallback (sdk.d.ts v0.3.233
+	// L4712).
+	TerminalSlashCommands []string       `json:"terminal_slash_commands,omitempty"`
+	OutputStyle           string         `json:"output_style"`              // Output formatting style
+	ClaudeCodeVersion     string         `json:"claude_code_version"`       // Claude Code version
+	Skills                []string       `json:"skills"`                    // Available skills
+	Plugins               []SystemPlugin `json:"plugins"`                   // Available plugins
+	Agents                []string       `json:"agents,omitempty"`          // Available agents
+	Betas                 []string       `json:"betas,omitempty"`           // Enabled beta flags
+	FastModeState         *FastModeState `json:"fast_mode_state,omitempty"` // Fast mode state
 	// FastModeDisabledReason explains why fast mode could not serve, when
 	// FastModeState is not "on". Absent when nothing blocks it.
 	FastModeDisabledReason *FastModeDisabledReason `json:"fast_mode_disabled_reason,omitempty"`

--- a/messages_test.go
+++ b/messages_test.go
@@ -2056,6 +2056,47 @@ func TestParseMessageSystemInit(t *testing.T) {
 	assert.Equal(t, []string{"/help"}, systemMsg.SlashCommands)
 	assert.Equal(t, "default", systemMsg.OutputStyle)
 	assert.Empty(t, systemMsg.Capabilities, "capabilities absent on older CLIs")
+	assert.Empty(t, systemMsg.TerminalSlashCommands,
+		"terminal_slash_commands absent on older CLIs")
+}
+
+func TestParseMessageSystemInitTerminalSlashCommands(t *testing.T) {
+	input := `{
+		"type": "system",
+		"subtype": "init",
+		"uuid": "550e8400-e29b-41d4-a716-446655440800",
+		"session_id": "sess_term_001",
+		"apiKeySource": "env",
+		"cwd": "/workspace/project",
+		"tools": ["Read"],
+		"mcp_servers": [],
+		"model": "claude-opus-4-5-20250929",
+		"permissionMode": "default",
+		"slash_commands": ["/help", "/exit", "/statusline"],
+		"terminal_slash_commands": ["/exit", "/statusline"],
+		"output_style": "default"
+	}`
+
+	msg, err := ParseMessage([]byte(input))
+	require.NoError(t, err)
+
+	systemMsg, ok := msg.(SystemMessage)
+	require.True(t, ok, "expected SystemMessage")
+
+	assert.Equal(t, []string{"/exit", "/statusline"},
+		systemMsg.TerminalSlashCommands)
+	assert.Subset(t, systemMsg.SlashCommands, systemMsg.TerminalSlashCommands,
+		"terminal commands must also be advertised in slash_commands")
+}
+
+func TestSystemMessageTerminalSlashCommandsOmitEmpty(t *testing.T) {
+	data, err := json.Marshal(SystemMessage{Type: "system", Subtype: "init"})
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.NotContains(t, got, "terminal_slash_commands")
 }
 
 func TestParseMessageSystemInitCapabilities(t *testing.T) {


### PR DESCRIPTION
In this PR, we add `terminal_slash_commands` to `SystemMessage`, from `sdk.d.ts` L4712. It's the subset of `slash_commands` whose UX is bound to the local terminal, `exit` and `statusline` being the examples upstream gives. A phone or other remote UI should hide these from its command menu; desktop surfaces can keep them.

The CLI sends the field only when it's non-empty, so an empty slice on our side means either a CLI that predates the tag or a session where none of the advertised commands carry it. Showing everything is the correct fallback in both of those cases, which is why this stays a plain `omitempty` slice and not a pointer: there's no behavioral difference between "absent" and "empty" worth modeling.

## Testing

`messages_test.go` gets a parse test with a tagged init payload, plus an omitempty round-trip, and the pre-existing older-CLI init test now also asserts the field stays empty when the CLI doesn't send it.

`TestIntegrationInitTerminalSlashCommands` pulls the real init message off a live query and asserts the containment invariant: every terminal command has to also appear in `slash_commands`. The 2.1.222 binary in CI tags nothing, so it skips with that reason after the round trip, and starts asserting once the binary catches up.

Part of #199. See `memory/catchup-v0.3.233/PLAN.md` §"PR 2".