### PR TITLE
options: add v0.3.241 Settings parity fields

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2092,6 +2092,52 @@ exec "$real_cli" "$@"
 		assert.Equal(t, want.Env, got.Env)
 	})
 
+	// The v0.3.241 fields are all top-level scalars, maps or plain nested
+	// objects — no source-union members — so the installed CLI accepts them
+	// rather than failing schema validation and stalling the handshake the
+	// way an unknown union variant does. Verified against the bare binary
+	// before landing this: CLI 2.1.222 runs a --settings payload carrying all
+	// six to completion.
+	t.Run("v0_3_241_fields", func(t *testing.T) {
+		syncOff := false
+		autoContinue := true
+		spellcheckOn := true
+
+		want := Settings{
+			SyncClaudeAiSkills:       &syncOff,
+			KeybindingFlavor:         KeybindingFlavorReadline,
+			AutoContinueAtUsageLimit: &autoContinue,
+			Worktree: &SettingsWorktree{
+				Location: "~/src/worktrees",
+			},
+			ModelSettings: map[string]SettingsModel{
+				"claude-opus-4-7": {EffortLevel: EffortXHigh},
+			},
+			Spellcheck: &SettingsSpellcheck{
+				Enabled:  &spellcheckOn,
+				Checker:  "auto",
+				Language: "en_GB",
+				Color:    "ansi256(203)",
+			},
+		}
+
+		argv := runWithArgvCapture(t, WithSettings(want))
+		var got Settings
+		require.NoError(t, json.Unmarshal(
+			[]byte(argValue(t, argv, "--settings")), &got))
+
+		require.NotNil(t, got.SyncClaudeAiSkills)
+		assert.False(t, *got.SyncClaudeAiSkills,
+			"only false is honored upstream, so it must survive the round trip")
+		assert.Equal(t, KeybindingFlavorReadline, got.KeybindingFlavor)
+		require.NotNil(t, got.AutoContinueAtUsageLimit)
+		assert.True(t, *got.AutoContinueAtUsageLimit)
+		require.NotNil(t, got.Worktree)
+		assert.Equal(t, "~/src/worktrees", got.Worktree.Location)
+		assert.Equal(t, want.ModelSettings, got.ModelSettings)
+		assert.Equal(t, want.Spellcheck, got.Spellcheck)
+	})
+
 	// Only the gate is asserted live. Feeding a command-sourced marketplace to
 	// a CLI that predates the variant makes it fail schema validation on the
 	// managed tier and stall the handshake, so that half stays in

