### PR TITLE
options: add the marketplace settings alias keys

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2109,6 +2109,42 @@ exec "$real_cli" "$@"
 		require.NotNil(t, got.DisableCommandPluginSources)
 		assert.True(t, *got.DisableCommandPluginSources)
 	})
+
+	// Whether the CLI resolves these to their canonical spellings is its
+	// business, and 2.1.222 predates them so it won't. What's ours is that they
+	// serialize under their own keys, don't get folded into the canonical ones,
+	// and don't trip managed-tier schema validation on the way through.
+	t.Run("marketplace_aliases", func(t *testing.T) {
+		want := Settings{
+			AdditionalMarketplaces: map[string]SettingsMarketplace{
+				"vendor": {
+					Source: SettingsMarketplaceSource{
+						"source":  string(SettingsMarketplaceSourceNPM),
+						"package": "@vendor/plugins",
+					},
+				},
+			},
+			AllowedMarketplaces: []SettingsMarketplaceSource{
+				{
+					"source":      string(SettingsMarketplaceSourcePathPattern),
+					"pathPattern": "^/opt/approved/",
+				},
+			},
+		}
+
+		argv := runWithArgvCapture(t, WithManagedSettings(want))
+		var got Settings
+		require.NoError(t, json.Unmarshal([]byte(argValue(t, argv, "--managed-settings")), &got))
+
+		assert.Contains(t, got.AdditionalMarketplaces, "vendor")
+		assert.Empty(t, got.ExtraKnownMarketplaces,
+			"alias must not be folded into the canonical key")
+
+		require.Len(t, got.AllowedMarketplaces, 1)
+		assert.Equal(t, "^/opt/approved/", got.AllowedMarketplaces[0]["pathPattern"])
+		assert.Empty(t, got.StrictKnownMarketplaces,
+			"alias must not be folded into the canonical key")
+	})
 }
 
 func TestIntegrationSettingsManagedOrgFields(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -366,6 +366,23 @@ type Settings struct {
 	// (sdk.d.ts v0.3.226 L5909, L6112).
 	StrictKnownMarketplaces []SettingsMarketplaceSource `json:"strictKnownMarketplaces,omitempty"`
 	BlockedMarketplaces     []SettingsMarketplaceSource `json:"blockedMarketplaces,omitempty"`
+	// AdditionalMarketplaces is read exactly as if it were spelled
+	// ExtraKnownMarketplaces. Setting both in one file makes this one lose: it
+	// is ignored with a warning. Claude Code may also rewrite the key back to
+	// extraKnownMarketplaces when it updates the file.
+	//
+	// Prefer ExtraKnownMarketplaces while older clients still share the same
+	// settings: a client predating the alias ignores it outright, and its
+	// settings sync then uploads a file that declares no marketplaces at all.
+	// Mirrors sdk.d.ts v0.3.233 L6023.
+	AdditionalMarketplaces map[string]SettingsMarketplace `json:"additionalMarketplaces,omitempty"`
+	// AllowedMarketplaces is read exactly as if it were spelled
+	// StrictKnownMarketplaces, and like it is honored only from managed
+	// settings. Setting both in one file makes this one lose: it is ignored
+	// with a warning. Keep using StrictKnownMarketplaces when the allowlist
+	// must also bind clients that predate the alias, since they ignore this
+	// spelling and would run unrestricted. Mirrors sdk.d.ts v0.3.233 L6468.
+	AllowedMarketplaces []SettingsMarketplaceSource `json:"allowedMarketplaces,omitempty"`
 	// DisableSideloadFlags, when true and set in managed settings, rejects the
 	// --plugin-dir, --plugin-url, --agents, and non-sdk --mcp-config CLI flags
 	// at startup, closing the CLI-flag bypass of strictKnownMarketplaces.

--- a/options_test.go
+++ b/options_test.go
@@ -1862,3 +1862,97 @@ func TestSettingsDisableCommandPluginSourcesJSON(t *testing.T) {
 		assert.True(t, *out.DisableCommandPluginSources)
 	})
 }
