### PR TITLE
options: add forceLoginGatewayUrl

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2109,6 +2109,23 @@ exec "$real_cli" "$@"
 		require.NotNil(t, got.DisableCommandPluginSources)
 		assert.True(t, *got.DisableCommandPluginSources)
 	})
+
+	// The login flow itself can't be driven here (the session is already
+	// authenticated), so this covers the reachable half: the pair survives the
+	// managed tier and the CLI starts on it.
+	t.Run("force_login_gateway_url", func(t *testing.T) {
+		want := Settings{
+			ForceLoginMethod:     "gateway",
+			ForceLoginGatewayURL: "https://gateway.corp.example",
+		}
+
+		argv := runWithArgvCapture(t, WithManagedSettings(want))
+		var got Settings
+		require.NoError(t, json.Unmarshal([]byte(argValue(t, argv, "--managed-settings")), &got))
+
+		assert.Equal(t, "gateway", got.ForceLoginMethod)
+		assert.Equal(t, want.ForceLoginGatewayURL, got.ForceLoginGatewayURL)
+	})
 }
 
 func TestIntegrationSettingsManagedOrgFields(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -384,7 +384,15 @@ type Settings struct {
 	// PluginSuggestionMarketplaces names managed marketplaces whose plugins may surface as contextual install suggestions. Honored only from managed settings. Mirrors sdk.d.ts v0.3.168 L5242.
 	PluginSuggestionMarketplaces []string `json:"pluginSuggestionMarketplaces,omitempty"`
 	// ForceLoginMethod pins the login flow: "claudeai" for Claude Pro/Max, "console" for Console billing, "gateway" for the Cloud gateway OIDC device flow (the "gateway" variant was added in v0.3.168). Mirrors sdk.d.ts v0.3.168 L5246.
-	ForceLoginMethod           string                       `json:"forceLoginMethod,omitempty"`
+	ForceLoginMethod string `json:"forceLoginMethod,omitempty"`
+	// ForceLoginGatewayURL is the Cloud gateway URL to pre-fill and
+	// auto-connect to during login, and only means anything alongside
+	// ForceLoginMethod "gateway". Honored only from admin-controlled managed
+	// settings (MDM, managed-settings.json, policy helper) and ignored in
+	// user, project, and remote-delivered settings, since pointing a login
+	// flow at an attacker-chosen gateway is exactly what that tier exists to
+	// prevent. Mirrors sdk.d.ts v0.3.233 L6914.
+	ForceLoginGatewayURL       string                       `json:"forceLoginGatewayUrl,omitempty"`
 	ForceLoginOrgUUID          interface{}                  `json:"forceLoginOrgUUID,omitempty"`
 	ForceRemoteSettingsRefresh *bool                        `json:"forceRemoteSettingsRefresh,omitempty"`
 	OtelHeadersHelper          string                       `json:"otelHeadersHelper,omitempty"`

--- a/options_test.go
+++ b/options_test.go
@@ -1862,3 +1862,32 @@ func TestSettingsDisableCommandPluginSourcesJSON(t *testing.T) {
 		assert.True(t, *out.DisableCommandPluginSources)
 	})
 }
+
+func TestSettingsForceLoginGatewayURLJSON(t *testing.T) {
+	t.Run("round-trips alongside forceLoginMethod", func(t *testing.T) {
+		in := Settings{
+			ForceLoginMethod:     "gateway",
+			ForceLoginGatewayURL: "https://gateway.corp.example",
+		}
+		data, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, "https://gateway.corp.example", got["forceLoginGatewayUrl"])
+
+		var out Settings
+		require.NoError(t, json.Unmarshal(data, &out))
+		assert.Equal(t, in.ForceLoginMethod, out.ForceLoginMethod)
+		assert.Equal(t, in.ForceLoginGatewayURL, out.ForceLoginGatewayURL)
+	})
+
+	t.Run("empty omits the key", func(t *testing.T) {
+		data, err := json.Marshal(Settings{ForceLoginMethod: "gateway"})
+		require.NoError(t, err)
+
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.NotContains(t, got, "forceLoginGatewayUrl")
+	})
+}


### PR DESCRIPTION
In this PR, we add `forceLoginGatewayUrl` (`sdk.d.ts` L6914), the Cloud gateway URL that the login flow pre-fills and auto-connects to. It only means anything alongside `forceLoginMethod: "gateway"`, so it sits directly next to that field.

Like the method it pairs with, it's honored only from admin-controlled managed settings (MDM, `managed-settings.json`, policy helper) and ignored in user, project, and remote-delivered settings. That restriction is the interesting part and it's what the doc comment leads with: a login flow that a project-local settings file could point at an attacker-chosen gateway is a credential handoff, so the admin tier is the only one allowed to say where it goes.

## Testing

`options_test.go` round-trips it with `forceLoginMethod` and covers empty-omits-the-key.

`TestIntegrationSettingsOptions` gets a `force_login_gateway_url` case pushing the pair through `--managed-settings`. The login flow itself isn't drivable from an already-authenticated integration session, so what this asserts is the reachable half: the pair survives the managed tier without tripping schema validation and the CLI comes up on it.

Part of #199. See `memory/catchup-v0.3.233/PLAN.md` §"PR 5".