### PR TITLE
docs: refresh TypeScript SDK parity to v0.3.233

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 package/*
 .sessions/
 .tasks/
+
+# Vendored TS SDK trees pulled for parity diffing during catchup cycles.
+scratch/

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ stdin/stdout, giving you access to Claude's tool use, extended thinking,
 session management, and hook system.
 
 This repository tracks the official TypeScript Agent SDK surface through the
-v0.3.226 catchup work, using Go idioms where the API shape differs.
+v0.3.233 catchup work, using Go idioms where the API shape differs.
 
 ```mermaid
 flowchart TB
@@ -635,6 +635,62 @@ follow-up work: with no `OnUserDialog` registered, the Go SDK answers a
 at least v0.3.220 so a renderer-bearing client or the worker's park deadline can
 settle it. v0.3.226 only reworded the doc comment to match the behavior it
 already had.
+
+The v0.3.233 catchup added:
+
+- `AssistantMessage.ContextUsage` — the structured twin of the `/context` report,
+  riding as a wrapper-level sibling on the synthetic assistant message that
+  delivers the markdown table, so it is never replayed to the model. This is a
+  separate wire shape from `SDKControlGetContextUsageResponse`, which mirrors the
+  camelCase `/context` control response: the new one is snake_case, deliberately
+  smaller, and upstream commits to evolving it additively. Category rows and the
+  over-limit reason get named kinds (`ContextUsageUsed` / `Free` / `Buffer` /
+  `Deferred`, `ContextWindowHardLimit` / `Compaction`); classify rows on the kind,
+  never on the display name.
+- `SystemMessage.TerminalSlashCommands` — the subset of `SlashCommands` whose UX
+  is bound to the local terminal (`exit`, `statusline`). Remote UIs should hide
+  these; empty means either an older CLI or an untagged session, and showing
+  everything is the right fallback for both.
+- `SettingsMarketplaceSourceCommand` — plugin sources whose directory is produced
+  by running a marketplace-declared command that prints one absolute path
+  (`command`, optional `timeout`, `mode: "copy"` / `"link"`). Under `link` the
+  cache points at that directory in place, so it must stay valid for the life of
+  the process and a changed path is the only signal of new content. Gated by the
+  managed-settings-only `DisableCommandPluginSources`, which follows
+  `AllowManagedHooksOnly` when unset.
+- `Settings.AdditionalMarketplaces` / `AllowedMarketplaces` — aliases read exactly
+  as `ExtraKnownMarketplaces` / `StrictKnownMarketplaces`. Prefer the canonical
+  spellings while older clients share the same settings file: they ignore the
+  alias outright, and an allowlist that silently isn't there means unrestricted.
+  The SDK does not fold aliases into the canonical fields, since resolving that
+  conflict is the CLI's job.
+- `Settings.ForceLoginGatewayURL` — the Cloud gateway URL to pre-fill and
+  auto-connect to alongside `ForceLoginMethod: "gateway"`. Admin-controlled
+  managed settings only.
+- `queued_notifications` on `SystemMessage.Capabilities` — the CLI accepts inbound
+  `queued_notification` stream messages and drains them via `ReadNotifications`.
+  Doc-only here: `Capabilities` is already an open `[]string`, and the drain tool
+  sits outside the curated `tool_inputs.go` subset.
+
+PRs in this cycle (squash-merged): #200 assistant `context_usage`, #201
+`terminal_slash_commands`, #202 command plugin source, #203 marketplace settings
+aliases, #204 `forceLoginGatewayUrl`, plus this docs refresh.
+
+Deferred this cycle:
+
+- `sdk-tools.d.ts` churn (`ReadNotifications` and `ProposeGoal` tools,
+  `RemoteTrigger` gaining `list_runs` / `get_run_log`, `Bash` gaining
+  `backgroundEndsWithFinalResponse`, the commit `branch` field,
+  `output_tokens_details.thinking_tokens`) — outside the curated
+  `tool_inputs.go` subset, the standing deferral.
+- `bridge.d.ts` close codes 4093 (presence heartbeats failing while SSE stays
+  healthy) and 4094 (worker credential expired on the request path), plus the
+  `isCreateSessionFailure` narrowing — browser bridge, no Go surface.
+- The `attribution` index signature — Go already ignores unknown keys on decode,
+  so an extras map would only add round-trip ambiguity to the public API.
+- A `ripgrep` settings doc reword: it is honored only from user, managed/policy,
+  or CLI (`--settings`) settings, and ignored from project settings. Behavior
+  the Go SDK does not model either way.
 
 Some areas remain intentionally limited by the CLI or integration harness:
 desktop/IDE-only settings are not modeled exhaustively, several runtime control

--- a/messages.go
+++ b/messages.go
@@ -1002,7 +1002,9 @@ type SystemMessage struct {
 	// still_queued. "interrupt_cancel_queued_v1" means the interrupt honors
 	// cancel_queued:true — queued and pending-dispatch commands are cancelled
 	// alongside the abort and listed on the response's cancelled field (see
-	// Stream.InterruptCancelQueued). Absent on older CLIs.
+	// Stream.InterruptCancelQueued). "queued_notifications" means the CLI
+	// accepts inbound queued_notification stream messages and drains them via
+	// the ReadNotifications tool. Absent on older CLIs.
 	Capabilities []string `json:"capabilities,omitempty"`
 }
 


### PR DESCRIPTION
In this PR, we close out the v0.3.233 cycle: the README parity section gets the new entries, the version reference at the top moves off v0.3.226, and the deferral list records what we skipped and why.

One code touch, and it's a comment. `queued_notifications` joins the documented values on `SystemMessage.Capabilities`: the CLI advertising it accepts inbound `queued_notification` stream messages and drains them through the `ReadNotifications` tool. Nothing to add for it, since `Capabilities` is already an open `[]string` (that's the point of an open set) and the drain tool lives outside the curated `tool_inputs.go` subset, same as the rest of the `sdk-tools.d.ts` churn.

We also ignore `scratch/`. Every catchup pulls a vendored TS SDK tree in there to diff against, and it's been sitting untracked across enough cycles that a stray `git add -A` would have committed a couple megabytes of unpacked npm tarball. I nearly did exactly that earlier in this cycle.

## What the cycle covered

The `sdk.d.ts` delta read as ~700 lines, but most of it was the `command` plugin source repeated across five copies of the marketplace schema. The one genuinely new surface was `SDKContextUsage`. Everything else was additive settings and init fields, and nothing broke.

Merged: #200 assistant `context_usage`, #201 `terminal_slash_commands`, #202 command plugin source + managed gate, #203 marketplace settings aliases, #204 `forceLoginGatewayUrl`.

Deferred, with reasons written into the README rather than left implicit: the `sdk-tools.d.ts` churn (`ReadNotifications`, `ProposeGoal`, `RemoteTrigger.list_runs`/`get_run_log`, `Bash.backgroundEndsWithFinalResponse`, commit `branch`, `thinking_tokens`), the `bridge.d.ts` close codes 4093/4094 and the `isCreateSessionFailure` narrowing, the `attribution` index signature, and a `ripgrep` settings doc reword.

Closes #199.