### PR TITLE
messages: add backgrounding and spawn depth to task_started

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -740,6 +740,18 @@ func TestIntegrationHookSuppressOriginalPrompt(t *testing.T) {
 	t.Skip("not directly assertable from CLI: suppressOriginalPrompt is a CLI block-message rendering behavior, not surfaced on the SDK transport")
 }
 
+func TestIntegrationTaskStartedBackgrounding(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// Probed against CLI 2.1.222 with a prompt that spawns one Explore
+	// subagent: the task_started frame carries task_id, tool_use_id,
+	// description, subagent_type and task_type "local_agent", but neither
+	// is_backgrounded nor spawn_depth. The runner CLI predates both fields,
+	// so a live assertion could only re-assert the absent state.
+	t.Skip("not triggerable from CLI: runner CLI 2.1.222 omits is_backgrounded and spawn_depth from task_started")
+}
+
 func TestIntegrationSessionStartReloadSkills(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/messages.go
+++ b/messages.go
@@ -1158,8 +1158,20 @@ type TaskStartedMessage struct {
 	WorkflowName   string `json:"workflow_name,omitempty"`   // Workflow script metadata name
 	Prompt         string `json:"prompt,omitempty"`          // Task prompt
 	SkipTranscript *bool  `json:"skip_transcript,omitempty"` // Ambient task marker
-	UUID           string `json:"uuid"`                      // Unique message ID
-	SessionID      string `json:"session_id"`                // Session identifier
+	// IsBackgrounded reports whether the task was registered in the
+	// background (true) or in the foreground with the spawning tool call
+	// blocking on it (false). A resumed subagent is always registered in the
+	// background. A later move to the background does not restate this field
+	// — it arrives as TaskUpdatePatch.IsBackgrounded on a task_updated
+	// message. Set for local_agent and local_bash tasks; nil elsewhere and on
+	// CLIs that predate the field (sdk.d.ts v0.3.241 L4883).
+	IsBackgrounded *bool `json:"is_backgrounded,omitempty"`
+	// SpawnDepth is the nesting depth of a spawned subagent (local_agent)
+	// task: 1 for a top-level spawn, N+1 when spawned from inside a depth-N
+	// agent. Not set on other task types (sdk.d.ts v0.3.241 L4887).
+	SpawnDepth *int   `json:"spawn_depth,omitempty"`
+	UUID       string `json:"uuid"`       // Unique message ID
+	SessionID  string `json:"session_id"` // Session identifier
 }
 
 // MessageType implements Message.

--- a/messages_test.go
+++ b/messages_test.go
@@ -2671,6 +2671,57 @@ func TestParseMessageTaskStarted(t *testing.T) {
 				assert.Empty(t, taskMsg.WorkflowName)
 				assert.Empty(t, taskMsg.Prompt)
 				assert.Nil(t, taskMsg.SkipTranscript)
+				assert.Nil(t, taskMsg.IsBackgrounded)
+				assert.Nil(t, taskMsg.SpawnDepth)
+			},
+		},
+		{
+			name: "foreground subagent spawn",
+			input: `{
+				"type": "system",
+				"subtype": "task_started",
+				"task_id": "task_01J8Z8Y2X3K4M5N6P7Q8R9S0T9",
+				"description": "Search the repo",
+				"task_type": "local_agent",
+				"subagent_type": "Explore",
+				"is_backgrounded": false,
+				"spawn_depth": 1,
+				"uuid": "550e8400-e29b-41d4-a716-446655440013",
+				"session_id": "sess_task_123"
+			}`,
+			check: func(t *testing.T, taskMsg TaskStartedMessage) {
+				t.Helper()
+				assert.Equal(t, "local_agent", taskMsg.TaskType)
+				assert.Equal(t, "Explore", taskMsg.SubagentType)
+				// false is a meaningful value here, not an absent
+				// field: the spawning tool call is blocking on it.
+				require.NotNil(t, taskMsg.IsBackgrounded)
+				assert.False(t, *taskMsg.IsBackgrounded)
+				require.NotNil(t, taskMsg.SpawnDepth)
+				assert.Equal(t, 1, *taskMsg.SpawnDepth)
+			},
+		},
+		{
+			name: "nested background subagent spawn",
+			input: `{
+				"type": "system",
+				"subtype": "task_started",
+				"task_id": "task_01J8Z8Y2X3K4M5N6P7Q8R9S0TA",
+				"description": "Verify a finding",
+				"task_type": "local_agent",
+				"subagent_type": "general-purpose",
+				"is_backgrounded": true,
+				"spawn_depth": 2,
+				"uuid": "550e8400-e29b-41d4-a716-446655440014",
+				"session_id": "sess_task_123"
+			}`,
+			check: func(t *testing.T, taskMsg TaskStartedMessage) {
+				t.Helper()
+				require.NotNil(t, taskMsg.IsBackgrounded)
+				assert.True(t, *taskMsg.IsBackgrounded)
+				require.NotNil(t, taskMsg.SpawnDepth)
+				assert.Equal(t, 2, *taskMsg.SpawnDepth,
+					"a spawn from inside a depth-1 agent is depth 2")
 			},
 		},
 	}


### PR DESCRIPTION
Part of #206 (TypeScript SDK v0.3.241 parity).

`sdk.d.ts` v0.3.241 adds two fields to `SDKTaskStartedMessage`:

- **L4883 `is_backgrounded?: boolean`** — whether the task was registered in
  the background (true) or in the foreground with the spawning tool call
  blocking on it (false). A resumed subagent is always registered in the
  background. Set for `local_agent` and `local_bash` tasks.
- **L4887 `spawn_depth?: number`** — nesting depth of a spawned subagent
  (`local_agent`) task: 1 for a top-level spawn, N+1 when spawned from inside
  a depth-N agent. Not set on other task types.

Both land as pointers. `false` and `0` are not "absent" here — a foreground
spawn genuinely reports `is_backgrounded: false`, and collapsing that into the
zero value would make it indistinguishable from a `local_workflow` task that
never carries the field at all.

Worth noting for consumers, and called out in the doc comment: `task_started`
reports the state at registration only. A task that *later* moves to the
background does not restate it — that arrives as `patch.is_backgrounded` on a
`task_updated` message, which `TaskUpdatePatch` already models. Reading only
`task_started` and caching the result gets you a stale answer.

### Testing

Two new cases on the existing `TestParseMessageTaskStarted` table: a foreground
depth-1 spawn (asserting `false` survives as a set value, not a nil) and a
nested background depth-2 spawn. The minimum-required-fields case now also
asserts both fields stay nil when absent.

Integration test is a documented skip. Probed against the live CLI 2.1.222 with
a prompt that spawns one Explore subagent — the `task_started` frame carries
`task_id`, `tool_use_id`, `description`, `subagent_type` and `task_type:
"local_agent"`, but neither new field. The runner CLI predates both, so a live
assertion could only re-assert the absent state.