### PR TITLE
protocol: carry default_to_no on permission asks

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -3139,3 +3139,75 @@ func TestIntegrationAmbientTaskMarker(t *testing.T) {
 	assert.False(t, userWorkSet,
 		"a subagent the user asked for is not a housekeeping task")
 }
+
+// TestIntegrationPermissionRequestContext provokes a real permission ask and
+// records the context the CLI attached. default_to_no is new in TS SDK
+// v0.3.251; the siblings are asserted because the SDK-format path used to
+// deliver an empty context regardless of what the CLI sent.
+func TestIntegrationPermissionRequestContext(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	// An in-process SDK MCP server is auto-allowed, so the ask has to come
+	// from a stdio server under a strict config — the same setup
+	// TestIntegrationPermissionCallback uses.
+	mcpServerPath := filepath.Join(t.TempDir(), "example-mcp-server")
+	buildCmd := exec.Command("go", "build", "-o", mcpServerPath,
+		"./cmd/example-mcp-server")
+	buildCmd.Dir = "."
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build MCP server: %v\n%s", err, out)
+	}
+
+	var (
+		mu       sync.Mutex
+		captured []PermissionContext
+	)
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("When asked to add numbers you MUST use the "+
+			"add_numbers tool. Do not calculate manually."),
+		WithMCPServers(map[string]MCPServerConfig{
+			"example": {Type: "stdio", Command: mcpServerPath},
+		}),
+		WithStrictMCPConfig(true),
+		WithPermissionMode(PermissionModeDefault),
+		WithCanUseTool(func(
+			ctx context.Context, req ToolPermissionRequest,
+		) PermissionResult {
+			mu.Lock()
+			captured = append(captured, req.Context)
+			mu.Unlock()
+			return PermissionAllow{}
+		}),
+		WithMaxTurns(5),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	for msg := range client.Query(ctx, "Use the add_numbers tool to add 7 and 5.") {
+		if _, ok := msg.(ResultMessage); ok {
+			break
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, captured, "expected at least one permission ask")
+
+	for _, c := range captured {
+		t.Logf("ask: tool_use_id=%q agent_id=%q requires_interaction=%v "+
+			"suppress_always_allow=%v default_to_no=%v",
+			c.ToolUseID, c.AgentID, c.RequiresUserInteraction,
+			c.SuppressAlwaysAllowRule, c.DefaultToNo)
+
+		// Whichever control path served the ask, tool_use_id is always on
+		// the wire — an empty one means the context never got populated.
+		assert.NotEmpty(t, c.ToolUseID,
+			"a permission ask must arrive carrying its tool_use_id")
+	}
+}

