### PR TITLE
hooks: add PreModelSwitch and PostModelSwitch events

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2673,4 +2674,92 @@ func TestIntegrationInitTerminalSlashCommands(t *testing.T) {
 
 	assert.Subset(t, init.SlashCommands, init.TerminalSlashCommands,
 		"every terminal command must also appear in slash_commands")
+}
+
+// TestIntegrationModelSwitchHooks drives a live model switch through
+// Stream.SetModel and asserts the PreModelSwitch / PostModelSwitch hooks added
+// in TS SDK v0.3.251 fire with source "sdk".
+func TestIntegrationModelSwitchHooks(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	var mu sync.Mutex
+	var pre []PreModelSwitchInput
+	var post []PostModelSwitchInput
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithModel("claude-sonnet-4-6"),
+		WithMaxTurns(1),
+		WithHooks(map[HookType][]HookConfig{
+			HookTypePreModelSwitch: {
+				{Matcher: "*", Callback: func(
+					ctx context.Context, input HookInput,
+				) (HookResult, error) {
+					if in, ok := input.(PreModelSwitchInput); ok {
+						mu.Lock()
+						pre = append(pre, in)
+						mu.Unlock()
+					}
+					return HookResult{Continue: true}, nil
+				}},
+			},
+			HookTypePostModelSwitch: {
+				{Matcher: "*", Callback: func(
+					ctx context.Context, input HookInput,
+				) (HookResult, error) {
+					if in, ok := input.(PostModelSwitchInput); ok {
+						mu.Lock()
+						post = append(post, in)
+						mu.Unlock()
+					}
+					return HookResult{Continue: true}, nil
+				}},
+			},
+		}),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	stream, err := client.Stream(ctx)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	if err := stream.SetModel(ctx, "claude-opus-4-8"); err != nil {
+		t.Skipf("CLI does not support set_model: %v", err)
+	}
+
+	// The switch is acked before the hooks round-trip, so give them a beat.
+	require.NoError(t, stream.Send(ctx, "Say OK."))
+	for msg := range stream.Messages() {
+		if _, ok := msg.(ResultMessage); ok {
+			break
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(pre) == 0 && len(post) == 0 {
+		t.Skip("not triggerable from CLI: this CLI build does not emit " +
+			"PreModelSwitch / PostModelSwitch hook events for set_model")
+	}
+
+	for _, in := range pre {
+		assert.Equal(t, ModelSwitchSourceSDK, in.Source)
+		assert.NotEmpty(t, in.ToModel)
+		assert.Contains(t,
+			[]CacheTTL{CacheTTL5m, CacheTTL1h}, in.CacheTTL,
+			"cache_ttl is a closed set upstream",
+		)
+	}
+	for _, in := range post {
+		assert.NotEmpty(t, in.ToModel)
+		assert.NotEqual(t, in.FromModel, in.ToModel,
+			"a post-switch report must name two different models")
+	}
 }

--- a/options.go
+++ b/options.go
@@ -1952,6 +1952,13 @@ const (
 	// HookTypePostCompact fires after context compaction.
 	HookTypePostCompact HookType = "PostCompact"
 
+	// HookTypePreModelSwitch fires before the active model changes, and can
+	// veto the switch via HookResult.PermissionDecision.
+	HookTypePreModelSwitch HookType = "PreModelSwitch"
+
+	// HookTypePostModelSwitch fires after the active model has changed.
+	HookTypePostModelSwitch HookType = "PostModelSwitch"
+
 	// HookTypePostToolBatch fires after a batch of tool calls completes.
 	HookTypePostToolBatch HookType = "PostToolBatch"
 
@@ -2243,6 +2250,137 @@ func (PostCompactInput) HookType() HookType { return HookTypePostCompact }
 
 // Base implements HookInput.
 func (i PostCompactInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// CacheTTL is the lifetime of a prompt-cache entry. It bounds how long a warm
+// cache stays warm, and so how much of a model switch or a session resume can
+// be served without paying a fresh cache write.
+type CacheTTL string
+
+const (
+	// CacheTTL5m is the default prompt-cache lifetime.
+	CacheTTL5m CacheTTL = "5m"
+
+	// CacheTTL1h is the extended prompt-cache lifetime.
+	CacheTTL1h CacheTTL = "1h"
+)
+
+// ModelSwitchSource identifies what initiated a model switch.
+type ModelSwitchSource string
+
+const (
+	// ModelSwitchSourceCommand is a switch from the /model slash command.
+	ModelSwitchSourceCommand ModelSwitchSource = "command"
+
+	// ModelSwitchSourcePicker is a switch from the interactive model picker.
+	ModelSwitchSourcePicker ModelSwitchSource = "picker"
+
+	// ModelSwitchSourceSDK is a switch driven by the SDK's set_model control
+	// request.
+	ModelSwitchSourceSDK ModelSwitchSource = "sdk"
+
+	// ModelSwitchSourceAuto is a switch the CLI performed on its own, such as
+	// a fallback after a refusal. PostModelSwitch only — see
+	// PostModelSwitchInput.Source.
+	ModelSwitchSourceAuto ModelSwitchSource = "auto"
+
+	// ModelSwitchSourceResume is the model being restored when a session is
+	// resumed. PostModelSwitch only — see PostModelSwitchInput.Source.
+	ModelSwitchSourceResume ModelSwitchSource = "resume"
+)
+
+// ModelPricingBasis says where the per-token prices behind a cost estimate came
+// from.
+type ModelPricingBasis string
+
+const (
+	// ModelPricingConfigured means Settings.ModelPricing supplied the rates.
+	ModelPricingConfigured ModelPricingBasis = "configured"
+
+	// ModelPricingCatalog means the rates came from the published model
+	// catalog.
+	ModelPricingCatalog ModelPricingBasis = "catalog"
+
+	// ModelPricingDefault means neither applied and a fallback rate was used,
+	// so the estimate is indicative only.
+	ModelPricingDefault ModelPricingBasis = "default"
+)
+
+// modelSwitchContext is the prompt-cache economics both model-switch hooks
+// carry. A switch invalidates the warm cache for the outgoing model, so the
+// interesting question at hook time is what re-warming will cost.
+type modelSwitchContext struct {
+	// FromModel is the model in effect before the switch.
+	FromModel string `json:"from_model"`
+
+	// ToModel is the model that will be (or has been) switched to.
+	ToModel string `json:"to_model"`
+
+	// RequestedModel is what the user or caller actually asked for, when that
+	// differs from the resolved ToModel. Nil when the request named no target
+	// — cycling the picker, say — and also on CLIs that predate the field;
+	// the two are not distinguishable and nothing consumes the difference.
+	RequestedModel *string `json:"requested_model,omitempty"`
+
+	// ContextTokens is the size of the context that would have to be re-sent
+	// against the new model.
+	ContextTokens int `json:"context_tokens"`
+
+	// PromptCacheWarm reports whether the outgoing model's prompt cache is
+	// currently warm. Switching away from a warm cache is what makes
+	// EstimatedCacheWriteUSD non-trivial.
+	PromptCacheWarm bool `json:"prompt_cache_warm"`
+
+	// CacheTTL is the prompt-cache lifetime in effect.
+	CacheTTL CacheTTL `json:"cache_ttl"`
+
+	// EstimatedCacheWriteUSD is the projected cost of writing the context into
+	// the new model's cache.
+	EstimatedCacheWriteUSD float64 `json:"estimated_cache_write_usd"`
+
+	// Pricing says where the rates behind EstimatedCacheWriteUSD came from.
+	// ModelPricingDefault means treat the figure as indicative.
+	Pricing ModelPricingBasis `json:"pricing"`
+}
+
+// PreModelSwitchInput contains data for PreModelSwitch hooks.
+//
+// The hook can veto the switch: returning HookResult.PermissionDecision "deny"
+// cancels it, "ask" asks the user to confirm (a headless session refuses
+// instead), and "allow" proceeds while skipping the interactive cache-miss
+// confirm (sdk.d.ts v0.3.251 L2482).
+type PreModelSwitchInput struct {
+	BaseHookInput
+	modelSwitchContext
+
+	// Source is what initiated the switch: ModelSwitchSourceCommand,
+	// ModelSwitchSourcePicker, or ModelSwitchSourceSDK. A switch the CLI made
+	// on its own has no vetoable pre-phase and so never reaches this hook.
+	Source ModelSwitchSource `json:"source"`
+}
+
+// HookType implements HookInput.
+func (PreModelSwitchInput) HookType() HookType { return HookTypePreModelSwitch }
+
+// Base implements HookInput.
+func (i PreModelSwitchInput) Base() BaseHookInput { return i.BaseHookInput }
+
+// PostModelSwitchInput contains data for PostModelSwitch hooks.
+type PostModelSwitchInput struct {
+	BaseHookInput
+	modelSwitchContext
+
+	// Source is what initiated the switch. Beyond the three values
+	// PreModelSwitch admits, this also reports ModelSwitchSourceAuto and
+	// ModelSwitchSourceResume — switches the CLI performed itself, which by
+	// construction only ever surface after the fact.
+	Source ModelSwitchSource `json:"source"`
+}
+
+// HookType implements HookInput.
+func (PostModelSwitchInput) HookType() HookType { return HookTypePostModelSwitch }
+
+// Base implements HookInput.
+func (i PostModelSwitchInput) Base() BaseHookInput { return i.BaseHookInput }
 
 // PostToolBatchInput contains data for PostToolBatch hooks.
 type PostToolBatchInput struct {
@@ -2813,12 +2951,50 @@ type HookResult struct {
 	// a real redaction.
 	ClassifierContext string
 
+	// PermissionDecision lets a pre-phase hook rule on the action it is
+	// gating. Honored on PreToolUse (sdk.d.ts v0.3.251 L2500) and
+	// PreModelSwitch (L2487); silently dropped elsewhere. Empty string omits
+	// the field on the wire. Composes with an explicit HookSpecificOutput
+	// map the same way AdditionalContext does: the typed value overwrites
+	// permissionDecision and leaves the caller's other keys alone.
+	//
+	// Note the value sets differ. PreToolUse takes all four constants;
+	// PreModelSwitch takes allow, deny and ask only, and there is no
+	// deferred model switch to hand off to.
+	PermissionDecision HookPermissionDecision
+
+	// PermissionDecisionReason is the human-readable justification shown
+	// alongside PermissionDecision. Honored on the same hook events, and
+	// meaningless without one.
+	PermissionDecisionReason string
+
 	// HookSpecificOutput provides raw hookSpecificOutput for the CLI
 	// response. When set, this takes precedence over auto-translation
 	// of Modify. Use this for finer control over permissionDecision,
 	// additionalContext, or other hook-specific fields.
 	HookSpecificOutput map[string]interface{}
 }
+
+// HookPermissionDecision is a pre-phase hook's ruling on the action it gates
+// (sdk.d.ts v0.3.251 L878).
+type HookPermissionDecision string
+
+const (
+	// HookPermissionAllow proceeds without asking the user. On PreModelSwitch
+	// this also skips the interactive cache-miss confirm.
+	HookPermissionAllow HookPermissionDecision = "allow"
+
+	// HookPermissionDeny cancels the action.
+	HookPermissionDeny HookPermissionDecision = "deny"
+
+	// HookPermissionAsk puts the decision to the user. A headless session has
+	// nobody to ask and refuses instead.
+	HookPermissionAsk HookPermissionDecision = "ask"
+
+	// HookPermissionDefer hands the decision to the normal permission flow as
+	// though the hook had not run. PreToolUse only.
+	HookPermissionDefer HookPermissionDecision = "defer"
+)
 
 // AgentDefinition defines a specialized subagent.
 type AgentDefinition struct {

--- a/protocol.go
+++ b/protocol.go
@@ -555,6 +555,18 @@ func (p *Protocol) handleHookCallback(ctx context.Context, req ControlRequest) S
 			Trigger:        getString(inputData, "trigger"),
 			CompactSummary: getString(inputData, "compact_summary"),
 		}
+	case HookTypePreModelSwitch:
+		input = PreModelSwitchInput{
+			BaseHookInput:      base,
+			modelSwitchContext: getModelSwitchContext(inputData),
+			Source:             ModelSwitchSource(getString(inputData, "source")),
+		}
+	case HookTypePostModelSwitch:
+		input = PostModelSwitchInput{
+			BaseHookInput:      base,
+			modelSwitchContext: getModelSwitchContext(inputData),
+			Source:             ModelSwitchSource(getString(inputData, "source")),
+		}
 	case HookTypePostToolBatch:
 		input = PostToolBatchInput{
 			BaseHookInput: base,
@@ -1072,6 +1084,18 @@ func (p *Protocol) handleSDKHookCallback(ctx context.Context, req SDKControlRequ
 			Trigger:        getString(hookInput, "trigger"),
 			CompactSummary: getString(hookInput, "compact_summary"),
 		}
+	case "PreModelSwitch":
+		input = PreModelSwitchInput{
+			BaseHookInput:      base,
+			modelSwitchContext: getModelSwitchContext(hookInput),
+			Source:             ModelSwitchSource(getString(hookInput, "source")),
+		}
+	case "PostModelSwitch":
+		input = PostModelSwitchInput{
+			BaseHookInput:      base,
+			modelSwitchContext: getModelSwitchContext(hookInput),
+			Source:             ModelSwitchSource(getString(hookInput, "source")),
+		}
 	case "PostToolBatch":
 		input = PostToolBatchInput{
 			BaseHookInput: base,
@@ -1537,6 +1561,27 @@ func getBool(m map[string]interface{}, key string) bool {
 	return v
 }
 
+func getFloat(m map[string]interface{}, key string) float64 {
+	v, ok := m[key].(float64)
+	if !ok {
+		return 0
+	}
+	return v
+}
+
+func getModelSwitchContext(m map[string]interface{}) modelSwitchContext {
+	return modelSwitchContext{
+		FromModel:              getString(m, "from_model"),
+		ToModel:                getString(m, "to_model"),
+		RequestedModel:         getOptionalString(m, "requested_model"),
+		ContextTokens:          getInt(m, "context_tokens"),
+		PromptCacheWarm:        getBool(m, "prompt_cache_warm"),
+		CacheTTL:               CacheTTL(getString(m, "cache_ttl")),
+		EstimatedCacheWriteUSD: getFloat(m, "estimated_cache_write_usd"),
+		Pricing:                ModelPricingBasis(getString(m, "pricing")),
+	}
+}
+
 func getHookEffort(m map[string]interface{}) *HookEffort {
 	effort, ok := m["effort"].(map[string]interface{})
 	if !ok {
@@ -1741,6 +1786,20 @@ func buildHookResponse(hookType string, result HookResult) map[string]interface{
 		resp["hookSpecificOutput"] = hookSpecificOutput
 	}
 
+	if result.PermissionDecision != "" && isPermissionDecisionHook(hookType) {
+		hookSpecificOutput, _ := resp["hookSpecificOutput"].(map[string]interface{})
+		if hookSpecificOutput == nil {
+			hookSpecificOutput = map[string]interface{}{
+				"hookEventName": hookType,
+			}
+		}
+		hookSpecificOutput["permissionDecision"] = string(result.PermissionDecision)
+		if result.PermissionDecisionReason != "" {
+			hookSpecificOutput["permissionDecisionReason"] = result.PermissionDecisionReason
+		}
+		resp["hookSpecificOutput"] = hookSpecificOutput
+	}
+
 	if result.AdditionalContext != "" && isAdditionalContextHook(hookType) {
 		hookSpecificOutput, _ := resp["hookSpecificOutput"].(map[string]interface{})
 		if hookSpecificOutput == nil {
@@ -1820,6 +1879,7 @@ func isAdditionalContextHook(hookType string) bool {
 		string(HookTypePostToolUseFailure),
 		string(HookTypePostToolUse),
 		string(HookTypePreToolUse),
+		string(HookTypePostModelSwitch),
 		string(HookTypeSessionStart),
 		string(HookTypeSetup),
 		string(HookTypeStop),
@@ -1827,6 +1887,18 @@ func isAdditionalContextHook(hookType string) bool {
 		string(HookTypeSubagentStop),
 		string(HookTypeUserPromptExpansion),
 		string(HookTypeUserPromptSubmit):
+		return true
+	default:
+		return false
+	}
+}
+
+// isPermissionDecisionHook returns true for hook events whose
+// hookSpecificOutput accepts permissionDecision: PreToolUse (sdk.d.ts
+// v0.3.251 L2500) and PreModelSwitch (L2487).
+func isPermissionDecisionHook(hookType string) bool {
+	switch hookType {
+	case string(HookTypePreToolUse), string(HookTypePreModelSwitch):
 		return true
 	default:
 		return false

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -4356,3 +4356,149 @@ func TestBuildHookResponse_SuppressOriginalPrompt_UserPromptExpansion(t *testing
 		assert.Equal(t, true, hso["suppressOriginalPrompt"])
 	})
 }
+
+// TestHandleHookCallback_PreModelSwitchInput exercises the legacy hook-callback
+// builder for the PreModelSwitch event added in TS SDK v0.3.251.
+func TestHandleHookCallback_PreModelSwitchInput(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+
+	protocol.hookCallbacks["hook_pre_switch"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+		in, ok := input.(PreModelSwitchInput)
+		require.True(t, ok)
+		assert.Equal(t, "claude-sonnet-4-6", in.FromModel)
+		assert.Equal(t, "claude-opus-4-8", in.ToModel)
+		require.NotNil(t, in.RequestedModel)
+		assert.Equal(t, "opus", *in.RequestedModel)
+		assert.Equal(t, ModelSwitchSourceCommand, in.Source)
+		assert.Equal(t, 148000, in.ContextTokens)
+		assert.True(t, in.PromptCacheWarm)
+		assert.Equal(t, CacheTTL1h, in.CacheTTL)
+		assert.InDelta(t, 2.22, in.EstimatedCacheWriteUSD, 1e-9)
+		assert.Equal(t, ModelPricingCatalog, in.Pricing)
+		return HookResult{
+			Continue:                 true,
+			PermissionDecision:       HookPermissionDeny,
+			PermissionDecisionReason: "cache write over budget",
+		}, nil
+	}
+
+	resp := protocol.handleHookCallback(context.Background(), ControlRequest{
+		Type:      "control",
+		Subtype:   "hook_callback",
+		RequestID: "req_pre_switch",
+		Payload: map[string]interface{}{
+			"callback_id": "hook_pre_switch",
+			"input": map[string]interface{}{
+				"hook_event":                "PreModelSwitch",
+				"from_model":                "claude-sonnet-4-6",
+				"to_model":                  "claude-opus-4-8",
+				"requested_model":           "opus",
+				"source":                    "command",
+				"context_tokens":            float64(148000),
+				"prompt_cache_warm":         true,
+				"cache_ttl":                 "1h",
+				"estimated_cache_write_usd": 2.22,
+				"pricing":                   "catalog",
+			},
+		},
+	})
+
+	require.Equal(t, "success", resp.Response.Subtype)
+	hso, ok := resp.Response.Response["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok, "a PreModelSwitch veto must ride hookSpecificOutput")
+	assert.Equal(t, "PreModelSwitch", hso["hookEventName"])
+	assert.Equal(t, "deny", hso["permissionDecision"])
+	assert.Equal(t, "cache write over budget", hso["permissionDecisionReason"])
+}
+
+// TestHandleSDKHookCallback_PostModelSwitchInput exercises the SDK
+// hook-callback builder, which is a separate field-mapping switch from the
+// legacy one and drifts independently.
+func TestHandleSDKHookCallback_PostModelSwitchInput(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	protocol := NewProtocol(NewSubprocessTransportWithRunner(runner, opts), opts)
+
+	protocol.hookCallbacks["sdk_post_switch"] = func(ctx context.Context, input HookInput) (HookResult, error) {
+		in, ok := input.(PostModelSwitchInput)
+		require.True(t, ok)
+		assert.Equal(t, "claude-opus-4-8", in.FromModel)
+		assert.Equal(t, "claude-sonnet-4-6", in.ToModel)
+		assert.Nil(t, in.RequestedModel, "a resume names no requested model")
+		assert.Equal(t, ModelSwitchSourceResume, in.Source)
+		assert.False(t, in.PromptCacheWarm)
+		assert.Equal(t, CacheTTL5m, in.CacheTTL)
+		assert.Equal(t, ModelPricingConfigured, in.Pricing)
+		return HookResult{Continue: true, AdditionalContext: "restored after resume"}, nil
+	}
+
+	resp := protocol.handleSDKHookCallback(context.Background(), SDKControlRequest{
+		Type:      "control_request",
+		RequestID: "sdk_post_switch",
+		Request: SDKControlRequestBody{
+			Subtype:    "hook_callback",
+			CallbackID: "sdk_post_switch",
+			Input: map[string]interface{}{
+				"hook_event_name":           "PostModelSwitch",
+				"from_model":                "claude-opus-4-8",
+				"to_model":                  "claude-sonnet-4-6",
+				"source":                    "resume",
+				"context_tokens":            float64(9000),
+				"prompt_cache_warm":         false,
+				"cache_ttl":                 "5m",
+				"estimated_cache_write_usd": 0.14,
+				"pricing":                   "configured",
+			},
+		},
+	})
+
+	require.Equal(t, "success", resp.Response.Subtype)
+	hso, ok := resp.Response.Response["hookSpecificOutput"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "PostModelSwitch", hso["hookEventName"])
+	assert.Equal(t, "restored after resume", hso["additionalContext"])
+}
+
+func TestBuildHookResponse_PermissionDecision(t *testing.T) {
+	t.Run("emitted on PreToolUse", func(t *testing.T) {
+		resp := buildHookResponse("PreToolUse", HookResult{
+			Continue:           true,
+			PermissionDecision: HookPermissionDefer,
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "defer", hso["permissionDecision"])
+		_, hasReason := hso["permissionDecisionReason"]
+		assert.False(t, hasReason, "an empty reason must not reach the wire")
+	})
+
+	t.Run("dropped on unsupported hook", func(t *testing.T) {
+		resp := buildHookResponse("PostModelSwitch", HookResult{
+			Continue:           true,
+			PermissionDecision: HookPermissionDeny,
+		})
+
+		_, has := resp["hookSpecificOutput"]
+		assert.False(t, has,
+			"only pre-phase hooks gate an action; the post-phase cannot veto one")
+	})
+
+	t.Run("composes with an explicit hookSpecificOutput", func(t *testing.T) {
+		resp := buildHookResponse("PreModelSwitch", HookResult{
+			Continue:           true,
+			PermissionDecision: HookPermissionAsk,
+			HookSpecificOutput: map[string]interface{}{
+				"hookEventName": "PreModelSwitch",
+				"customKey":     "preserved",
+			},
+		})
+
+		hso, ok := resp["hookSpecificOutput"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "ask", hso["permissionDecision"])
+		assert.Equal(t, "preserved", hso["customKey"])
+	})
+}


### PR DESCRIPTION
Part of #217 (parity with TypeScript Agent SDK v0.3.251).

A model switch throws away the outgoing model's warm prompt cache, and re-warming it against the new model is not free. v0.3.251 adds a hook pair around that moment so a host can see the bill before it is incurred. Both inputs carry the same context: `from_model`, `to_model`, `requested_model`, `context_tokens`, `prompt_cache_warm`, `cache_ttl`, `estimated_cache_write_usd`, and `pricing`.

The two differ in what they can do about it. `PreModelSwitch` is vetoable on the same contract as `PreToolUse` — `deny` cancels the switch, `ask` defers to the user (a headless session refuses instead), `allow` proceeds and skips the interactive cache-miss confirm. `PostModelSwitch` is a report and takes only `additionalContext`.

They also differ in which switches they see. `Pre` admits `command | picker | sdk`; `Post` adds `auto | resume`. A switch the CLI performs on its own — a refusal fallback, restoring a model on resume — has no pre-phase to veto, so those two values only ever surface after the fact. That asymmetry is the reason the shared fields sit in an embedded `modelSwitchContext` while `Source` is spelled separately on each type.

## permissionDecision gets a typed path

There was no typed way to return `permissionDecision` before this — `PreToolUse` callers reached it through the raw `HookSpecificOutput` map. Adding a field that worked only for `PreModelSwitch` would have been the odd shape, so it lands as `HookResult.PermissionDecision` + `PermissionDecisionReason`, honored on both pre-phase hooks and silently dropped elsewhere. It composes with an explicit `HookSpecificOutput` map the way `AdditionalContext` already does: the typed value overwrites its own key and leaves the caller's others alone.

The value sets are not identical and the doc comment says so. `HookPermissionDecision` carries all four upstream constants including `defer`, but `defer` is `PreToolUse`-only — there is no deferred model switch to hand off to.

## Also here

- `CacheTTL` (`5m` / `1h`) is defined here and reused by `Settings.promptCacheTtl` / `subagentPromptCacheTtl` in a later PR of this series rather than being spelled twice.
- `ModelPricingBasis` (`configured` / `catalog` / `default`) — `configured` is what `Settings.modelPricing` produces, and it is the same distinction `ModelUsage.costBasis` reports. Both land later in the series.
- `RequestedModel` is `*string`. Upstream types it `string | null`, but nothing consumes the difference between an absent field and an explicit null here, so a plain pointer is honest and the nullable-value dance is unnecessary.

## Testing

Both `protocol.go` hook-input builders are updated — they are separate field-mapping switches, and a field added to only one is silently empty in the other. Unit tests cover each builder independently plus the three `permissionDecision` response paths (emitted, dropped on an unsupported hook, composed with an explicit map).

`TestIntegrationModelSwitchHooks` drives a real switch through `Stream.SetModel` and asserts `source == "sdk"`. It skips on CLI 2.1.222, which does not emit either event yet.

`go test ./...`, `go vet ./...`, `gofmt -l .`, and `golangci-lint run` are all clean.