### PR TITLE
query: add hooks_applied to the initialize response

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2414,6 +2414,53 @@ func TestIntegrationReinitialize(t *testing.T) {
 	require.NotNil(t, resp, "expected a fresh initialize response")
 }
 
+// TestIntegrationReinitializeHooksApplied checks hooks_applied on a repeated
+// initialize. This SDK owns the CLI's stdin, so if the CLI reports the field at
+// all it must report true — the repeated initialize's hook set replaces the one
+// registered earlier. CLIs predating the field omit it, so the assertion is
+// conditional on presence.
+func TestIntegrationReinitializeHooksApplied(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithMaxTurns(1),
+		WithHooks(map[HookType][]HookConfig{
+			HookTypePreToolUse: {
+				{Matcher: "*", Callback: func(
+					ctx context.Context, input HookInput,
+				) (HookResult, error) {
+					return HookResult{Continue: true}, nil
+				}},
+			},
+		}),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	stream, err := client.Stream(ctx)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	resp, err := stream.Reinitialize(ctx)
+	if err != nil {
+		t.Skipf("CLI does not support reinitialize: %v", err)
+	}
+	require.NotNil(t, resp)
+
+	if resp.HooksApplied == nil {
+		t.Skip("CLI does not report hooks_applied on the initialize response")
+	}
+	assert.True(t, *resp.HooksApplied,
+		"a repeated initialize from the process owning stdin must replace "+
+			"the registered hook set")
+}
+
 func TestIntegrationModelRefusalNoFallback(t *testing.T) {
 	skipIfNoToken(t)
 	skipIfNoCLI(t)

--- a/query_types.go
+++ b/query_types.go
@@ -47,6 +47,23 @@ type SDKControlInitializeResponse struct {
 	// FastModeDisabledReason explains why fast mode could not serve, when
 	// FastModeState is not "on". Absent when nothing blocks it.
 	FastModeDisabledReason FastModeDisabledReason `json:"fast_mode_disabled_reason,omitempty"`
+	// HooksApplied reports whether the hooks this initialize carried were
+	// registered: true on a session's first initialize, and on a repeated
+	// initialize from the process that owns the CLI's stdin — its set replaces
+	// the one registered earlier. False when a repeated initialize's hooks were
+	// ignored, which happens to a client joining a remote session another
+	// client configured.
+	//
+	// Nil means either the request carried no hooks, or the CLI predates the
+	// field — and those are not equivalent, because a CLI that predates it
+	// ignored hooks on every repeated initialize. So a nil here after a
+	// Reinitialize that did carry hooks is not evidence they took effect.
+	//
+	// Reinitialize is where a false is actionable: a caller reattaching to a
+	// session it did not configure keeps whatever hooks the owning client
+	// registered, and its own callbacks will never fire (sdk.d.ts v0.3.241
+	// L3752).
+	HooksApplied *bool `json:"hooks_applied,omitempty"`
 }
 
 // McpServerStatus reports the connection status of an MCP server.

--- a/query_types_test.go
+++ b/query_types_test.go
@@ -1,0 +1,52 @@
+package claudeagent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSDKControlInitializeResponseHooksApplied(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want *bool
+	}{
+		{
+			name: "true when the CLI registered this initialize's hooks",
+			body: `{"output_style": "default", "hooks_applied": true}`,
+			want: boolPtr(true),
+		},
+		{
+			name: "false when a repeated initialize's hooks were ignored",
+			body: `{"output_style": "default", "hooks_applied": false}`,
+			want: boolPtr(false),
+		},
+		{
+			// Not the same as false: a CLI predating the field ignored
+			// hooks on every repeated initialize without saying so.
+			name: "nil when absent",
+			body: `{"output_style": "default"}`,
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp SDKControlInitializeResponse
+			require.NoError(t, json.Unmarshal([]byte(tc.body), &resp))
+			assert.Equal(t, tc.want, resp.HooksApplied)
+		})
+	}
+}
+
+func TestSDKControlInitializeResponseHooksAppliedOmitEmpty(t *testing.T) {
+	data, err := json.Marshal(SDKControlInitializeResponse{})
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(data, &raw))
+	assert.NotContains(t, raw, "hooks_applied")
+}


### PR DESCRIPTION
Part of #206 (TypeScript SDK v0.3.241 parity).

`sdk.d.ts` v0.3.241 L3752 adds `hooks_applied?: boolean` to the initialize
control response.

- **true** — a session's first initialize, or a repeated initialize from the
  process that owns the CLI's stdin. Its hook set replaces the one registered
  earlier.
- **false** — a repeated initialize's hooks were ignored. This is what a
  client joining a remote session *another* client configured gets.
- **absent** — the request carried no hooks, or the CLI predates the field.

### Why it is a pointer

Nil is not false, and conflating them is the mistake worth preventing: a CLI
that predates the field ignored `hooks` on every repeated initialize *without
saying so*. So a nil after a `Reinitialize` that did carry hooks is not
evidence they took effect — it is the absence of evidence either way. The doc
comment says that outright.

`Reinitialize` is where a false is actionable, so the comment points at it. A
caller reattaching to a session it did not configure keeps whatever hooks the
owning client registered, and its own callbacks silently never fire. That is a
failure mode with no other signal.

### Testing

Table-driven unmarshal test over true / false / absent, plus an omitempty
check.

The integration test is a **live** one rather than a hard skip:
`TestIntegrationReinitializeHooksApplied` registers a PreToolUse hook, opens a
stream, and reinitializes. This SDK owns the CLI's stdin, so if the field is
reported at all it must be true. The assertion is conditional on presence, so
it skips cleanly on CLIs that omit it and starts asserting the moment the
runner catches up — same pattern `TestIntegrationAssistantContextUsage` uses.

Verified against the live CLI 2.1.222:

```
=== RUN   TestIntegrationReinitializeHooksApplied
    integration_test.go:2457: CLI does not report hooks_applied on the initialize response
--- SKIP: TestIntegrationReinitializeHooksApplied (1.30s)
```