### PR TITLE
options: add account_on_hold and apiKeySource constants

### DIFF
--- a/options.go
+++ b/options.go
@@ -2320,14 +2320,44 @@ type AssistantMessageError string
 const (
 	AssistantMessageErrorAuthenticationFailed AssistantMessageError = "authentication_failed"
 	AssistantMessageErrorOAuthOrgNotAllowed   AssistantMessageError = "oauth_org_not_allowed"
-	AssistantMessageErrorBillingError         AssistantMessageError = "billing_error"
-	AssistantMessageErrorRateLimit            AssistantMessageError = "rate_limit"
-	AssistantMessageErrorOverloaded           AssistantMessageError = "overloaded"
-	AssistantMessageErrorInvalidRequest       AssistantMessageError = "invalid_request"
-	AssistantMessageErrorModelNotFound        AssistantMessageError = "model_not_found"
-	AssistantMessageErrorServerError          AssistantMessageError = "server_error"
-	AssistantMessageErrorUnknown              AssistantMessageError = "unknown"
-	AssistantMessageErrorMaxOutputTokens      AssistantMessageError = "max_output_tokens"
+	// AssistantMessageErrorAccountOnHold marks a turn refused because the
+	// account is on hold (sdk.d.ts v0.3.241 L159).
+	AssistantMessageErrorAccountOnHold   AssistantMessageError = "account_on_hold"
+	AssistantMessageErrorBillingError    AssistantMessageError = "billing_error"
+	AssistantMessageErrorRateLimit       AssistantMessageError = "rate_limit"
+	AssistantMessageErrorOverloaded      AssistantMessageError = "overloaded"
+	AssistantMessageErrorInvalidRequest  AssistantMessageError = "invalid_request"
+	AssistantMessageErrorModelNotFound   AssistantMessageError = "model_not_found"
+	AssistantMessageErrorServerError     AssistantMessageError = "server_error"
+	AssistantMessageErrorUnknown         AssistantMessageError = "unknown"
+	AssistantMessageErrorMaxOutputTokens AssistantMessageError = "max_output_tokens"
+)
+
+// Known values for the apiKeySource field on SystemMessage and AccountInfo,
+// naming where the credential used for API requests came from.
+//
+// The field stays a plain string: it is an open set on the wire, and the CLI
+// is free to add sources. Compare against these instead of literals, but do
+// not assume the set is exhaustive.
+//
+// TS also retains five legacy members — "user", "project", "org", "temporary"
+// and "oauth" — solely so the type stays backward compatible. Current CLIs
+// never emit them, so there is nothing to branch on and they get no constants
+// here (sdk.d.ts v0.3.241 L124).
+const (
+	// APIKeySourceAnthropicAPIKey means the ANTHROPIC_API_KEY environment
+	// variable supplied the credential.
+	APIKeySourceAnthropicAPIKey = "ANTHROPIC_API_KEY"
+	// APIKeySourceAPIKeyHelper means the configured apiKeyHelper command
+	// supplied the credential.
+	APIKeySourceAPIKeyHelper = "apiKeyHelper"
+	// APIKeySourceLoginManagedKey means the credential is an API key created
+	// and stored by /login with an Anthropic Console account.
+	APIKeySourceLoginManagedKey = "/login managed key"
+	// APIKeySourceNone means no API key is in use — a claude.ai OAuth login,
+	// a bearer token, or a third-party cloud provider. This is what a
+	// subscription-authenticated session reports, so it is not an error state.
+	APIKeySourceNone = "none"
 )
 
 // StopFailureInput contains data for StopFailure hooks.

