### PR TITLE
messages: record pricing provenance on ModelUsage

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -2841,3 +2841,70 @@ func TestIntegrationSdkMcpServerTimeout(t *testing.T) {
 		"a per-server timeout of %dms must cut the call off well before the "+
 			"tool's own %s sleep", toolTimeoutMs, toolSleep)
 }
+
+// TestIntegrationModelUsageCostBasis asserts the pricing-provenance fields on
+// ModelUsage — costBasis is new in TS SDK v0.3.251, canonicalModel and provider
+// predate it and were never modeled here.
+func TestIntegrationModelUsageCostBasis(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithMaxTurns(1),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var result *ResultMessage
+	for msg := range client.Query(ctx, "Say OK.") {
+		if m, ok := msg.(ResultMessage); ok {
+			result = &m
+			break
+		}
+	}
+	require.NotNil(t, result, "expected a result message")
+	require.NotEmpty(t, result.ModelUsage, "expected per-model usage")
+
+	var sawBasis, sawCanonical bool
+	for model, usage := range result.ModelUsage {
+		t.Logf("%s: canonical=%q provider=%q basis=%q cost=%v",
+			model, usage.CanonicalModel, usage.Provider,
+			usage.CostBasis, usage.CostUSD)
+
+		if usage.CanonicalModel != "" {
+			sawCanonical = true
+			assert.NotEmpty(t, usage.Provider,
+				"a priced entry names the provider that served it")
+		}
+
+		if usage.CostBasis == "" {
+			// Absent until this process has priced a request for the
+			// model, and on CLIs that predate the field.
+			continue
+		}
+		sawBasis = true
+		assert.Contains(t,
+			[]ModelCostBasis{
+				ModelCostBasisList,
+				ModelCostBasisManaged,
+				ModelCostBasisUnknown,
+			},
+			usage.CostBasis,
+			"costBasis is a closed set upstream",
+		)
+	}
+
+	assert.True(t, sawCanonical,
+		"canonicalModel/provider have been on the wire since v0.3.220 and "+
+			"were simply never decoded here")
+
+	if !sawBasis {
+		t.Skip("not triggerable from CLI: this CLI build does not report " +
+			"costBasis on modelUsage")
+	}
+}

--- a/messages.go
+++ b/messages.go
@@ -1884,7 +1884,48 @@ type ModelUsage struct {
 	CostUSD                  float64 `json:"costUSD"`                  // Cost in USD
 	ContextWindow            int     `json:"contextWindow"`            // Context window size
 	MaxOutputTokens          int     `json:"maxOutputTokens"`          // Max output tokens for this model
+
+	// CanonicalModel is the model id the pricing lookup used, which can
+	// differ from the raw model string this entry is keyed by — a
+	// provider-specific id or an alias resolves to it (sdk.d.ts v0.3.251
+	// L1318). Empty when this process has not yet priced a request for the
+	// model.
+	CanonicalModel string `json:"canonicalModel,omitempty"`
+
+	// Provider is the API provider that served the model: "firstParty",
+	// "bedrock", "vertex", "foundry", "anthropicAws", "mantle", or
+	// "gateway" (sdk.d.ts v0.3.251 L1322).
+	Provider string `json:"provider,omitempty"`
+
+	// CostBasis says which price table produced CostUSD, so a host
+	// aggregating spend does not sum figures that are not the same kind of
+	// number. ModelCostBasisUnknown in particular means CostUSD is a guess at
+	// the default model's rate rather than a price for this model.
+	//
+	// Like CanonicalModel it is overwritten per request, so differencing the
+	// cumulative CostUSD across turns yields the basis for that turn. Empty
+	// until this process has priced a request for the model — right after a
+	// --resume, say — and on CLIs that predate the field. Treat empty as
+	// ModelCostBasisList (sdk.d.ts v0.3.251 L1326).
+	CostBasis ModelCostBasis `json:"costBasis,omitempty"`
 }