+
+// The alias keys have to serialize under their own spelling and stay
+// independent of the canonical keys, since the CLI warns and drops the alias
+// when both appear in one file.
+func TestSettingsMarketplaceAliasesJSON(t *testing.T) {
+	t.Run("aliases serialize under their own keys", func(t *testing.T) {
+		data, err := json.Marshal(Settings{
+			AdditionalMarketplaces: map[string]SettingsMarketplace{
+				"vendor": {
+					Source: SettingsMarketplaceSource{
+						"source":  string(SettingsMarketplaceSourceNPM),
+						"package": "@vendor/plugins",
+					},
+				},
+			},
+			AllowedMarketplaces: []SettingsMarketplaceSource{
+				{
+					"source":      string(SettingsMarketplaceSourceHostPattern),
+					"hostPattern": "^github\\.corp\\.example$",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Contains(t, got, "additionalMarketplaces")
+		assert.Contains(t, got, "allowedMarketplaces")
+		assert.NotContains(t, got, "extraKnownMarketplaces")
+		assert.NotContains(t, got, "strictKnownMarketplaces")
+	})
+
+	t.Run("aliases round-trip", func(t *testing.T) {
+		in := Settings{
+			AdditionalMarketplaces: map[string]SettingsMarketplace{
+				"vendor": {
+					Source: SettingsMarketplaceSource{
+						"source": string(SettingsMarketplaceSourceGithub),
+						"repo":   "vendor/plugins",
+						"ref":    "v1.0.0",
+					},
+					InstallLocation: "/opt/marketplaces/vendor",
+				},
+			},
+			AllowedMarketplaces: []SettingsMarketplaceSource{
+				{"source": string(SettingsMarketplaceSourceGithub), "repo": "vendor/*"},
+			},
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+
+		vendor := out.AdditionalMarketplaces["vendor"]
+		assert.Equal(t, "github", vendor.Source["source"])
+		assert.Equal(t, "vendor/plugins", vendor.Source["repo"])
+		assert.Equal(t, "/opt/marketplaces/vendor", vendor.InstallLocation)
+
+		require.Len(t, out.AllowedMarketplaces, 1)
+		assert.Equal(t, "vendor/*", out.AllowedMarketplaces[0]["repo"])
+	})
+
+	// Both spellings decode side by side. The CLI is what resolves the
+	// conflict, so the SDK must not silently fold one into the other.
+	t.Run("canonical and alias decode independently", func(t *testing.T) {
+		var out Settings
+		require.NoError(t, json.Unmarshal([]byte(`{
+			"extraKnownMarketplaces": {
+				"canonical": {"source": {"source": "npm", "package": "@a/x"}}
+			},
+			"additionalMarketplaces": {
+				"aliased": {"source": {"source": "npm", "package": "@b/y"}}
+			},
+			"strictKnownMarketplaces": [{"source": "skills-dir"}],
+			"allowedMarketplaces": [{"source": "pathPattern", "pathPattern": "^/opt/"}]
+		}`), &out))
+
+		assert.Contains(t, out.ExtraKnownMarketplaces, "canonical")
+		assert.Contains(t, out.AdditionalMarketplaces, "aliased")
+		assert.Len(t, out.StrictKnownMarketplaces, 1)
+		assert.Len(t, out.AllowedMarketplaces, 1)
+	})
+
+	t.Run("nil omits both keys", func(t *testing.T) {
+		data, err := json.Marshal(Settings{})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "additionalMarketplaces")
+		assert.NotContains(t, got, "allowedMarketplaces")
+	})
+}


### PR DESCRIPTION
In this PR, we add `additionalMarketplaces` (`sdk.d.ts` L6023) and `allowedMarketplaces` (L6468). Neither is a new capability: the CLI reads them exactly as if they were spelled `extraKnownMarketplaces` and `strictKnownMarketplaces`, so they take the same Go types as the keys they alias, and `allowedMarketplaces` inherits the managed-settings-only restriction from its canonical twin.

The reason this is worth more than two struct fields is the migration hazard, which belongs in the doc comment where someone reaching for the shorter name will actually read it. A client that predates the alias ignores it outright. So a settings file written using only the new spelling reads, to that client, as declaring no marketplaces at all, and its settings sync will happily upload it that way. For `allowedMarketplaces` that failure mode is the dangerous direction: an allowlist that silently isn't there means unrestricted, not blocked. Setting both spellings in one file isn't a fix either, since the alias loses and gets dropped with a warning. The comments say to keep using the canonical spelling until the older clients sharing that file are gone.

We deliberately don't fold the alias into the canonical field on decode. Resolving that conflict is the CLI's job, and merging them here would paper over exactly the misconfiguration the CLI warns about.

## Testing

`options_test.go` covers the serialization contract in both directions, including a case that decodes all four keys side by side to prove the aliases stay independent of the canonical fields, plus the nil-omits-both case.

`TestIntegrationSettingsOptions` gets a `marketplace_aliases` case pushing both keys through `--managed-settings` and asserting they survive the trip under their own spellings without being folded. Worth noting what this does and doesn't prove: 2.1.222 predates the aliases so it won't resolve them, but it does accept them without tripping managed-tier schema validation, which is the part that would break the handshake. I checked that directly rather than assuming, since a nested `command` source in the same position does fail validation and stall init (see #202).

Part of #199. See `memory/catchup-v0.3.233/PLAN.md` §"PR 4".