### PR TITLE
options: add the command plugin source and its managed gate

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2091,6 +2091,24 @@ exec "$real_cli" "$@"
 		require.NoError(t, json.Unmarshal([]byte(argValue(t, argv, "--managed-settings")), &got))
 		assert.Equal(t, want.Env, got.Env)
 	})
+
+	// Only the gate is asserted live. Feeding a command-sourced marketplace to
+	// a CLI that predates the variant makes it fail schema validation on the
+	// managed tier and stall the handshake, so that half stays in
+	// TestIntegrationSettingsMiscFields with the other source variants until
+	// the installed binary is new enough to accept it.
+	t.Run("disable_command_plugin_sources", func(t *testing.T) {
+		disable := true
+
+		argv := runWithArgvCapture(t, WithManagedSettings(Settings{
+			DisableCommandPluginSources: &disable,
+		}))
+
+		var got Settings
+		require.NoError(t, json.Unmarshal([]byte(argValue(t, argv, "--managed-settings")), &got))
+		require.NotNil(t, got.DisableCommandPluginSources)
+		assert.True(t, *got.DisableCommandPluginSources)
+	})
 }
 
 func TestIntegrationSettingsManagedOrgFields(t *testing.T) {
@@ -2147,11 +2165,14 @@ func TestIntegrationSettingsMiscFields(t *testing.T) {
 
 	// TODO: Backfill when the CLI test fixture can deterministically inject
 	// statusLine.hideVimModeIndicator and the marketplace skills-dir /
-	// unsupported source variants via managed-settings.json so the SDK can
-	// observe them round-tripping through the resolved-settings transport. Both
-	// fields are consumed by CLI renderer / registration code paths the Go SDK
-	// does not invoke directly.
-	t.Skip("not directly assertable from CLI: statusLine.hideVimModeIndicator and marketplace skills-dir/unsupported source variants are consumed by CLI code paths the Go SDK does not invoke")
+	// unsupported / command source variants via managed-settings.json so the
+	// SDK can observe them round-tripping through the resolved-settings
+	// transport. Both fields are consumed by CLI renderer / registration code
+	// paths the Go SDK does not invoke directly. The command variant has a
+	// second blocker on top of that: the installed 2.1.222 binary predates it,
+	// so it fails schema validation on the managed tier and stalls the
+	// handshake rather than round-tripping.
+	t.Skip("not directly assertable from CLI: statusLine.hideVimModeIndicator and marketplace skills-dir/unsupported/command source variants are consumed by CLI code paths the Go SDK does not invoke")
 }
 
 func TestIntegrationToolAliases(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -371,6 +371,16 @@ type Settings struct {
 	// at startup, closing the CLI-flag bypass of strictKnownMarketplaces.
 	// Honored only from managed settings. Mirrors sdk.d.ts v0.3.195 L5712.
 	DisableSideloadFlags *bool `json:"disableSideloadFlags,omitempty"`
+	// DisableCommandPluginSources gates the "command" plugin source, whose
+	// plugin directory is produced by running a marketplace-declared command on
+	// this machine (see SettingsMarketplaceSourceCommand). True means
+	// command-sourced plugins are never installed, updated, or re-resolved, so
+	// the command never runs; false allows them explicitly. Left nil it follows
+	// AllowManagedHooksOnly, on the reasoning that an org restricting hook
+	// execution to managed settings wants arbitrary plugin-resolution commands
+	// off too. Honored only from managed settings. Mirrors sdk.d.ts v0.3.233
+	// L6898.
+	DisableCommandPluginSources *bool `json:"disableCommandPluginSources,omitempty"`
 	// PluginSuggestionMarketplaces names managed marketplaces whose plugins may surface as contextual install suggestions. Honored only from managed settings. Mirrors sdk.d.ts v0.3.168 L5242.
 	PluginSuggestionMarketplaces []string `json:"pluginSuggestionMarketplaces,omitempty"`
 	// ForceLoginMethod pins the login flow: "claudeai" for Claude Pro/Max, "console" for Console billing, "gateway" for the Cloud gateway OIDC device flow (the "gateway" variant was added in v0.3.168). Mirrors sdk.d.ts v0.3.168 L5246.
@@ -745,6 +755,24 @@ const (
 	// changing only the digest while a version is declared does not trigger an
 	// update. Mirrors sdk.d.ts v0.3.226 L5869.
 	SettingsMarketplaceSourceArchive SettingsMarketplaceSourceKind = "archive"
+	// SettingsMarketplaceSourceCommand identifies a plugin source whose
+	// directory is produced by running a command on this machine. Honors
+	// "command": string (a shell command that prints the absolute path of the
+	// plugin directory on stdout, exactly one line, and exits 0, having left a
+	// complete plugin there), optional "timeout": number (seconds to wait,
+	// default 60) and optional "mode": "copy" | "link".
+	//
+	// The command runs through the platform shell from the user's home
+	// directory, and is re-resolved on every install and update plus once per
+	// session in the background, so the printed path may differ between runs.
+	// Under the default "copy" mode the directory is copied into the plugin
+	// cache and content-hashed, so it may be deleted afterwards. Under "link"
+	// the cache entry points at the printed directory in place (no copy, no
+	// size limit, macOS/Linux only), which means the directory has to stay
+	// valid for as long as Claude Code runs, and a changed printed path is the
+	// only signal of new content. See Settings.DisableCommandPluginSources for
+	// the managed-settings gate. Mirrors sdk.d.ts v0.3.233 L5974.
+	SettingsMarketplaceSourceCommand SettingsMarketplaceSourceKind = "command"
 	// SettingsMarketplaceSourceUnsupported identifies a bare-tag unsupported marketplace source. Mirrors sdk.d.ts v0.3.150 L4619.
 	// Honors optional "error": string carrying why the source was rejected, per sdk.d.ts v0.3.226 L5871.
 	SettingsMarketplaceSourceUnsupported SettingsMarketplaceSourceKind = "unsupported"

--- a/options_test.go
+++ b/options_test.go
@@ -1408,6 +1408,53 @@ func TestSettingsMarketplaceSourceVariants(t *testing.T) {
 		assert.NotContains(t, got, "sha256")
 	})
 
+	t.Run("command source round-trips with timeout and mode", func(t *testing.T) {
+		in := Settings{
+			ExtraKnownMarketplaces: map[string]SettingsMarketplace{
+				"internal-export": {
+					Source: SettingsMarketplaceSource{
+						"source":  string(SettingsMarketplaceSourceCommand),
+						"command": "/opt/corp/bin/export-plugin --print-path",
+						"timeout": 120,
+						"mode":    "link",
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		got := out.ExtraKnownMarketplaces["internal-export"].Source
+		assert.Equal(t, "command", got["source"])
+		assert.Equal(t, "/opt/corp/bin/export-plugin --print-path", got["command"])
+		assert.Equal(t, float64(120), got["timeout"])
+		assert.Equal(t, "link", got["mode"])
+	})
+
+	t.Run("command source round-trips bare", func(t *testing.T) {
+		in := Settings{
+			ExtraKnownMarketplaces: map[string]SettingsMarketplace{
+				"internal-export": {
+					Source: SettingsMarketplaceSource{
+						"source":  string(SettingsMarketplaceSourceCommand),
+						"command": "echo /srv/plugins/corp",
+					},
+				},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		got := out.ExtraKnownMarketplaces["internal-export"].Source
+		assert.Len(t, got, 2)
+		assert.NotContains(t, got, "timeout")
+		assert.NotContains(t, got, "mode")
+	})
+
 	t.Run("unsupported source carries an error string", func(t *testing.T) {
 		in := Settings{
 			ExtraKnownMarketplaces: map[string]SettingsMarketplace{
@@ -1776,5 +1823,42 @@ func TestSettingsParityV0201FieldsJSON(t *testing.T) {
 		require.NoError(t, json.Unmarshal(data, &got))
 		assert.NotContains(t, got, "enableArtifact")
 		assert.NotContains(t, got, "askUserQuestionTimeout")
+	})
+}
+
+func TestSettingsDisableCommandPluginSourcesJSON(t *testing.T) {
+	t.Run("explicit values are emitted", func(t *testing.T) {
+		for _, v := range []bool{true, false} {
+			data, err := json.Marshal(Settings{
+				DisableCommandPluginSources: &v,
+			})
+			require.NoError(t, err)
+
+			var got map[string]interface{}
+			require.NoError(t, json.Unmarshal(data, &got))
+			assert.Equal(t, v, got["disableCommandPluginSources"])
+		}
+	})
+
+	// Unset is not the same as false: it defers to allowManagedHooksOnly, so
+	// the key has to stay off the wire rather than serialize as false.
+	t.Run("nil omits the key", func(t *testing.T) {
+		data, err := json.Marshal(Settings{})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "disableCommandPluginSources")
+	})
+
+	t.Run("round-trips", func(t *testing.T) {
+		tr := true
+		data, err := json.Marshal(Settings{DisableCommandPluginSources: &tr})
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		require.NotNil(t, out.DisableCommandPluginSources)
+		assert.True(t, *out.DisableCommandPluginSources)
 	})
 }


### PR DESCRIPTION
In this PR, we add the `command` marketplace source (`sdk.d.ts` L5974, repeated across all five copies of the marketplace schema) plus `disableCommandPluginSources`, the managed-settings gate that turns it off (L6898).

Unlike every other source, a `command` plugin isn't fetched, it's produced. The marketplace declares a shell command; that command prints exactly one absolute path on stdout, exits 0, and has to leave a complete plugin sitting at that path. It runs through the platform shell from the user's home directory.

Two details land in the doc comment because they're the ones that bite in practice. The path is re-resolved on every install and update plus once per session in the background, so it can differ run to run. And under `mode: "link"` the cache entry points at the printed directory in place instead of copying it (no size limit, macOS/Linux), which flips the lifetime contract: the directory has to stay valid for as long as Claude Code runs, and a changed printed path becomes the only signal of new content.

Running a marketplace-declared command on the user's machine is a bigger ask than fetching an archive, which is what `disableCommandPluginSources` is for. Left unset it follows `allowManagedHooksOnly`, on the reasoning that an org that locked hook execution down to managed settings didn't mean to leave arbitrary plugin-resolution commands wide open. It stays a `*bool` for exactly that reason: unset and `false` are different states here, so the key has to be able to stay off the wire.

The source itself is one const on `SettingsMarketplaceSourceKind`, same shape as the `archive` source in #196, since `SettingsMarketplaceSource` is an open map and the keys live in the comment.

## Testing

`options_test.go` round-trips the source both fully populated (`timeout`, `mode`) and bare, asserting the optional keys stay off the wire, plus a table on the gate covering `true`, `false`, and nil-omits-the-key.

For the integration side, `TestIntegrationSettingsOptions` gets a `disable_command_plugin_sources` case that pushes the gate through `--managed-settings` and confirms the CLI comes up on it.

The source variant does **not** get a live case, and that's worth flagging: I tried it first and the handshake stalled for the full 120s timeout. Running it against the bare CLI shows why:

```
$ claude --managed-settings '{"extraKnownMarketplaces":{"internal-export":{"source":{"source":"command",...}}}}' -p "say ok"
Contact your administrator.

Detail: parent managed settings: Failed schema validation. This field was ignored.
```

The installed 2.1.222 binary predates the variant, so it fails schema validation on the managed tier and the init never completes. That half is parked in `TestIntegrationSettingsMiscFields` alongside the other source variants the SDK doesn't drive, with the version blocker written down.

Part of #199. See `memory/catchup-v0.3.233/PLAN.md` §"PR 3".