### PR TITLE
messages: add effort to the init system message

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -740,6 +740,17 @@ func TestIntegrationHookSuppressOriginalPrompt(t *testing.T) {
 	t.Skip("not directly assertable from CLI: suppressOriginalPrompt is a CLI block-message rendering behavior, not surfaced on the SDK transport")
 }
 
+func TestIntegrationInitEffort(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// effort is published on Remote Control bridge init frames; a subprocess
+	// transport is not one. Verified against CLI 2.1.222: the init message
+	// carries apiKeySource and capabilities but no effort key at all, so a
+	// live assertion here could only ever re-assert the absent state.
+	t.Skip("not triggerable from CLI: effort is published on Remote Control bridge init frames, not on the subprocess transport's init message")
+}
+
 func TestIntegrationSessionStartReloadSkills(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/messages.go
+++ b/messages.go
@@ -1006,6 +1006,57 @@ type SystemMessage struct {
 	// accepts inbound queued_notification stream messages and drains them via
 	// the ReadNotifications tool. Absent on older CLIs.
 	Capabilities []string `json:"capabilities,omitempty"`
+	// Effort is the effort level the session will send on its next request,
+	// after env overrides, session state, org caps and model-support
+	// downgrades — the same value get_settings reports as applied.effort.
+	//
+	// Three states, all distinguishable: an unset Effort (Present false)
+	// means the host does not publish the field, or the CLI predates it, so
+	// the applied effort is unknown. Present with a nil Level is an explicit
+	// wire null, meaning no effort parameter will be sent at all — a model
+	// without effort, CLAUDE_CODE_EFFORT_LEVEL=unset, or an internal numeric
+	// budget. A non-nil Level is the level itself.
+	//
+	// Published on Remote Control bridge init frames (terminal- and
+	// Desktop/VS Code-hosted sessions). Re-emitted inits carry the current
+	// value, so the newest frame wins (sdk.d.ts v0.3.241 L4816).
+	Effort NullableEffortLevel `json:"effort,omitzero"`
+}
+
+// NullableEffortLevel carries a wire field where an explicit JSON null means
+// something other than "absent".
+//
+// The field must be tagged omitzero, not omitempty: encoding/json resolves a
+// null into a nil pointer without ever calling UnmarshalJSON, so a pointer
+// field cannot tell an explicit null apart from an absent key.
+type NullableEffortLevel struct {
+	// Present is false only when the key was absent from the wire.
+	Present bool
+	// Level is nil when the wire carried an explicit null.
+	Level *EffortLevel
+}
+
+// MarshalJSON implements json.Marshaler.
+func (e NullableEffortLevel) MarshalJSON() ([]byte, error) {
+	if e.Level == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(*e.Level)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (e *NullableEffortLevel) UnmarshalJSON(data []byte) error {
+	e.Present = true
+	if string(data) == "null" {
+		e.Level = nil
+		return nil
+	}
+	var level EffortLevel
+	if err := json.Unmarshal(data, &level); err != nil {
+		return err
+	}
+	e.Level = &level
+	return nil
 }
 
 // MessageType implements Message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -2,6 +2,7 @@ package claudeagent
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -2193,7 +2194,120 @@ func TestParseMessageSystemInit(t *testing.T) {
 	assert.Empty(t, systemMsg.Capabilities, "capabilities absent on older CLIs")
 	assert.Empty(t, systemMsg.TerminalSlashCommands,
 		"terminal_slash_commands absent on older CLIs")
+	assert.False(t, systemMsg.Effort.Present, "effort absent on hosts that omit it")
 }
+
+func TestParseMessageSystemInitEffort(t *testing.T) {
+	tests := []struct {
+		name      string
+		field     string
+		wantSet   bool
+		wantLevel *EffortLevel
+	}{
+		{
+			name:    "absent",
+			field:   "",
+			wantSet: false,
+		},
+		{
+			name:    "explicit null",
+			field:   `"effort": null,`,
+			wantSet: true,
+		},
+		{
+			name:      "level",
+			field:     `"effort": "xhigh",`,
+			wantSet:   true,
+			wantLevel: effortPtr(EffortXHigh),
+		},
+		{
+			name:      "max",
+			field:     `"effort": "max",`,
+			wantSet:   true,
+			wantLevel: effortPtr(EffortMax),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			input := fmt.Sprintf(`{
+				"type": "system",
+				"subtype": "init",
+				"uuid": "550e8400-e29b-41d4-a716-446655440900",
+				"session_id": "sess_effort_001",
+				"apiKeySource": "none",
+				"cwd": "/workspace/project",
+				"tools": ["Read"],
+				"mcp_servers": [],
+				"model": "claude-opus-4-5-20250929",
+				"permissionMode": "default",
+				"slash_commands": ["/help"],
+				%s
+				"output_style": "default"
+			}`, tc.field)
+
+			msg, err := ParseMessage([]byte(input))
+			require.NoError(t, err)
+
+			systemMsg, ok := msg.(SystemMessage)
+			require.True(t, ok, "expected SystemMessage")
+
+			assert.Equal(t, tc.wantSet, systemMsg.Effort.Present,
+				"an explicit null must stay distinguishable from an absent key")
+			assert.Equal(t, tc.wantLevel, systemMsg.Effort.Level)
+		})
+	}
+}
+
+func TestSystemMessageEffortRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		effort NullableEffortLevel
+		want   string
+	}{
+		{
+			name:   "absent omits the key",
+			effort: NullableEffortLevel{},
+		},
+		{
+			name:   "explicit null",
+			effort: NullableEffortLevel{Present: true},
+			want:   "null",
+		},
+		{
+			name:   "level",
+			effort: NullableEffortLevel{Present: true, Level: effortPtr(EffortLow)},
+			want:   `"low"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(SystemMessage{
+				Type:    "system",
+				Subtype: "init",
+				Effort:  tc.effort,
+			})
+			require.NoError(t, err)
+
+			var raw map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(data, &raw))
+
+			if tc.want == "" {
+				assert.NotContains(t, raw, "effort")
+				return
+			}
+			require.Contains(t, raw, "effort")
+			assert.JSONEq(t, tc.want, string(raw["effort"]))
+
+			var back SystemMessage
+			require.NoError(t, json.Unmarshal(data, &back))
+			assert.Equal(t, tc.effort, back.Effort)
+		})
+	}
+}
+
+func effortPtr(l EffortLevel) *EffortLevel { return &l }
 
 func TestParseMessageSystemInitTerminalSlashCommands(t *testing.T) {
 	input := `{


### PR DESCRIPTION
Part of #206 (TypeScript SDK v0.3.241 parity).

`sdk.d.ts` v0.3.241 L4816 adds `effort` to `SDKSystemMessage`:

```ts
effort?: ('low' | 'medium' | 'high' | 'xhigh' | 'max') | null;
```

It reports the effort level the session will send on its next request —
after env overrides, session state, org caps and model-support downgrades.
Same value `get_settings` reports as `applied.effort`.

### The tri-state

This field is not a plain optional. The upstream doc distinguishes two
different "no level" cases, and they mean opposite things to a consumer:

- **explicit `null`** — no effort parameter will be sent at all. A model
  without effort, `CLAUDE_CODE_EFFORT_LEVEL=unset`, or an internal numeric
  budget. This is a definite answer.
- **absent** — the host does not publish the field, or the CLI predates it.
  The applied effort is simply unknown.

The obvious `*EffortLevel` collapses both to `nil`. Worse, so does
`*NullableEffortLevel`: `encoding/json` resolves a `null` into a nil pointer
without ever calling `UnmarshalJSON`, so a pointer field structurally cannot
carry the distinction no matter what the pointee implements.

So it lands as an `omitzero` value type that records presence separately:

```go
type NullableEffortLevel struct {
	Present bool
	Level   *EffortLevel
}
```

`Present` false is absent; `Present` with a nil `Level` is the explicit null;
a non-nil `Level` is the level. Round-trips in all three states, which the
test asserts directly rather than trusting the tag.

Re-emitted inits carry the current value, so the newest frame wins — noted in
the doc comment since a consumer caching the first init would otherwise go
stale.

### Testing

Table-driven parse test over all three states plus `max` (which the init
message accepts but `Settings.modelSettings` does not), and a round-trip test
asserting the marshalled key is present/absent/`null` as expected.

Integration test is a documented skip. Probed against the live CLI 2.1.222:
the init message carries `apiKeySource` and `capabilities` but no `effort`
key. The field is published on Remote Control bridge init frames, and a
subprocess transport is not one, so a live assertion could only re-assert the
absent state.