--- a/messages.go
+++ b/messages.go
@@ -675,31 +675,39 @@ type SDKControlRequestBody struct {
 	Input                  map[string]interface{}              `json:"input,omitempty"`                  // For can_use_tool/hook_callback
 	ToolUseID              string                              `json:"tool_use_id,omitempty"`            // For can_use_tool/hooks/background_tasks
 	AgentID                string                              `json:"agent_id,omitempty"`               // For can_use_tool
-	CallbackID             string                              `json:"callback_id,omitempty"`            // For hook_callback
-	Mode                   string                              `json:"mode,omitempty"`                   // For set_permission_mode
-	Model                  string                              `json:"model,omitempty"`                  // For set_model
-	MaxThinkingTokens      *int                                `json:"max_thinking_tokens,omitempty"`    // For set_max_thinking_tokens
-	ThinkingDisplay        *ThinkingDisplayOverride            `json:"thinking_display,omitempty"`       // For set_max_thinking_tokens
-	Directory              string                              `json:"directory,omitempty"`              // For register_repo_root
-	ReloadClaudeMD         *bool                               `json:"reload_claude_md,omitempty"`       // For register_repo_root
-	ReloadPlugins          *bool                               `json:"reload_plugins,omitempty"`         // For register_repo_root
-	ReloadSkills           *bool                               `json:"reload_skills,omitempty"`          // For register_repo_root
-	UserMessageID          string                              `json:"user_message_id,omitempty"`        // For rewind_files
-	DryRun                 *bool                               `json:"dry_run,omitempty"`                // For rewind_files
-	CancelQueued           *bool                               `json:"cancel_queued,omitempty"`          // For interrupt (interrupt_cancel_queued_v1)
-	Path                   string                              `json:"path,omitempty"`                   // For read_file/seed_read_state
-	MaxBytes               *int                                `json:"max_bytes,omitempty"`              // For read_file
-	Encoding               string                              `json:"encoding,omitempty"`               // For read_file ("utf-8"|"base64")
-	MTime                  *int64                              `json:"mtime,omitempty"`                  // For seed_read_state
-	Settings               *map[string]interface{}             `json:"settings,omitempty"`               // For apply_flag_settings
-	Description            string                              `json:"description,omitempty"`            // For submit_feedback
-	Surface                string                              `json:"surface,omitempty"`                // For submit_feedback
-	TaskID                 string                              `json:"task_id,omitempty"`                // For stop_task
-	ServerName             string                              `json:"server_name,omitempty"`            // For mcp_message (snake_case)
-	MCPServerName          string                              `json:"serverName,omitempty"`             // For mcp_reconnect/mcp_toggle/mcp_set_servers (camelCase)
-	Enabled                *bool                               `json:"enabled,omitempty"`                // For mcp_toggle (pointer so explicit false serializes)
-	Servers                *map[string]MCPServerConfig         `json:"servers,omitempty"`                // For mcp_set_servers (pointer so nil/empty round-trips as {})
-	Message                map[string]interface{}              `json:"message,omitempty"`                // For mcp_message (JSONRPC)
+
+	// Inbound can_use_tool context. These describe how the ask reached the
+	// host and constrain how it may be rendered; see PermissionContext.
+	RequiresUserInteraction bool            `json:"requires_user_interaction,omitempty"`
+	SuppressAlwaysAllowRule bool            `json:"suppress_always_allow_rule,omitempty"`
+	DefaultToNo             bool            `json:"default_to_no,omitempty"`
+	MatchedAskRule          *MatchedAskRule `json:"matched_ask_rule,omitempty"`
+
+	CallbackID        string                      `json:"callback_id,omitempty"`         // For hook_callback
+	Mode              string                      `json:"mode,omitempty"`                // For set_permission_mode
+	Model             string                      `json:"model,omitempty"`               // For set_model
+	MaxThinkingTokens *int                        `json:"max_thinking_tokens,omitempty"` // For set_max_thinking_tokens
+	ThinkingDisplay   *ThinkingDisplayOverride    `json:"thinking_display,omitempty"`    // For set_max_thinking_tokens
+	Directory         string                      `json:"directory,omitempty"`           // For register_repo_root
+	ReloadClaudeMD    *bool                       `json:"reload_claude_md,omitempty"`    // For register_repo_root
+	ReloadPlugins     *bool                       `json:"reload_plugins,omitempty"`      // For register_repo_root
+	ReloadSkills      *bool                       `json:"reload_skills,omitempty"`       // For register_repo_root
+	UserMessageID     string                      `json:"user_message_id,omitempty"`     // For rewind_files
+	DryRun            *bool                       `json:"dry_run,omitempty"`             // For rewind_files
+	CancelQueued      *bool                       `json:"cancel_queued,omitempty"`       // For interrupt (interrupt_cancel_queued_v1)
+	Path              string                      `json:"path,omitempty"`                // For read_file/seed_read_state
+	MaxBytes          *int                        `json:"max_bytes,omitempty"`           // For read_file
+	Encoding          string                      `json:"encoding,omitempty"`            // For read_file ("utf-8"|"base64")
+	MTime             *int64                      `json:"mtime,omitempty"`               // For seed_read_state
+	Settings          *map[string]interface{}     `json:"settings,omitempty"`            // For apply_flag_settings
+	Description       string                      `json:"description,omitempty"`         // For submit_feedback
+	Surface           string                      `json:"surface,omitempty"`             // For submit_feedback
+	TaskID            string                      `json:"task_id,omitempty"`             // For stop_task
+	ServerName        string                      `json:"server_name,omitempty"`         // For mcp_message (snake_case)
+	MCPServerName     string                      `json:"serverName,omitempty"`          // For mcp_reconnect/mcp_toggle/mcp_set_servers (camelCase)
+	Enabled           *bool                       `json:"enabled,omitempty"`             // For mcp_toggle (pointer so explicit false serializes)
+	Servers           *map[string]MCPServerConfig `json:"servers,omitempty"`             // For mcp_set_servers (pointer so nil/empty round-trips as {})
+	Message           map[string]interface{}      `json:"message,omitempty"`             // For mcp_message (JSONRPC)
 }
 
 // SDKHookCallbackMatcher defines hook callback matching configuration.

