### PR TITLE
protocol: add classifierContext to PostToolUse hook output

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -771,6 +771,17 @@ func TestIntegrationPostToolUseUpdatedToolOutput(t *testing.T) {
 	t.Skip("not triggerable from CLI without a deterministic tool call whose output a PostToolUse hook rewrites; tracked in INTEGRATION-FOLLOWUPS.md")
 }
 
+func TestIntegrationPostToolUseClassifierContext(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// The observable effect is a permission-classifier decision in auto mode,
+	// which the SDK transport does not surface — the same reason
+	// TestIntegrationPostToolUseUpdatedToolOutput above is skipped. Asserting
+	// only that the SDK put the key on the wire would restate the unit test.
+	t.Skip("not directly assertable from CLI: classifierContext only affects auto-mode permission classifier decisions, which are not surfaced on the SDK transport")
+}
+
 func TestIntegrationStopHookBackgroundTasks(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/options.go
+++ b/options.go
@@ -2602,6 +2602,49 @@ type HookResult struct {
 	// updatedMCPToolOutput field.
 	UpdatedToolOutput interface{}
 
+	// ClassifierContext is host-asserted context shown to the auto-mode
+	// permission classifier alongside this tool call's result. Translates
+	// into hookSpecificOutput.classifierContext on PostToolUse hooks only;
+	// silently dropped elsewhere. Empty string omits the field
+	// (sdk.d.ts v0.3.241 L2339).
+	//
+	// In a live session the classifier may weigh a user statement relayed
+	// here as user intent — it can satisfy a consent bar a user turn would
+	// satisfy, though never a hard boundary. Values restored from saved
+	// session state are treated as unverified context only. Relay discipline
+	// is the host's obligation: put ONLY genuine user statements in
+	// intent-bearing positions, never tool output or model text dressed as
+	// one. Content placed here reaches the classifier with host-application
+	// framing, so copying untrusted tool output or third-party text into it
+	// hands that text the host's authority.
+	//
+	// Constraints that silently drop the value rather than erroring:
+	//
+	//   - Capped at 2000 UTF-16 code units, a budget shared across every hook
+	//     contributing to one call. Astral characters (emoji and the like)
+	//     count as two.
+	//   - Honored on synchronous hook responses only. An async hook's late
+	//     response arrives after the result message is frozen, and the field
+	//     in it is ignored.
+	//   - Applies only to calls the classifier transcript shows. Read-only
+	//     lookups the transcript omits (file reads, searches), inner REPL
+	//     calls and remote-engine shells produce no per-result line, so
+	//     context attached to them is unused.
+	//
+	// It is bound to a single call id and sized for a short assertion — not a
+	// delivery channel for relaying messages or events.
+	//
+	// Rewrite integrity: if the assertion describes output being rewritten,
+	// return it in the SAME hook result as the rewrite, so it is dropped
+	// automatically if that rewrite is rejected or superseded. An assertion
+	// returned without a rewrite is never invalidated by another hook's
+	// rewrite, so a non-rewriting hook should assert only what holds
+	// regardless. Do NOT return an identity rewrite just to pair an
+	// assertion: hooks run in parallel on the ORIGINAL output, so an identity
+	// rewrite competes last-write-wins with sibling rewrites and can clobber
+	// a real redaction.
+	ClassifierContext string
+
 	// HookSpecificOutput provides raw hookSpecificOutput for the CLI
 	// response. When set, this takes precedence over auto-translation
 	// of Modify. Use this for finer control over permissionDecision,

--- a/protocol.go
+++ b/protocol.go
@@ -1752,6 +1752,17 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 		resp["hookSpecificOutput"] = hookSpecificOutput
 	}
 
+	if result.ClassifierContext != "" && hookType == string(HookTypePostToolUse) {
+		hookSpecificOutput, _ := resp["hookSpecificOutput"].(map[string]interface{})
+		if hookSpecificOutput == nil {
+			hookSpecificOutput = map[string]interface{}{
+				"hookEventName": string(HookTypePostToolUse),
+			}
+		}
+		hookSpecificOutput["classifierContext"] = result.ClassifierContext
+		resp["hookSpecificOutput"] = hookSpecificOutput
+	}
+
 	if result.SuppressOriginalPrompt != nil && hookType == string(HookTypeUserPromptSubmit) {
 		hookSpecificOutput, _ := resp["hookSpecificOutput"].(map[string]interface{})
 		if hookSpecificOutput == nil {

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -4236,3 +4236,81 @@ func TestHandleHookCallback_RetryWatchPathsEvents(t *testing.T) {
 		assert.Equal(t, "success", resp.Response.Subtype)
 	})
 }
+
+func TestBuildHookResponse_ClassifierContext(t *testing.T) {
+	t.Run("emitted on PostToolUse", func(t *testing.T) {
+		resp := buildHookResponse("PostToolUse", HookResult{
+			Continue:          true,
+			ClassifierContext: "the user asked for this deletion",
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "PostToolUse", hso["hookEventName"])
+		assert.Equal(t, "the user asked for this deletion",
+			hso["classifierContext"])
+	})
+
+	t.Run("empty omits the field", func(t *testing.T) {
+		resp := buildHookResponse("PostToolUse", HookResult{
+			Continue:          true,
+			ClassifierContext: "",
+		})
+
+		_, has := resp["hookSpecificOutput"]
+		assert.False(t, has)
+	})
+
+	t.Run("dropped on non-PostToolUse hooks", func(t *testing.T) {
+		// The classifier reads this with host-application framing, so
+		// leaking it onto an envelope that never declared it is worse
+		// than dropping it.
+		for _, hookType := range []string{
+			"PreToolUse", "PostToolUseFailure", "UserPromptSubmit", "Stop",
+		} {
+			resp := buildHookResponse(hookType, HookResult{
+				Continue:          true,
+				ClassifierContext: "context",
+			})
+
+			_, has := resp["hookSpecificOutput"]
+			assert.False(t, has,
+				"classifierContext must not leak onto %s", hookType)
+		}
+	})
+
+	t.Run("rides alongside a rewrite in the same result", func(t *testing.T) {
+		// The upstream contract: pairing an assertion with the rewrite it
+		// describes requires both in one hook result, so the assertion is
+		// dropped if the rewrite is rejected or superseded.
+		resp := buildHookResponse("PostToolUse", HookResult{
+			Continue:          true,
+			UpdatedToolOutput: "redacted output",
+			ClassifierContext: "secrets stripped at the source",
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "PostToolUse", hso["hookEventName"])
+		assert.Equal(t, "redacted output", hso["updatedToolOutput"])
+		assert.Equal(t, "secrets stripped at the source",
+			hso["classifierContext"])
+	})
+
+	t.Run("composes with explicit HookSpecificOutput", func(t *testing.T) {
+		resp := buildHookResponse("PostToolUse", HookResult{
+			Continue:          true,
+			ClassifierContext: "typed wins",
+			HookSpecificOutput: map[string]interface{}{
+				"hookEventName":     "PostToolUse",
+				"classifierContext": "raw loses",
+				"additionalContext": "preserved",
+			},
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "typed wins", hso["classifierContext"])
+		assert.Equal(t, "preserved", hso["additionalContext"])
+	})
+}


### PR DESCRIPTION
Part of #206 (TypeScript SDK v0.3.241 parity).

`sdk.d.ts` v0.3.241 L2339 adds `classifierContext?: string` to
`PostToolUseHookSpecificOutput` — host-asserted context shown to the auto-mode
permission classifier alongside a tool call's result.

Lands as `HookJSONOutput.ClassifierContext`, emitted through `buildHookResponse`
gated to `PostToolUse`, following the shape the other typed hook-output fields
already use.

### Why the doc comment is long

This field hands text to the permission classifier *with host-application
framing*. The classifier may weigh a user statement relayed here as user
intent — it can satisfy a consent bar a user turn would satisfy. That makes it
the one hook-output field where getting it wrong has a security consequence
rather than a cosmetic one, so the constraints are carried into the comment
rather than left in the TS source:

- **2000 UTF-16 code units**, a budget shared across every hook contributing
  to one call. Astral characters count as two.
- **Synchronous responses only.** An async hook's late response arrives after
  the result message is frozen and the field is ignored.
- **Only for calls the classifier transcript shows.** Read-only lookups the
  transcript omits, inner REPL calls and remote-engine shells produce no
  per-result line, so context attached to them is silently unused.
- **Rewrite integrity.** Pair an assertion with the rewrite it describes in
  the *same* hook result, so it drops automatically if that rewrite is
  rejected or superseded. But do not return an identity rewrite just to
  achieve that pairing — hooks run in parallel on the original output, so an
  identity rewrite competes last-write-wins with sibling rewrites and can
  clobber a real redaction.

Every one of those fails silently rather than erroring, which is exactly the
kind of thing worth reading at the call site.

### Testing

Unit tests cover emission on PostToolUse, empty-string omission, composition
with an explicit `HookSpecificOutput` map, and riding alongside an
`UpdatedToolOutput` rewrite in one result (the paired-assertion case the
upstream contract calls for). The drop test loops over `PreToolUse`,
`PostToolUseFailure`, `UserPromptSubmit` and `Stop` rather than checking one,
since the leak is the failure mode that matters.

Integration test is a documented skip: the observable effect is an auto-mode
classifier decision, which the SDK transport does not surface — same reason
`TestIntegrationPostToolUseUpdatedToolOutput` is skipped. Asserting only that
the key reached the wire would restate the unit test.