--- a/options.go
+++ b/options.go
@@ -315,10 +315,27 @@ type Settings struct {
 	AWSAuthRefresh      string `json:"awsAuthRefresh,omitempty"`
 	GCPAuthRefresh      string `json:"gcpAuthRefresh,omitempty"`
 	// PolicyHelper configures the admin-controlled policy executable invoked at startup to compute managed settings. Honored only from policy sources. Mirrors sdk.d.ts v0.3.150 L3993.
-	PolicyHelper               *SettingsPolicyHelper            `json:"policyHelper,omitempty"`
-	FileSuggestion             *SettingsFileSuggestion          `json:"fileSuggestion,omitempty"`
-	RespectGitignore           *bool                            `json:"respectGitignore,omitempty"`
-	CleanupPeriodDays          *int                             `json:"cleanupPeriodDays,omitempty"`
+	PolicyHelper      *SettingsPolicyHelper   `json:"policyHelper,omitempty"`
+	FileSuggestion    *SettingsFileSuggestion `json:"fileSuggestion,omitempty"`
+	RespectGitignore  *bool                   `json:"respectGitignore,omitempty"`
+	CleanupPeriodDays *int                    `json:"cleanupPeriodDays,omitempty"`
+	// SyncClaudeAiSkills turns off syncing of the skills enabled on
+	// claude.ai. Only false is honored: the feature is enabled server-side per
+	// account, so setting true does not turn it on early. Not read from
+	// project settings (.claude/settings.json), and only applies when signed
+	// in with a Claude account.
+	//
+	// The effect of a false depends on which file carries it. In user or
+	// managed settings it is destructive-ish: nothing more is downloaded,
+	// previously synced skills under ~/.claude/skills/synced stop running and
+	// are hidden from sessions started afterwards, and at the next launch they
+	// move to ~/.claude/skills/.trash — deleted after CleanupPeriodDays, and
+	// re-downloaded rather than restored if the setting is reverted. In
+	// .claude/settings.local.json or --settings it is scoped and reversible:
+	// downloads stop and synced skills are blocked and hidden for that
+	// workspace or invocation only, with nothing moved (sdk.d.ts v0.3.241
+	// L5392).
+	SyncClaudeAiSkills         *bool                            `json:"syncClaudeAiSkills,omitempty"`
 	SkillListingMaxDescChars   *int                             `json:"skillListingMaxDescChars,omitempty"`
 	SkillListingBudgetFraction *float64                         `json:"skillListingBudgetFraction,omitempty"`
 	WSLInheritsWindowsSettings *bool                            `json:"wslInheritsWindowsSettings,omitempty"`
@@ -426,6 +443,17 @@ type Settings struct {
 	TerminalTitleFromRename    *bool                        `json:"terminalTitleFromRename,omitempty"`
 	AlwaysThinkingEnabled      *bool                        `json:"alwaysThinkingEnabled,omitempty"`
 	EffortLevel                EffortLevel                  `json:"effortLevel,omitempty"`
+	// ModelSettings holds per-model settings keyed by canonical model name —
+	// the per-model twin of EffortLevel above. Note the ceiling differs: a
+	// persisted per-model effort tops out at "xhigh", where the init message's
+	// applied effort also admits "max" (sdk.d.ts v0.3.241 L7415).
+	ModelSettings map[string]SettingsModel `json:"modelSettings,omitempty"`
+	// Spellcheck underlines misspelled words in the prompt input as you type,
+	// using an installed aspell, hunspell or ispell. Read from user, flag and
+	// managed settings only — the whole block from the highest-precedence of
+	// those applies, and it is ignored in .claude/settings.json and
+	// .claude/settings.local.json (sdk.d.ts v0.3.241 L7381).
+	Spellcheck *SettingsSpellcheck `json:"spellcheck,omitempty"`
 	// Ultracode enables session-scoped workflow orchestration, typically via --settings or apply_flag_settings. Mirrors sdk.d.ts v0.3.168 L5413.
 	Ultracode                    *bool  `json:"ultracode,omitempty"`
 	AutoCompactWindow            *int   `json:"autoCompactWindow,omitempty"`
@@ -479,6 +507,10 @@ type Settings struct {
 	PluginTrustMessage string   `json:"pluginTrustMessage,omitempty"`
 	Theme              string   `json:"theme,omitempty"`
 	EditorMode         string   `json:"editorMode,omitempty"`
+	// KeybindingFlavor selects which conventions the prompt's word-editing
+	// keys follow. Empty string leaves the CLI default (KeybindingFlavorClassic)
+	// in place (sdk.d.ts v0.3.241 L7640).
+	KeybindingFlavor KeybindingFlavor `json:"keybindingFlavor,omitempty"`
 	// VimInsertModeRemaps holds vim INSERT-mode key-sequence remaps, e.g.
 	// {"jj": "<Esc>"}. Each key is exactly two printable characters typed in
 	// sequence; "<Esc>" (return to NORMAL mode) is the only supported target.
@@ -492,7 +524,12 @@ type Settings struct {
 	// Mirrors sdk.d.ts v0.3.220 L6545.
 	PrecomputeCompactionEnabled *bool `json:"precomputeCompactionEnabled,omitempty"`
 	// SwitchModelsOnFlag switches models automatically when safety measures flag a message. Mirrors sdk.d.ts v0.3.168 L5620.
-	SwitchModelsOnFlag         *bool `json:"switchModelsOnFlag,omitempty"`
+	SwitchModelsOnFlag *bool `json:"switchModelsOnFlag,omitempty"`
+	// AutoContinueAtUsageLimit waits for a claude.ai usage limit to reset and
+	// continues the task automatically when one stops the session. When off,
+	// the limit dialog offers the wait as a choice instead (sdk.d.ts v0.3.241
+	// L7670).
+	AutoContinueAtUsageLimit   *bool `json:"autoContinueAtUsageLimit,omitempty"`
 	AutoScrollEnabled          *bool `json:"autoScrollEnabled,omitempty"`
 	FileCheckpointingEnabled   *bool `json:"fileCheckpointingEnabled,omitempty"`
 	ShowTurnDuration           *bool `json:"showTurnDuration,omitempty"`
@@ -725,6 +762,67 @@ type SettingsWorktree struct {
 	BaseRef string `json:"baseRef,omitempty"`
 	// BgIsolation selects the isolation mode for background sessions. Mirrors sdk.d.ts v0.3.150 L4368.
 	BgIsolation string `json:"bgIsolation,omitempty"`
+	// Location is the directory under which Claude Code Desktop creates the
+	// worktrees of SSH sessions running on this machine, instead of
+	// <project>/.claude/worktrees. An absolute path, or one starting with ~/.
+	// Read by the desktop app from the SSH host user settings; a location
+	// chosen in the desktop app's SSH connection settings takes precedence.
+	//
+	// The CLI does not read it — not for --worktree, not for EnterWorktree,
+	// not for agent isolation — so setting it has no effect on an SDK-driven
+	// session (sdk.d.ts v0.3.241 L5766).
+	Location string `json:"location,omitempty"`
+}
+
+// KeybindingFlavor selects which conventions the prompt's word-editing keys
+// follow.
+type KeybindingFlavor string
+
+const (
+	// KeybindingFlavorClassic is the CLI default: Ctrl+W deletes the previous
+	// word, and the word keys use Unicode word segmentation, so "foo_bar" and
+	// "3.14" each count as one word.
+	KeybindingFlavorClassic KeybindingFlavor = "classic"
+	// KeybindingFlavorReadline matches Bash and other readline programs:
+	// Ctrl+W deletes back to the previous whitespace; Alt+F and Alt+D stop at
+	// the end of the current word and Ctrl+Y pastes back what Alt+D deleted.
+	// For Alt+B, Alt+F, Alt+D, Ctrl/Option+Arrow and Option/Ctrl+Backspace a
+	// word is a run of letters and digits, so punctuation separates words.
+	KeybindingFlavorReadline KeybindingFlavor = "readline"
+)
+
+// SettingsModel holds the persisted settings for one model, keyed in
+// Settings.ModelSettings by canonical model name.
+//
+// TS declares an open index signature on this entry, so the CLI may add keys
+// here that this struct drops on a round trip.
+type SettingsModel struct {
+	// EffortLevel is the persisted effort level for this model. Unlike the
+	// init message's applied effort, "max" is not a member here.
+	EffortLevel EffortLevel `json:"effortLevel,omitempty"`
+}
+
+// SettingsSpellcheck configures prompt-input spell checking. It does nothing
+// unless Enabled is true and one of aspell, hunspell or ispell is installed.
+//
+// TS declares an open index signature on this block, so the CLI may add keys
+// here that this struct drops on a round trip.
+type SettingsSpellcheck struct {
+	// Enabled turns on spell checking of the prompt input. Default false.
+	Enabled *bool `json:"enabled,omitempty"`
+	// Checker selects which spell checker to run: "aspell", "hunspell",
+	// "ispell", or "auto" (the default) for the first of those found on PATH.
+	Checker string `json:"checker,omitempty"`
+	// Language is the dictionary, passed to the checker as-is (aspell --lang,
+	// hunspell -d, ispell -d), e.g. "en_GB". Names are checker-specific and
+	// accept only letters, digits and _ - . , characters. Empty string leaves
+	// the checker's own default.
+	Language string `json:"language,omitempty"`
+	// Color is the color of misspelled words, which are also underlined: a
+	// terminal color name such as "red" or "magenta", "#rrggbb",
+	// "rgb(r,g,b)", "ansi256(n)" or "ansi:<name>". Empty string leaves the
+	// theme's error color.
+	Color string `json:"color,omitempty"`
 }
 
 type SettingsCommand struct {

--- a/options_test.go
+++ b/options_test.go
@@ -1985,3 +1985,87 @@ func TestSettingsForceLoginGatewayURLJSON(t *testing.T) {
 		assert.NotContains(t, got, "forceLoginGatewayUrl")
 	})
 }
+
+func TestSettingsParityV0_3_241(t *testing.T) {
+	enabled := true
+	syncOff := false
+	autoContinue := true
+
+	settings := Settings{
+		SyncClaudeAiSkills:       &syncOff,
+		KeybindingFlavor:         KeybindingFlavorReadline,
+		AutoContinueAtUsageLimit: &autoContinue,
+		Worktree: &SettingsWorktree{
+			BgIsolation: "worktree",
+			Location:    "~/src/worktrees",
+		},
+		ModelSettings: map[string]SettingsModel{
+			"claude-opus-4-7": {EffortLevel: EffortXHigh},
+			"claude-sonnet-5": {EffortLevel: EffortLow},
+		},
+		Spellcheck: &SettingsSpellcheck{
+			Enabled:  &enabled,
+			Checker:  "hunspell",
+			Language: "en_GB",
+			Color:    "ansi256(203)",
+		},
+	}
+
+	data, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, false, got["syncClaudeAiSkills"])
+	assert.Equal(t, "readline", got["keybindingFlavor"])
+	assert.Equal(t, true, got["autoContinueAtUsageLimit"])
+
+	worktree, ok := got["worktree"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "~/src/worktrees", worktree["location"])
+
+	modelSettings, ok := got["modelSettings"].(map[string]interface{})
+	require.True(t, ok)
+	opus, ok := modelSettings["claude-opus-4-7"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "xhigh", opus["effortLevel"])
+
+	spellcheck, ok := got["spellcheck"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, spellcheck["enabled"])
+	assert.Equal(t, "hunspell", spellcheck["checker"])
+	assert.Equal(t, "en_GB", spellcheck["language"])
+	assert.Equal(t, "ansi256(203)", spellcheck["color"])
+
+	var back Settings
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, settings, back)
+}
+
+func TestSettingsParityV0_3_241OmitEmpty(t *testing.T) {
+	data, err := json.Marshal(Settings{})
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	for _, key := range []string{
+		"syncClaudeAiSkills",
+		"keybindingFlavor",
+		"autoContinueAtUsageLimit",
+		"modelSettings",
+		"spellcheck",
+	} {
+		assert.NotContains(t, got, key)
+	}
+}
+
+func TestSettingsSyncClaudeAiSkillsFalseSurvives(t *testing.T) {
+	// Only false is honored upstream, so it is the one value that must not be
+	// swallowed by omitempty. A *bool is what makes that work.
+	off := false
+	data, err := json.Marshal(Settings{SyncClaudeAiSkills: &off})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"syncClaudeAiSkills": false}`, string(data))
+}


### PR DESCRIPTION
Part of #206 (TypeScript SDK v0.3.241 parity).

Six additions to `Settings`.

### `syncClaudeAiSkills` (L5392)

Turns off syncing of the skills enabled on claude.ai. **Only `false` is
honored** — the feature is enabled server-side per account, so setting `true`
does not turn it on early. That makes `false` the one value `omitempty` would
otherwise swallow, which is why it lands as a `*bool`; there is a dedicated
test pinning that.

The effect depends on which file carries it, and the asymmetry is worth
knowing before setting it:

- **user / managed settings** — destructive. Previously synced skills under
  `~/.claude/skills/synced` stop running, are hidden from later sessions, and
  move to `~/.claude/skills/.trash` at next launch. Deleted after
  `cleanupPeriodDays`, and re-*downloaded* rather than restored if you revert.
- **`.claude/settings.local.json` / `--settings`** — scoped and reversible.
  Downloads stop and synced skills are blocked for that workspace or
  invocation only. Nothing moves.

Not read from project settings at all.

### `worktree.location` (L5766)

Where Claude Code Desktop puts the worktrees of SSH sessions running on this
machine, instead of `<project>/.claude/worktrees`.

Called out in the comment because it is a trap for this SDK's users: **the CLI
does not read it.** Not `--worktree`, not `EnterWorktree`, not agent
isolation. Setting it from an SDK-driven session does nothing.

### `keybindingFlavor` (L7640)

`classic` (default) or `readline`, as a named type with two consts. The
difference is mostly Ctrl+W and what counts as a word — `readline` treats a
word as a run of letters and digits so punctuation separates words, where
`classic` uses Unicode word segmentation and keeps `foo_bar` and `3.14`
whole.

### `autoContinueAtUsageLimit` (L7670)

Wait out a claude.ai usage limit and continue automatically. When off, the
limit dialog offers the wait as a choice.

### `modelSettings` (L7415)

Per-model settings keyed by canonical model name — the per-model twin of the
existing top-level `EffortLevel`. Note the ceiling differs and the comment
says so: a persisted per-model effort tops out at `xhigh`, where the init
message's applied effort (see #207) also admits `max`.

### `spellcheck` (L7381)

New `SettingsSpellcheck` block: `enabled`, `checker`, `language`, `color`.
Read from user, flag and managed settings only — the whole block from the
highest-precedence of those applies, and it is ignored in
`.claude/settings.json` and `.claude/settings.local.json`.

Both `modelSettings` entries and the `spellcheck` block carry open index
signatures in TS. They land as plain structs per repo convention, with the
comment noting the CLI may add keys these drop on a round trip.

### Testing

Round-trip and omitempty tests over all six, plus the `syncClaudeAiSkills:
false` case on its own.

Integration test is **live**, as a new `v0_3_241_fields` subtest on
`TestIntegrationSettingsOptions` — it feeds all six through `--settings` to a
real session and asserts the round trip.

Probed the bare binary first, per the known failure mode where an unknown
*nested source-union* member fails managed-tier schema validation and stalls
the handshake for the full timeout instead of erroring. These are all
top-level scalars, maps or plain nested objects, so none of them trip it —
CLI 2.1.222 runs a `--settings` payload carrying all six to completion.

```
--- PASS: TestIntegrationSettingsOptions/v0_3_241_fields (1.35s)
```