### PR TITLE
mcp: add per-server tool-call timeout for SDK MCP servers

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2763,3 +2763,81 @@ func TestIntegrationModelSwitchHooks(t *testing.T) {
 			"a post-switch report must name two different models")
 	}
 }
+
+// TestIntegrationSdkMcpServerTimeout registers an in-process MCP server with a
+// short per-server timeout and a tool that sleeps well past it, then asserts
+// the CLI cuts the call off rather than waiting for the tool. This exercises
+// sdkMcpServerConfigs on the initialize request, added in TS SDK v0.3.251.
+func TestIntegrationSdkMcpServerTimeout(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	const (
+		toolTimeoutMs = 2000
+		toolSleep     = 60 * time.Second
+	)
+
+	type NoArgs struct{}
+
+	timeout := toolTimeoutMs
+	server := CreateMcpServer(McpServerOptions{
+		Name:    "slowpoke",
+		Timeout: &timeout,
+		Tools: []ToolRegistrar{
+			Tool("stall", "Stall for a long time",
+				func(ctx context.Context, args NoArgs) (ToolResult, error) {
+					select {
+					case <-time.After(toolSleep):
+						return TextResult("finished"), nil
+					case <-ctx.Done():
+						return TextResult("cancelled"), nil
+					}
+				},
+			),
+		},
+	})
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You have one tool, mcp__slowpoke__stall. When asked "+
+			"to run it you MUST call it. Do not explain, do not refuse, do "+
+			"not ask questions. Call it exactly once, then stop."),
+		WithMcpServer("slowpoke", server),
+		WithPermissionMode(PermissionModeBypassAll),
+		WithAllowDangerouslySkipPermissions(true),
+		WithMaxTurns(2),
+	)
+
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	var calledTool bool
+	for msg := range client.Query(ctx, "Call the mcp__slowpoke__stall tool now.") {
+		if m, ok := msg.(AssistantMessage); ok {
+			for _, block := range m.Message.Content {
+				if block.Type == "tool_use" {
+					calledTool = true
+				}
+			}
+		}
+		if _, ok := msg.(ResultMessage); ok {
+			break
+		}
+	}
+	elapsed := time.Since(start)
+
+	if !calledTool {
+		t.Skip("not triggerable from CLI: the model declined to call the tool")
+	}
+
+	// The tool itself never returns inside the window. Finishing the turn at
+	// all means the timeout fired; the generous bound leaves room for model
+	// latency around the call without admitting a full tool completion.
+	assert.Less(t, elapsed, toolSleep,
+		"a per-server timeout of %dms must cut the call off well before the "+
+			"tool's own %s sleep", toolTimeoutMs, toolSleep)
+}

--- a/mcp.go
+++ b/mcp.go
@@ -17,6 +17,7 @@ type McpServer struct {
 	name         string
 	version      string
 	instructions string
+	timeout      *int
 	tools        map[string]*toolEntry
 }
 
@@ -67,6 +68,17 @@ type McpServerOptions struct {
 	// the way through. Empty string omits the field entirely from the
 	// MCP initialize response.
 	Instructions string
+
+	// Timeout is the per-server tool-call timeout in milliseconds. Overrides
+	// the MCP_TOOL_TIMEOUT environment variable for this server. Hard
+	// wall-clock limit per call; progress notifications do not extend it.
+	// Values below 1000ms are ignored and fall through to MCP_TOOL_TIMEOUT
+	// or the default, as are non-positive and non-integer values.
+	//
+	// It is read when the server is registered. Changing it on a server the
+	// CLI already knows about has no effect until the server is removed and
+	// re-added (sdk.d.ts v0.3.251 L1093).
+	Timeout *int
 }
 
 // CreateMcpServer creates a new in-process MCP server.
@@ -91,6 +103,7 @@ func CreateMcpServer(opts McpServerOptions) *McpServer {
 		name:         opts.Name,
 		version:      version,
 		instructions: opts.Instructions,
+		timeout:      opts.Timeout,
 		tools:        make(map[string]*toolEntry),
 	}
 
