### PR TITLE
options: document headersHelper on marketplace sources

### DIFF
--- a/options.go
+++ b/options.go
@@ -372,9 +372,10 @@ type Settings struct {
 	// extraKnownMarketplaces when it updates the file.
 	//
 	// Prefer ExtraKnownMarketplaces while older clients still share the same
-	// settings: a client predating the alias ignores it outright, and its
-	// settings sync then uploads a file that declares no marketplaces at all.
-	// Mirrors sdk.d.ts v0.3.233 L6023.
+	// settings: a client predating the alias ignores it outright. Mirrors
+	// sdk.d.ts v0.3.241 L6152, which dropped the earlier claim that such a
+	// client's settings sync re-uploads the file as declaring no
+	// marketplaces.
 	AdditionalMarketplaces map[string]SettingsMarketplace `json:"additionalMarketplaces,omitempty"`
 	// AllowedMarketplaces is read exactly as if it were spelled
 	// StrictKnownMarketplaces, and like it is honored only from managed
@@ -746,6 +747,21 @@ type SettingsMarketplace struct {
 // selects the variant; remaining keys depend on the variant (e.g. "repo", "url", "package",
 // "path", "ref", "sparsePaths", "skipLfs"). Per sdk.d.ts v0.3.168 L4695/L4717 (github) and
 // L4895/L4917 (git), the optional "skipLfs": boolean key sets GIT_LFS_SKIP_SMUDGE=1 on clone/update.
+//
+// Sources that carry an inline "catalog" array accept two per-entry keys
+// scoped to downloading that entry's "archive" source: "headers"
+// (map[string]string) and "headersHelper" (string, a command printing a JSON
+// object of headers). The helper here runs only when a user explicitly
+// installs or updates that plugin — unlike the url source's helper, which is
+// re-run on every marketplace refresh. Use an absolute path.
+//
+// Two asymmetries worth knowing before writing one. An entry declared in a
+// settings file does not need "strict": false the way a manifest catalog entry
+// does, because a settings file has no manifest fields to inline. And a
+// declaration in *project* settings is not operator-authored, so
+// request-routing and client-identity header names stay filtered there even
+// though the same declaration in user or managed settings would pass.
+// Mirrors sdk.d.ts v0.3.241 L6112.
 type SettingsMarketplaceSource map[string]interface{}
 
 // SettingsMarketplaceSourceKind is the discriminator value stored in a SettingsMarketplaceSource "source" entry.
@@ -770,6 +786,21 @@ const (
 	SettingsMarketplaceSourceHostPattern SettingsMarketplaceSourceKind = "hostPattern"
 	// SettingsMarketplaceSourcePathPattern identifies a pathPattern marketplace source. Mirrors sdk.d.ts v0.3.150 L4555.
 	SettingsMarketplaceSourcePathPattern SettingsMarketplaceSourceKind = "pathPattern"
+	// SettingsMarketplaceSourceURL identifies a marketplace fetched from a
+	// direct URL to a marketplace.json file. Honors "url": string, optional
+	// "headers": map[string]string (custom HTTP headers, e.g. for auth), and
+	// optional "headersHelper": string.
+	//
+	// The helper is a command that prints a JSON object of HTTP headers — a
+	// short-lived auth token, typically. Its output overrides "headers" and,
+	// like "headers", is inherited by same-origin archive downloads from this
+	// marketplace. It runs from a fixed directory (the Claude config home,
+	// never the session's), so a relative path will not resolve the way a
+	// caller expects: give a bare command found via PATH, or an absolute
+	// path. Re-run on later refreshes of this marketplace, so it must stay
+	// callable for the life of the config, not just at install time.
+	// Mirrors sdk.d.ts v0.3.241 L5930.
+	SettingsMarketplaceSourceURL SettingsMarketplaceSourceKind = "url"
 	// SettingsMarketplaceSourceArchive identifies a zip-archive plugin source.
 	// Honors "url": string (HTTPS URL of the archive; the plugin root may sit at
 	// the top or one directory deep, as a single wrapping directory is stripped)

--- a/options_test.go
+++ b/options_test.go
@@ -1985,3 +1985,82 @@ func TestSettingsForceLoginGatewayURLJSON(t *testing.T) {
 		assert.NotContains(t, got, "forceLoginGatewayUrl")
 	})
 }
+
+func TestSettingsMarketplaceSourceURLHeadersHelper(t *testing.T) {
+	// The source descriptor is an open map, so the point of this test is that
+	// the documented v0.3.241 keys survive a round trip intact rather than
+	// that a new field exists.
+	settings := Settings{
+		ExtraKnownMarketplaces: map[string]SettingsMarketplace{
+			"internal": {
+				Source: SettingsMarketplaceSource{
+					"source": string(SettingsMarketplaceSourceURL),
+					"url":    "https://example.internal/marketplace.json",
+					"headers": map[string]interface{}{
+						"X-Env": "prod",
+					},
+					"headersHelper": "/usr/local/bin/mp-headers",
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	var back Settings
+	require.NoError(t, json.Unmarshal(data, &back))
+
+	src := back.ExtraKnownMarketplaces["internal"].Source
+	assert.Equal(t, "url", src["source"])
+	assert.Equal(t, "https://example.internal/marketplace.json", src["url"])
+	assert.Equal(t, "/usr/local/bin/mp-headers", src["headersHelper"])
+	assert.Equal(t,
+		map[string]interface{}{"X-Env": "prod"},
+		src["headers"])
+}
+
+func TestSettingsMarketplaceSourceCatalogHeaders(t *testing.T) {
+	// Inline catalog entries carry their own headers/headersHelper, scoped to
+	// that entry's archive download.
+	src := SettingsMarketplaceSource{
+		"source": string(SettingsMarketplaceSourceGithub),
+		"repo":   "example/plugins",
+		"catalog": []interface{}{
+			map[string]interface{}{
+				"name": "inner",
+				"source": map[string]interface{}{
+					"source": string(SettingsMarketplaceSourceArchive),
+					"url":    "https://example.internal/inner.zip",
+				},
+				"headers": map[string]interface{}{
+					"Authorization": "Bearer placeholder",
+				},
+				"headersHelper": "/usr/local/bin/entry-headers",
+			},
+		},
+	}
+
+	data, err := json.Marshal(src)
+	require.NoError(t, err)
+
+	var back SettingsMarketplaceSource
+	require.NoError(t, json.Unmarshal(data, &back))
+
+	catalog, ok := back["catalog"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, catalog, 1)
+
+	entry, ok := catalog[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "/usr/local/bin/entry-headers", entry["headersHelper"])
+	assert.Equal(t,
+		map[string]interface{}{"Authorization": "Bearer placeholder"},
+		entry["headers"])
+}
+
+func TestSettingsMarketplaceSourceURLConstant(t *testing.T) {
+	assert.Equal(t,
+		SettingsMarketplaceSourceKind("url"),
+		SettingsMarketplaceSourceURL)
+}


### PR DESCRIPTION
Part of #206 (TypeScript SDK v0.3.241 parity).

`sdk.d.ts` v0.3.241 adds `headersHelper` to the url marketplace source, and
`headers` + `headersHelper` to inline catalog entries — repeated across all
four marketplace settings keys (`extraKnownMarketplaces`,
`additionalMarketplaces`, `strictKnownMarketplaces`, `allowedMarketplaces`),
which is most of why the raw diff looked bigger than it is.

`SettingsMarketplaceSource` is an open `map[string]interface{}`, so both keys
are already representable. **This PR is the contract, not a new field** — the
same treatment `skipLfs` and `sha256` got in earlier cycles. It adds the
missing `SettingsMarketplaceSourceURL` const (the url variant had none) and
documents what these keys actually do.

### What is worth documenting

The two helpers look identical and are not:

- **url source** — re-run on **every later refresh** of the marketplace. It
  has to stay callable for the life of the config, not just at install time.
  It also runs from a *fixed* directory (the Claude config home, never the
  session's), so a relative path silently resolves somewhere the caller did
  not intend. Bare command on PATH, or absolute.
- **inline catalog entry** — runs **only** when a user explicitly installs or
  updates that plugin, and is scoped to that entry's `archive` download.

Two more asymmetries on catalog entries, both easy to get wrong:

- An entry declared in a settings file does **not** need `strict: false` the
  way a manifest catalog entry does — a settings file has no manifest fields
  to inline.
- A declaration in **project** settings is not operator-authored, so
  request-routing and client-identity header names stay filtered there, even
  though the identical declaration in user or managed settings passes.

### Also

Trims the `additionalMarketplaces` alias comment. Upstream reworded L6152 to
drop the claim that a client predating the alias would have its settings sync
re-upload the file as declaring no marketplaces; the Go comment still carried
it.

### Testing

Round-trip tests for a url source carrying `headers` + `headersHelper`, and
for an inline catalog entry carrying both, plus the const value. Since the
descriptor is an open map, what these assert is that the documented keys
survive marshal/unmarshal intact — which is the actual contract a caller
depends on here.

No integration test: this changes no wire behavior the SDK controls. Feeding a
real marketplace to the CLI is also the case that stalls the handshake on
schema mismatch, which `TestIntegrationSettingsMiscFields` already defers.