+
+// ModelCostBasis identifies the price table behind a ModelUsage.CostUSD.
+type ModelCostBasis string
+
+const (
+	// ModelCostBasisList is Claude Code's built-in list pricing.
+	ModelCostBasisList ModelCostBasis = "list"
+
+	// ModelCostBasisManaged is the organization's managed-settings rates or
+	// multiplier — Settings.ModelPricing.
+	ModelCostBasisManaged ModelCostBasis = "managed"
+
+	// ModelCostBasisUnknown means neither applied: no pricing row and no
+	// built-in price matched the model id, so CostUSD carries the default
+	// model's rate as a stand-in.
+	ModelCostBasisUnknown ModelCostBasis = "unknown"
+)
 
 // NonNullableUsage is like Usage but all fields are guaranteed non-zero.
 type NonNullableUsage struct {

--- a/messages_test.go
+++ b/messages_test.go
@@ -4837,3 +4837,66 @@ func TestParseMessageResultTerminalReasonV0207(t *testing.T) {
 	require.NotNil(t, resultMsg.TerminalReason)
 	assert.Equal(t, TerminalReasonBudgetExhausted, *resultMsg.TerminalReason)
 }
+
+func TestModelUsagePricingProvenanceRoundTrip(t *testing.T) {
+	usage := ModelUsage{
+		InputTokens:              10,
+		OutputTokens:             20,
+		CacheReadInputTokens:     3,
+		CacheCreationInputTokens: 4,
+		WebSearchRequests:        1,
+		CostUSD:                  0.25,
+		ContextWindow:            200000,
+		MaxOutputTokens:          32000,
+		CanonicalModel:           "claude-opus-4-8",
+		Provider:                 "bedrock",
+		CostBasis:                ModelCostBasisManaged,
+	}
+
+	data, err := json.Marshal(usage)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"inputTokens": 10,
+		"outputTokens": 20,
+		"cacheReadInputTokens": 3,
+		"cacheCreationInputTokens": 4,
+		"webSearchRequests": 1,
+		"costUSD": 0.25,
+		"contextWindow": 200000,
+		"maxOutputTokens": 32000,
+		"canonicalModel": "claude-opus-4-8",
+		"provider": "bedrock",
+		"costBasis": "managed"
+	}`, string(data))
+
+	var decoded ModelUsage
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, usage, decoded)
+}
+
+// A CLI that predates the field, or one that has not yet priced a request for
+// the model, sends neither key. Both decode empty, and callers are told to
+// read that as list pricing.
+func TestModelUsagePricingProvenanceAbsent(t *testing.T) {
+	var decoded ModelUsage
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"inputTokens": 1,
+		"outputTokens": 2,
+		"cacheReadInputTokens": 0,
+		"cacheCreationInputTokens": 0,
+		"webSearchRequests": 0,
+		"costUSD": 0.01,
+		"contextWindow": 200000,
+		"maxOutputTokens": 32000
+	}`), &decoded))
+
+	assert.Empty(t, decoded.CanonicalModel)
+	assert.Empty(t, decoded.Provider)
+	assert.Equal(t, ModelCostBasis(""), decoded.CostBasis)
+
+	data, err := json.Marshal(decoded)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "costBasis")
+	assert.NotContains(t, string(data), "canonicalModel")
+	assert.NotContains(t, string(data), "provider")
+}


### PR DESCRIPTION
Part of #217 (parity with TypeScript Agent SDK v0.3.251).

`ModelUsage.costUSD` has never said where its number came from. v0.3.251 adds `costBasis` (sdk.d.ts L1326) with three values:

- `list` — Claude Code's built-in list prices
- `managed` — the organization's managed-settings `modelPricing` rates or multiplier
- `unknown` — neither matched, so `costUSD` is the *default model's* rate standing in for a model nothing knew how to price

That last one is the interesting case. It is not a rounding concern; it means the figure is about a different model than the one it is filed under. And the `list` / `managed` split matters to anything that aggregates: summing across both produces a number that is not any organization's actual spend, and today a consumer has no way to notice it is doing that.

## canonicalModel and provider go in at the same time

Both have been on the wire since v0.3.220. That cycle added them to `ModelInfo`, which is a different type — `ModelUsage` was missed and has been silently dropping them since. The integration test confirms CLI 2.1.222 is already sending both:

```
claude-sonnet-4-5-20250929: canonical="claude-sonnet-4-5" provider="firstParty" basis="" cost=0.0278643
```

Same struct, same decode, and a diff-driven catchup will never surface them again on its own. Folding them in here rather than opening a separate PR for two fields nobody would otherwise find.

## Absence is not zero

All three are empty until this process has priced a request for the model — a `--resume` can defer that indefinitely — and on CLIs that predate them. Upstream says to read an empty `costBasis` as `list`, and the doc comment says so too rather than leaving callers to guess. `costBasis` is also overwritten per request rather than accumulated, so differencing cumulative `costUSD` across turns gives you that turn's basis; that is noted as well, since it is the non-obvious half.

## Testing

Round-trip with all three set, plus a decode of a payload carrying none of them that asserts the keys stay off the wire on re-marshal.

`TestIntegrationModelUsageCostBasis` runs live and passes. It hard-asserts `canonicalModel` and `provider` — they are on the wire today, so a silent regression there should fail rather than skip — and skips only the `costBasis` half, which CLI 2.1.222 does not emit yet.

`go test ./...`, `go vet ./...`, `gofmt -l .`, and `golangci-lint run` are all clean.