--- a/options.go
+++ b/options.go
@@ -1889,6 +1889,11 @@ type PermissionContext struct {
 	// rendering approve options should omit any persistent-rule row when set
 	// (sdk.d.ts v0.3.215).
 	SuppressAlwaysAllowRule bool
+	// DefaultToNo is true when the ask must not be approvable by a single
+	// stray keystroke: a terminal-style prompt opens on its decline option
+	// and takes no digit shortcut. Hosts rendering approve options must not
+	// pre-select approve (sdk.d.ts v0.3.251 L4079).
+	DefaultToNo bool
 	// MatchedAskRule is set when a user-configured ask rule forced this prompt
 	// while the ask still carries the tool's own decision reason. Nil when no
 	// such rule applied. See MatchedAskRule (sdk.d.ts v0.3.215).

--- a/protocol.go
+++ b/protocol.go
@@ -292,6 +292,7 @@ func (p *Protocol) handlePermissionRequest(ctx context.Context, req ControlReque
 	agentID, _ := req.Payload["agent_id"].(string)
 	requiresUserInteraction, _ := req.Payload["requires_user_interaction"].(bool)
 	suppressAlwaysAllowRule, _ := req.Payload["suppress_always_allow_rule"].(bool)
+	defaultToNo, _ := req.Payload["default_to_no"].(bool)
 	matchedAskRule := parseMatchedAskRule(req.Payload["matched_ask_rule"])
 
 	// Build permission request.
@@ -303,6 +304,7 @@ func (p *Protocol) handlePermissionRequest(ctx context.Context, req ControlReque
 			AgentID:                 agentID,
 			RequiresUserInteraction: requiresUserInteraction,
 			SuppressAlwaysAllowRule: suppressAlwaysAllowRule,
+			DefaultToNo:             defaultToNo,
 			MatchedAskRule:          matchedAskRule,
 		},
 	}
@@ -937,11 +939,21 @@ func (p *Protocol) handleSDKPermissionRequest(ctx context.Context, req SDKContro
 	toolName := req.Request.ToolName
 	arguments := req.Request.Input
 
-	// Build permission request.
+	// Build permission request. The context fields were only ever populated
+	// on the legacy control_request path; this is the shape the TS SDK
+	// documents as SDKControlPermissionRequest, so a host on this path was
+	// getting an empty context.
 	permReq := ToolPermissionRequest{
 		ToolName:  toolName,
 		Arguments: marshalJSON(arguments),
-		Context:   PermissionContext{},
+		Context: PermissionContext{
+			ToolUseID:               req.Request.ToolUseID,
+			AgentID:                 req.Request.AgentID,
+			RequiresUserInteraction: req.Request.RequiresUserInteraction,
+			SuppressAlwaysAllowRule: req.Request.SuppressAlwaysAllowRule,
+			DefaultToNo:             req.Request.DefaultToNo,
+			MatchedAskRule:          req.Request.MatchedAskRule,
+		},
 	}
 
 	// Check permission callback.

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -4555,3 +4555,94 @@ func TestBuildHookResponse_PermissionDecision(t *testing.T) {
 		assert.Equal(t, "preserved", hso["customKey"])
 	})
 }
