### PR TITLE
messages: add peer fromMode and the projects-relay subkind

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -411,6 +411,15 @@ type MessageOrigin struct {
 	Server string            `json:"server,omitempty"`
 	From   string            `json:"from,omitempty"`
 	Name   string            `json:"name,omitempty"`
+	// FromMode is the SENDING session's permission class, as declared by the
+	// host that injects this message on local stdin. It lets a recipient
+	// deliver a same-class message immediately while a cross-class or
+	// undeclared sender is still held at a recipient that runs without
+	// asking — so an empty FromMode must be treated as "hold", not as a
+	// default. Honored only from the injecting host on local stdin, and set
+	// only for the "peer" kind; absent when the host does not declare it
+	// (sdk.d.ts v0.3.241 L4350).
+	FromMode PeerFromMode `json:"fromMode,omitempty"`
 	// SenderTaskID is the observer's task id; set only for the
 	// "observer" kind (sdk.d.ts v0.3.201).
 	SenderTaskID string `json:"senderTaskId,omitempty"`
@@ -433,10 +442,10 @@ type MessageOrigin struct {
 	// only when the turn is exactly one harness-formed envelope; render it
 	// instead of re-parsing the message text (sdk.d.ts v0.3.207).
 	Body string `json:"body,omitempty"`
-	// Subkind refines the "task-notification" kind: a scheduled trigger or a
-	// coordinator co-member SendMessage delivery. Absent on webhook,
-	// PR-steward, plugin, and background-event deliveries (sdk.d.ts v0.3.226
-	// L4223).
+	// Subkind refines the "task-notification" kind: a scheduled trigger, a
+	// coordinator co-member SendMessage delivery, or a Claude Code Projects
+	// relay. Absent on webhook, PR-steward, plugin, and background-event
+	// deliveries (sdk.d.ts v0.3.241 L4377).
 	Subkind MessageOriginSubkind `json:"subkind,omitempty"`
 }
 
@@ -457,6 +466,27 @@ const (
 	// prompt authority but stays distinguishable so the receive-side
 	// crossSessionInbound setting can apply to it (sdk.d.ts v0.3.226 L4223).
 	MessageOriginSubkindPeerSendMessage MessageOriginSubkind = "peer-send-message"
+	// MessageOriginSubkindProjectsRelay marks a "task-notification" origin
+	// whose delivery is a Claude Code Projects message that Anthropic servers
+	// composed for the project's coordinator session and addressed to one of
+	// its thread sessions — either the thread's first message, or a relay
+	// carrying project messages. Stamped from server-asserted provenance.
+	//
+	// The harness frames such a delivery as a message from the coordinator
+	// session only when it carries the server's relay stamps; one without them
+	// keeps the generic background-notification frame (sdk.d.ts v0.3.241
+	// L4377).
+	MessageOriginSubkindProjectsRelay MessageOriginSubkind = "projects-relay"
+)
+
+// PeerFromMode is the sending session's permission class on a "peer" origin.
+type PeerFromMode string
+
+const (
+	// PeerFromModeBypass marks a sender that runs tools without asking.
+	PeerFromModeBypass PeerFromMode = "bypass"
+	// PeerFromModePrompting marks a sender that prompts before running tools.
+	PeerFromModePrompting PeerFromMode = "prompting"
 )
 
 // StreamEvent represents a progressive delta update during streaming.

--- a/messages_test.go
+++ b/messages_test.go
@@ -822,6 +822,7 @@ func TestParseMessageResultMessageOriginPeer(t *testing.T) {
 			"name": "reviewer",
 			"body": "please take a look",
 			"fromSession": "local_abc",
+			"fromMode": "bypass",
 			"verifiedPeerPid": 4242
 		}
 	}`)
@@ -837,14 +838,62 @@ func TestParseMessageResultMessageOriginPeer(t *testing.T) {
 	assert.Equal(t, "reviewer", resultMsg.Origin.Name)
 	assert.Equal(t, "please take a look", resultMsg.Origin.Body)
 	assert.Equal(t, "local_abc", resultMsg.Origin.FromSession)
+	assert.Equal(t, PeerFromModeBypass, resultMsg.Origin.FromMode)
 	require.NotNil(t, resultMsg.Origin.VerifiedPeerPid)
 	assert.Equal(t, 4242, *resultMsg.Origin.VerifiedPeerPid)
 
-	// Both are omitempty; a peer origin without them stays lean on the wire.
+	// All three are omitempty; a peer origin without them stays lean on the
+	// wire. An undeclared fromMode is "hold", not a default class, so it must
+	// not marshal as one.
 	out, err := json.Marshal(MessageOrigin{Kind: MessageOriginKindPeer, From: "a"})
 	require.NoError(t, err)
 	assert.NotContains(t, string(out), "fromSession")
 	assert.NotContains(t, string(out), "verifiedPeerPid")
+	assert.NotContains(t, string(out), "fromMode")
+}
+
+func TestParseMessageResultMessageOriginPeerFromModePrompting(t *testing.T) {
+	input := []byte(`{
+		"type": "result",
+		"status": "success",
+		"subtype": "success",
+		"result": "done",
+		"origin": {
+			"kind": "peer",
+			"from": "agent-7",
+			"fromMode": "prompting"
+		}
+	}`)
+
+	msg, err := ParseMessage(input)
+	require.NoError(t, err)
+
+	resultMsg, ok := msg.(ResultMessage)
+	require.True(t, ok)
+	require.NotNil(t, resultMsg.Origin)
+	assert.Equal(t, PeerFromModePrompting, resultMsg.Origin.FromMode)
+}
+
+func TestParseMessageResultMessageOriginProjectsRelay(t *testing.T) {
+	input := []byte(`{
+		"type": "result",
+		"status": "success",
+		"subtype": "success",
+		"result": "done",
+		"origin": {
+			"kind": "task-notification",
+			"subkind": "projects-relay"
+		}
+	}`)
+
+	msg, err := ParseMessage(input)
+	require.NoError(t, err)
+
+	resultMsg, ok := msg.(ResultMessage)
+	require.True(t, ok)
+	require.NotNil(t, resultMsg.Origin)
+	assert.Equal(t, MessageOriginKindTaskNotification, resultMsg.Origin.Kind)
+	assert.Equal(t, MessageOriginSubkindProjectsRelay, resultMsg.Origin.Subkind)
 }
 
 func TestParseMessageResultMessageOriginHuman(t *testing.T) {


### PR DESCRIPTION
Part of #206 (TypeScript SDK v0.3.241 parity).

Two additions to `MessageOrigin`.

### `fromMode` on the peer variant (`sdk.d.ts` L4350)

```ts
fromMode?: 'bypass' | 'prompting';
```

The **sending** session's permission class, as declared by the host that
injects the message on local stdin — `bypass` for sessions that run tools
without asking, `prompting` otherwise. A recipient that itself runs without
asking uses this to deliver a same-class message immediately, while a
cross-class or undeclared sender is still held.

That last clause is the part worth reading carefully, and the doc comment
says so explicitly: an **absent** `fromMode` means *hold*, not "assume
prompting". Treating the zero value as a default class would turn a missing
declaration into an immediate delivery, which is exactly backwards. It is
honored only from the injecting host on local stdin.

Lands as a named `PeerFromMode` with two consts rather than a bare string,
per the repo convention for TS union types.

### `projects-relay` subkind (`sdk.d.ts` L4377)

A Claude Code Projects delivery that Anthropic servers composed for the
project's coordinator session and addressed to one of its thread sessions —
the thread's first message, or a relay carrying project messages. Stamped
from server-asserted provenance.

Note the conditional framing, carried into the comment: the harness frames it
as a message from the coordinator session only when it carries the server's
relay stamps. One without them keeps the generic background-notification
frame. The subkind alone does not tell you which you got.

The `Subkind` field doc is updated to list all three refinements instead of
two.

### Testing

The existing peer-origin test gains `fromMode` and asserts it does *not*
marshal when unset (the omitempty behavior matters more than usual here,
given the hold semantics). Two new tests cover the `prompting` class and a
`projects-relay` task-notification origin.

No integration test: neither field is reachable from a subprocess transport.
`fromMode` is set only by a host injecting peer messages on local stdin, and
`projects-relay` requires a server-composed Projects delivery.