@@ -354,6 +367,12 @@ func (s *McpServer) Version() string {
 // Empty string means no instructions block is exposed.
 func (s *McpServer) Instructions() string {
 	return s.instructions
+}
+
+// Timeout returns the per-server tool-call timeout in milliseconds, or nil
+// when this server takes the CLI default. See McpServerOptions.Timeout.
+func (s *McpServer) Timeout() *int {
+	return s.timeout
 }
 
 // ToolNames returns the names of all registered tools.

--- a/messages.go
+++ b/messages.go
@@ -597,12 +597,23 @@ func (d *ThinkingDisplayOverride) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// SDKMCPServerConfig carries per-server settings for an in-process MCP server
+// named in SDKControlRequestBody.SDKMCPServers. The name list stays a bare
+// []string; this map sits beside it and is keyed by the same names
+// (sdk.d.ts v0.3.251 L3845).
+type SDKMCPServerConfig struct {
+	// Timeout is the per-server tool-call timeout in milliseconds. See
+	// McpServerOptions.Timeout.
+	Timeout *int `json:"timeout,omitempty"`
+}
+
 // SDKControlRequestBody contains the actual request data.
 // Note: This is a union type - different fields are used for different subtypes.
 type SDKControlRequestBody struct {
 	Subtype                string                              `json:"subtype"`                          // Request subtype
 	Hooks                  map[string][]SDKHookCallbackMatcher `json:"hooks,omitempty"`                  // For initialize
 	SDKMCPServers          []string                            `json:"sdkMcpServers,omitempty"`          // For initialize
+	SDKMCPServerConfigs    map[string]SDKMCPServerConfig       `json:"sdkMcpServerConfigs,omitempty"`    // For initialize
 	MCPServers             map[string]MCPServerConfig          `json:"mcpServers,omitempty"`             // For initialize
 	JSONSchema             map[string]interface{}              `json:"jsonSchema,omitempty"`             // For initialize
 	SystemPrompt           string                              `json:"systemPrompt,omitempty"`           // For initialize

--- a/protocol.go
+++ b/protocol.go
@@ -100,12 +100,26 @@ func (p *Protocol) doInitialize(ctx context.Context) error {
 		}
 	}
 
-	// Build list of SDK MCP server names.
+	// Build list of SDK MCP server names, plus per-server config for the
+	// subset that carries any. The config map stays absent when no server
+	// sets a timeout — the CLI reads a missing key and an empty object the
+	// same way, and sending {} is noise.
 	var sdkMcpServers []string
+	var sdkMcpServerConfigs map[string]SDKMCPServerConfig
 	if len(p.sdkMcpServers) > 0 {
 		sdkMcpServers = make([]string, 0, len(p.sdkMcpServers))
-		for name := range p.sdkMcpServers {
+		for name, server := range p.sdkMcpServers {
 			sdkMcpServers = append(sdkMcpServers, name)
+
+			if server == nil || server.Timeout() == nil {
+				continue
+			}
+			if sdkMcpServerConfigs == nil {
+				sdkMcpServerConfigs = make(map[string]SDKMCPServerConfig)
+			}
+			sdkMcpServerConfigs[name] = SDKMCPServerConfig{
+				Timeout: server.Timeout(),
+			}
 		}
 	}
 
@@ -132,6 +146,7 @@ func (p *Protocol) doInitialize(ctx context.Context) error {
 			Subtype:                "initialize",
 			Hooks:                  hooks,
 			SDKMCPServers:          sdkMcpServers,
+			SDKMCPServerConfigs:    sdkMcpServerConfigs,
 			MCPServers:             p.options.MCPServers,
 			SystemPrompt:           p.options.SystemPrompt,
 			PlanModeInstructions:   p.options.PlanModeInstructions,

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -316,6 +316,36 @@ func TestProtocolInitializeOptions(t *testing.T) {
 			configure:  func(opts *Options) {},
 			unexpected: []string{"agents"},
 		},
+		{
+			name: "sdk mcp server timeout wired through",
+			configure: func(opts *Options) {
+				timeout := 45000
+				WithMcpServer("timed", CreateMcpServer(McpServerOptions{
+					Name:    "timed",
+					Timeout: &timeout,
+				}))(opts)
+			},
+			expected: map[string]interface{}{
+				"sdkMcpServers": []interface{}{"timed"},
+				"sdkMcpServerConfigs": map[string]interface{}{
+					"timed": map[string]interface{}{
+						"timeout": float64(45000),
+					},
+				},
+			},
+		},
+		{
+			name: "sdk mcp server without timeout omits configs",
+			configure: func(opts *Options) {
+				WithMcpServer("plain", CreateMcpServer(McpServerOptions{
+					Name: "plain",
+				}))(opts)
+			},
+			expected: map[string]interface{}{
+				"sdkMcpServers": []interface{}{"plain"},
+			},
+			unexpected: []string{"sdkMcpServerConfigs"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Part of #217 (parity with TypeScript Agent SDK v0.3.251).

Remote MCP servers have carried a per-server `timeout` since v0.3.150 — `MCPServerConfig.Timeout` already models it. The in-process ones had no equivalent and fell through to `MCP_TOOL_TIMEOUT` or the CLI default. v0.3.251 closes the gap with three coupled additions: `CreateSdkMcpServerOptions.timeout` (L539), `McpSdkServerConfig.timeout` (L1095), and `SDKControlInitializeRequest.sdkMcpServerConfigs` (L3847).

## How it reaches the CLI

Not through the name list. `sdkMcpServers` stays a bare `[]string`, and the new `sdkMcpServerConfigs` map sits beside it keyed by the same names. Reading `sdk.mjs` confirms the CLI builds that map from a `flatMap` over the registered servers, keeping only those with a defined timeout, and drops the key entirely when the result is empty. This mirrors that: the map is allocated lazily on the first server that sets a timeout and stays `nil` otherwise. A missing key and `{}` mean the same thing to the CLI, so sending `{}` is just noise.

## Units, and two constraints worth stating

Milliseconds — stated outright at L1093, not inferred from the bundle. The doc comment also carries the two behaviors that would otherwise read as bugs:

- Values below 1000ms are silently ignored and fall through to `MCP_TOOL_TIMEOUT`. So is anything non-positive or non-integer; `sdk.mjs` validates with exactly that predicate.
- The value is read when the server is registered. Changing it on a server the CLI already knows about has no effect until the server is removed and re-added — `sdk.mjs` logs a warning on precisely that case.

`McpServer.Timeout()` is exported alongside the existing `Instructions()` accessor, since the protocol layer needs to read it back off a registered server.

## Testing

Two cases in the existing `TestProtocolInitializeOptions` table: one server with a timeout produces both `sdkMcpServers` and `sdkMcpServerConfigs`, one without produces the name list and no config key at all.

`TestIntegrationSdkMcpServerTimeout` is a real behavioral test rather than an argv assertion. It registers a tool that sleeps for a minute behind a two-second per-server timeout and asserts the turn completes anyway. That can only happen if the field reached the CLI and was honored — it passes in ~19s against CLI 2.1.222.

`go test ./...`, `go vet ./...`, `gofmt -l .`, and `golangci-lint run` are all clean.