+
+// TestProtocolPermissionDefaultToNo covers default_to_no on both permission
+// paths. The two are separate field-mapping sites and drift independently.
+func TestProtocolPermissionDefaultToNo(t *testing.T) {
+	capture := func(into *PermissionContext) *Options {
+		opts := NewOptions()
+		opts.CanUseTool = func(
+			ctx context.Context, req ToolPermissionRequest,
+		) PermissionResult {
+			*into = req.Context
+			return PermissionAllow{}
+		}
+		return opts
+	}
+
+	t.Run("legacy control_request path", func(t *testing.T) {
+		var captured PermissionContext
+		protocol := NewProtocol(nil, capture(&captured))
+
+		resp := protocol.handlePermissionRequest(context.Background(), ControlRequest{
+			Type:      "control",
+			Subtype:   "can_use_tool",
+			RequestID: "req_1",
+			Payload: map[string]interface{}{
+				"tool_name":     "Bash",
+				"tool_use_id":   "tool_1",
+				"input":         map[string]interface{}{},
+				"default_to_no": true,
+			},
+		})
+
+		require.Equal(t, "success", resp.Response.Subtype)
+		assert.True(t, captured.DefaultToNo)
+	})
+
+	// This path built an empty PermissionContext before v0.3.251, so the
+	// siblings are asserted alongside default_to_no rather than assumed.
+	t.Run("sdk control_request path", func(t *testing.T) {
+		var captured PermissionContext
+		protocol := NewProtocol(nil, capture(&captured))
+
+		resp := protocol.handleSDKPermissionRequest(context.Background(), SDKControlRequest{
+			Type:      "control_request",
+			RequestID: "sdk_req_1",
+			Request: SDKControlRequestBody{
+				Subtype:                 "can_use_tool",
+				ToolName:                "Bash",
+				ToolUseID:               "tool_1",
+				AgentID:                 "agent_1",
+				Input:                   map[string]interface{}{},
+				DefaultToNo:             true,
+				RequiresUserInteraction: true,
+				SuppressAlwaysAllowRule: true,
+				MatchedAskRule: &MatchedAskRule{
+					Source:      "settings",
+					ToolName:    "Bash",
+					RuleContent: "Bash(rm:*)",
+				},
+			},
+		})
+
+		require.Equal(t, "success", resp.Response.Subtype)
+		assert.True(t, captured.DefaultToNo)
+		assert.True(t, captured.RequiresUserInteraction)
+		assert.True(t, captured.SuppressAlwaysAllowRule)
+		assert.Equal(t, "tool_1", captured.ToolUseID)
+		assert.Equal(t, "agent_1", captured.AgentID)
+		require.NotNil(t, captured.MatchedAskRule)
+		assert.Equal(t, "Bash(rm:*)", captured.MatchedAskRule.RuleContent)
+	})
+
+	t.Run("absent leaves the safe-by-default false", func(t *testing.T) {
+		var captured PermissionContext
+		protocol := NewProtocol(nil, capture(&captured))
+
+		resp := protocol.handleSDKPermissionRequest(context.Background(), SDKControlRequest{
+			Type:      "control_request",
+			RequestID: "sdk_req_2",
+			Request: SDKControlRequestBody{
+				Subtype:   "can_use_tool",
+				ToolName:  "Read",
+				ToolUseID: "tool_2",
+				Input:     map[string]interface{}{},
+			},
+		})
+
+		require.Equal(t, "success", resp.Response.Subtype)
+		assert.False(t, captured.DefaultToNo)
+		assert.Nil(t, captured.MatchedAskRule)
+	})
+}


### PR DESCRIPTION
Part of #217 (parity with TypeScript Agent SDK v0.3.251).

`SDKControlPermissionRequest.default_to_no` (sdk.d.ts L4079). Some asks must not be approvable by a stray keystroke — the CLI's own prompt opens on the decline option and takes no digit shortcut. This tells SDK hosts the same thing, so they stop pre-selecting approve on an ask the CLI itself treats as decline-by-default.

## Both permission paths, and a gap found on one of them

`can_use_tool` reaches the SDK two ways: as a legacy `ControlRequest` with a `Payload` map, and as the SDK-format `SDKControlRequest` that `SDKControlPermissionRequest` actually documents. They are separate field-mapping sites that drift independently — the same shape as the two hook-input builders.

Adding the field to both turned up something worth flagging: **`handleSDKPermissionRequest` was building `PermissionContext{}` and discarding everything else.** A host served over that path saw no `tool_use_id`, no `agent_id`, no `requires_user_interaction`, no `suppress_always_allow_rule`, no `matched_ask_rule` — every context field added since v0.3.201, silently absent. Only the legacy path was ever populated.

Adding `default_to_no` to an empty struct would have shipped one more field nobody receives, so the context is populated properly here. That means four inbound fields added to `SDKControlRequestBody`, which had carried only `tool_name`, `input`, `tool_use_id` and `agent_id`.

Scope call: this is a bug fix, not a refactor, and it is the smallest change that makes the field this PR is about actually observable. Calling it out rather than burying it in the diff.

## Zero value is the safe one

Plain `bool` throughout. An ask with nothing declared renders as an ordinary ask, which is the correct default for every one of these fields — `false` never causes a host to under-protect. No pointer needed.

## Testing

`TestProtocolPermissionDefaultToNo` covers both paths separately. The SDK-path case asserts the siblings alongside `default_to_no` rather than assuming them, since that context was empty until this change.

`TestIntegrationPermissionRequestContext` provokes a real ask and passes live:

```
ask: tool_use_id="toolu_01N73djTzmtERAFKYbb7u1pm" agent_id="" requires_interaction=false suppress_always_allow=false default_to_no=false
```

Worth noting how it gets there: an in-process SDK MCP server is auto-allowed and never produces an ask at all — the first two drafts skipped for that reason. It takes a stdio server under `WithStrictMCPConfig(true)`, matching `TestIntegrationPermissionCallback`. The assertion is on `tool_use_id` being non-empty, which is the field that is always on the wire, so an unpopulated context fails rather than skips.

`go test ./...`, `go vet ./...` (both build tags), `gofmt -l .`, and `golangci-lint run` are all clean.