### PR TITLE
protocol: honor suppressOriginalPrompt on UserPromptExpansion

### DIFF
--- a/options.go
+++ b/options.go
@@ -2005,10 +2005,17 @@ type UserPromptSubmitInput struct {
 	// Source names who authored or injected the prompt: "user" (interactive
 	// composer), "sdk" (non-interactive entrypoint, -p / Agent SDK),
 	// "loop_wakeup" (dynamic /loop wakeup), "schedule_wakeup" (scheduled-task
-	// fire), or "system" (other machine-injected turns: peer/channel messages,
-	// task notifications, auto-continuation). Empty when absent — as of
-	// v0.3.215 it is only set for Anthropic-internal sessions while the field
-	// is trialed; external payloads omit it (sdk.d.ts v0.3.215).
+	// fire), "system" (other machine-injected turns: peer/channel messages,
+	// task notifications, auto-continuation), or "poll_event" (the poll-event
+	// channel enqueue-time pass, added in sdk.d.ts v0.3.241 L8228).
+	//
+	// A "poll_event" pass is the one source where a blocking verdict rejects
+	// something that has not been delivered yet: the hook fires when the host
+	// submits the event, before its delivery ack exists.
+	//
+	// Empty when absent — as of v0.3.215 it is only set for
+	// Anthropic-internal sessions while the field is trialed; external
+	// payloads omit it (sdk.d.ts v0.3.215).
 	Source string `json:"source,omitempty"`
 	// SessionTitle is the optional user-facing session label from TS L6094.
 	// Nil means the field was absent on the wire.
@@ -2556,13 +2563,14 @@ type HookResult struct {
 	// Honored on any hook return, sync or async.
 	TerminalSequence string
 
-	// SuppressOriginalPrompt, when set on a UserPromptSubmit hook return,
-	// asks the CLI to omit the original user prompt from the block message
-	// it returns when the hook blocks. Honored only on UserPromptSubmit
-	// hooks; nil (the default) leaves the wire field unset; a pointer to
-	// false explicitly opts out. Translates into hookSpecificOutput.
-	// suppressOriginalPrompt per sdk.d.ts v0.3.150 L5808. Useful when the
-	// prompt itself was the reason for the block (PII, credentials, etc.).
+	// SuppressOriginalPrompt asks the CLI to omit the original user prompt
+	// from the block message it returns when the hook blocks. Honored on
+	// UserPromptSubmit (sdk.d.ts v0.3.150 L5808) and UserPromptExpansion
+	// (sdk.d.ts v0.3.241 L8219) hooks, with identical semantics on both;
+	// silently dropped for other hook types. Nil (the default) leaves the
+	// wire field unset; a pointer to false explicitly opts out. Translates
+	// into hookSpecificOutput.suppressOriginalPrompt. Useful when the prompt
+	// itself was the reason for the block (PII, credentials, etc.).
 	SuppressOriginalPrompt *bool
 
 	// ReloadSkills, when set on a SessionStart hook return, asks the CLI to

--- a/protocol.go
+++ b/protocol.go
@@ -1752,11 +1752,11 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 		resp["hookSpecificOutput"] = hookSpecificOutput
 	}
 
-	if result.SuppressOriginalPrompt != nil && hookType == string(HookTypeUserPromptSubmit) {
+	if result.SuppressOriginalPrompt != nil && isSuppressOriginalPromptHook(hookType) {
 		hookSpecificOutput, _ := resp["hookSpecificOutput"].(map[string]interface{})
 		if hookSpecificOutput == nil {
 			hookSpecificOutput = map[string]interface{}{
-				"hookEventName": string(HookTypeUserPromptSubmit),
+				"hookEventName": hookType,
 			}
 		}
 		hookSpecificOutput["suppressOriginalPrompt"] = *result.SuppressOriginalPrompt
@@ -1786,6 +1786,18 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 	}
 
 	return resp
+}
+
+// isSuppressOriginalPromptHook returns true for hook events whose
+// hookSpecificOutput accepts suppressOriginalPrompt per sdk.d.ts v0.3.241.
+func isSuppressOriginalPromptHook(hookType string) bool {
+	switch hookType {
+	case string(HookTypeUserPromptSubmit),
+		string(HookTypeUserPromptExpansion):
+		return true
+	default:
+		return false
+	}
 }
 
 // isAdditionalContextHook returns true for hook events whose

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -4236,3 +4236,45 @@ func TestHandleHookCallback_RetryWatchPathsEvents(t *testing.T) {
 		assert.Equal(t, "success", resp.Response.Subtype)
 	})
 }