--- a/options.go
+++ b/options.go
@@ -2348,13 +2348,13 @@ const (
 	// APIKeySourceAnthropicAPIKey means the ANTHROPIC_API_KEY environment
 	// variable supplied the credential.
 	// These name where a credential came from; they are not credentials.
-	APIKeySourceAnthropicAPIKey = "ANTHROPIC_API_KEY" // #nosec G101
+	APIKeySourceAnthropicAPIKey = "ANTHROPIC_API_KEY" // #nosec G101 // #nosec G101
 	// APIKeySourceAPIKeyHelper means the configured apiKeyHelper command
 	// supplied the credential.
 	APIKeySourceAPIKeyHelper = "apiKeyHelper" // #nosec G101
 	// APIKeySourceLoginManagedKey means the credential is an API key created
 	// and stored by /login with an Anthropic Console account.
-	APIKeySourceLoginManagedKey = "/login managed key"
+	APIKeySourceLoginManagedKey = "/login managed key" // #nosec G101
 	// APIKeySourceNone means no API key is in use — a claude.ai OAuth login,
 	// a bearer token, or a third-party cloud provider. This is what a
 	// subscription-authenticated session reports, so it is not an error state.

--- a/options.go
+++ b/options.go
@@ -2347,10 +2347,11 @@ const (
 const (
 	// APIKeySourceAnthropicAPIKey means the ANTHROPIC_API_KEY environment
 	// variable supplied the credential.
-	APIKeySourceAnthropicAPIKey = "ANTHROPIC_API_KEY"
+	// These name where a credential came from; they are not credentials.
+	APIKeySourceAnthropicAPIKey = "ANTHROPIC_API_KEY" // #nosec G101
 	// APIKeySourceAPIKeyHelper means the configured apiKeyHelper command
 	// supplied the credential.
-	APIKeySourceAPIKeyHelper = "apiKeyHelper"
+	APIKeySourceAPIKeyHelper = "apiKeyHelper" // #nosec G101
 	// APIKeySourceLoginManagedKey means the credential is an API key created
 	// and stored by /login with an Anthropic Console account.
 	APIKeySourceLoginManagedKey = "/login managed key"

--- a/options_test.go
+++ b/options_test.go
@@ -1985,3 +1985,44 @@ func TestSettingsForceLoginGatewayURLJSON(t *testing.T) {
 		assert.NotContains(t, got, "forceLoginGatewayUrl")
 	})
 }
+
+func TestAPIKeySourceConstants(t *testing.T) {
+	// The wire values are not derivable from the constant names — two carry
+	// characters Go identifiers cannot ("/login managed key") or a casing
+	// that differs from the identifier ("apiKeyHelper") — so pin them.
+	assert.Equal(t, "ANTHROPIC_API_KEY", APIKeySourceAnthropicAPIKey)
+	assert.Equal(t, "apiKeyHelper", APIKeySourceAPIKeyHelper)
+	assert.Equal(t, "/login managed key", APIKeySourceLoginManagedKey)
+	assert.Equal(t, "none", APIKeySourceNone)
+}
+
+func TestSystemMessageAPIKeySourceNone(t *testing.T) {
+	// A subscription-authenticated session reports "none": no API key is in
+	// use, which is not an error state. This is what CLI 2.1.222 emits under
+	// a claude.ai OAuth login.
+	msg, err := ParseMessage([]byte(`{
+		"type": "system",
+		"subtype": "init",
+		"uuid": "550e8400-e29b-41d4-a716-446655440a00",
+		"session_id": "sess_aks_001",
+		"apiKeySource": "none",
+		"cwd": "/workspace",
+		"tools": [],
+		"mcp_servers": [],
+		"model": "claude-opus-4-5-20250929",
+		"permissionMode": "default",
+		"slash_commands": [],
+		"output_style": "default"
+	}`))
+	require.NoError(t, err)
+
+	systemMsg, ok := msg.(SystemMessage)
+	require.True(t, ok)
+	assert.Equal(t, APIKeySourceNone, systemMsg.APIKeySource)
+}
+
+func TestAssistantMessageErrorAccountOnHold(t *testing.T) {
+	assert.Equal(t,
+		AssistantMessageError("account_on_hold"),
+		AssistantMessageErrorAccountOnHold)
+}


### PR DESCRIPTION
Part of #206 (TypeScript SDK v0.3.241 parity).

### `account_on_hold`

`sdk.d.ts` L159 adds `'account_on_hold'` to `SDKAssistantMessageError`. One
const, slotted next to the other auth/billing codes.

### `apiKeySource`

`sdk.d.ts` L124 rewrote `ApiKeySource` — four real members, and a doc
explaining that the five it previously listed are legacy:

```ts
export declare type ApiKeySource = 'ANTHROPIC_API_KEY' | 'apiKeyHelper'
  | '/login managed key' | 'none'
  | 'user' | 'project' | 'org' | 'temporary' | 'oauth';
```

Upstream is explicit that `user`/`project`/`org`/`temporary`/`oauth` are kept
only so the type stays backward compatible and **current CLIs never emit
them**.

The Go field is a plain `string` on both `SystemMessage` and `AccountInfo`.
It stays that way — this is an open set the CLI can extend, and retyping a
public field would break consumers for no benefit. So this adds constants for
the four live values instead, with a doc saying the set is not exhaustive.
The legacy five get no constants: there is nothing to branch on.

Naming the values is worth more here than usual because two of them are not
guessable from a Go identifier — `"/login managed key"` has spaces and a
slash, and `"apiKeyHelper"` is lowerCamel where the identifier is not.

Confirmed live rather than assumed: CLI 2.1.222 under a claude.ai OAuth login
emits `"apiKeySource": "none"` on the init message. That is the
subscription-auth case, not an error state — called out in the const doc,
since `none` reads like a failure at a glance.

### Testing

Constants pinned against their wire literals (the point of the test is the
values, not the names), a parse test for the `none` init case, and the
`account_on_hold` code.