+
+func TestBuildHookResponse_SuppressOriginalPrompt_UserPromptExpansion(t *testing.T) {
+	t.Run("emitted with the expansion event name", func(t *testing.T) {
+		v := true
+		resp := buildHookResponse("UserPromptExpansion", HookResult{
+			Continue:               true,
+			SuppressOriginalPrompt: &v,
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		// The envelope must name the hook that produced it, not the
+		// UserPromptSubmit literal the gate used to hardcode.
+		assert.Equal(t, "UserPromptExpansion", hso["hookEventName"])
+		assert.Equal(t, true, hso["suppressOriginalPrompt"])
+	})
+
+	t.Run("explicit false still reaches the wire", func(t *testing.T) {
+		v := false
+		resp := buildHookResponse("UserPromptExpansion", HookResult{
+			Continue:               true,
+			SuppressOriginalPrompt: &v,
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, false, hso["suppressOriginalPrompt"])
+	})
+
+	t.Run("UserPromptSubmit still names itself", func(t *testing.T) {
+		v := true
+		resp := buildHookResponse("UserPromptSubmit", HookResult{
+			Continue:               true,
+			SuppressOriginalPrompt: &v,
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "UserPromptSubmit", hso["hookEventName"])
+		assert.Equal(t, true, hso["suppressOriginalPrompt"])
+	})
+}


### PR DESCRIPTION
Part of #206 (TypeScript SDK v0.3.241 parity).

Two prompt-hook items from this cycle.

### `suppressOriginalPrompt` on UserPromptExpansion (`sdk.d.ts` L8219)

`UserPromptExpansionHookSpecificOutput` now declares the field, with the same
semantics it has on `UserPromptSubmit`: when the decision is `block`, omit the
original prompt from the block message.

`buildHookResponse` hardcoded `HookTypeUserPromptSubmit` in two places — the
gate *and* the `hookEventName` it synthesized. Widening only the gate would
have emitted an expansion hook's output under a `UserPromptSubmit` event name,
so both move: the gate becomes `isSuppressOriginalPromptHook`, sitting next to
the existing `isAdditionalContextHook`, and the envelope now names the hook
that actually produced it.

### `poll_event` prompt source (`sdk.d.ts` L8228)

`UserPromptSubmitHookInput.source` gains `'poll_event'` — the poll-event
channel enqueue-time pass.

This one is **doc-only**. Both `protocol.go` hook-input builders already map
`source` through `getString`, so the value parses today; there is no plumbing
to add. What was missing is the meaning, and it is worth stating: `poll_event`
is the one source where a blocking verdict rejects something *not yet
delivered*. The hook fires when the host submits the event, before its
delivery ack exists. A hook author who assumes a blocking verdict merely
suppresses display will get that backwards.

### Testing

Three subtests on the expansion path: emission under the correct event name
(the regression the two-place hardcode invited), explicit `false` surviving to
the wire, and `UserPromptSubmit` still naming itself.

No integration test. `TestIntegrationUserPromptSubmitSuppressOriginalPrompt`
is already a documented skip — the omission is a CLI block-message rendering
behavior, not something the SDK transport surfaces — and the expansion variant
is unobservable for exactly the same reason.