### PR TITLE
options: add v0.3.251 Settings parity fields

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -3320,3 +3320,52 @@ func TestIntegrationSessionStartResumeCost(t *testing.T) {
 			"resume-cost fields on the SessionStart hook input")
 	}
 }
+
+// TestIntegrationSettingsParityV0_3_251 pushes the v0.3.251 Settings additions
+// through the managed tier and completes a turn. An unrecognized member of a
+// managed-settings union stalls the handshake outright rather than being
+// ignored, so a completed turn is real evidence the CLI understood the shape —
+// including the reshaped spinnerTipsOverride block.
+func TestIntegrationSettingsParityV0_3_251(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	desktopRetention := 14
+	syncPlugins := false
+	excludeDefault := false
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithManagedSettings(Settings{
+			DesktopSessionCleanupPeriodDays: &desktopRetention,
+			SyncClaudeAiPlugins:             &syncPlugins,
+			ManagedSourcesBehavior:          "merge",
+			PromptCacheTTL:                  CacheTTL1h,
+			SubagentPromptCacheTTL:          CacheTTL5m,
+			SpinnerTipsOverride: &SettingsSpinnerTipsOverride{
+				ExcludeDefault: &excludeDefault,
+				Tips:           []string{"run make lint before pushing"},
+				Label:          "Ops",
+			},
+		}),
+		WithMaxTurns(1),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var gotResult bool
+	for msg := range client.Query(ctx, "Say OK.") {
+		if m, ok := msg.(ResultMessage); ok {
+			assert.False(t, m.IsError,
+				"the v0.3.251 settings must not fail the session: %s", m.Result)
+			gotResult = true
+			break
+		}
+	}
+	assert.True(t, gotResult,
+		"a stalled managed-settings handshake shows up as no result at all")
+}

--- a/options.go
+++ b/options.go
@@ -340,6 +340,19 @@ type Settings struct {
 	FileSuggestion    *SettingsFileSuggestion `json:"fileSuggestion,omitempty"`
 	RespectGitignore  *bool                   `json:"respectGitignore,omitempty"`
 	CleanupPeriodDays *int                    `json:"cleanupPeriodDays,omitempty"`
+	// DesktopSessionCleanupPeriodDays bounds retention for transcripts a
+	// desktop-host surface (Claude Desktop, Cowork) created or last wrote,
+	// which are otherwise exempt from the CleanupPeriodDays sweep. Zero — the
+	// default — means no ceiling, and is allowed here where it is not on
+	// CleanupPeriodDays because this setting never disables writes, only
+	// bounds an exemption from deletion.
+	//
+	// It is a hard cap, so it also bounds an active archive grace: a release
+	// marker's grace window never keeps files past the ceiling. Setting it at
+	// or below CleanupPeriodDays effectively removes the exemption, and the
+	// effective retention is whichever period is longer. Ignored when
+	// CleanupPeriodDays is managed by org policy (sdk.d.ts v0.3.251 L5600).
+	DesktopSessionCleanupPeriodDays *int `json:"desktopSessionCleanupPeriodDays,omitempty"`
 	// SyncClaudeAiSkills turns off syncing of the skills enabled on
 	// claude.ai. Only false is honored: the feature is enabled server-side per
 	// account, so setting true does not turn it on early. Not read from
@@ -356,7 +369,14 @@ type Settings struct {
 	// downloads stop and synced skills are blocked and hidden for that
 	// workspace or invocation only, with nothing moved (sdk.d.ts v0.3.241
 	// L5392).
-	SyncClaudeAiSkills         *bool                            `json:"syncClaudeAiSkills,omitempty"`
+	SyncClaudeAiSkills *bool `json:"syncClaudeAiSkills,omitempty"`
+	// SyncClaudeAiPlugins is the plugin twin of SyncClaudeAiSkills, with the
+	// same only-false-is-honored rule and the same split between destructive
+	// user/managed scope and reversible workspace scope. While on, synced
+	// plugins load like ones installed locally, except that a locally
+	// installed plugin of the same name wins, and they re-sync at each launch
+	// rather than on a timer (sdk.d.ts v0.3.251 L5607).
+	SyncClaudeAiPlugins        *bool                            `json:"syncClaudeAiPlugins,omitempty"`
 	SkillListingMaxDescChars   *int                             `json:"skillListingMaxDescChars,omitempty"`
 	SkillListingBudgetFraction *float64                         `json:"skillListingBudgetFraction,omitempty"`
 	WSLInheritsWindowsSettings *bool                            `json:"wslInheritsWindowsSettings,omitempty"`
@@ -463,8 +483,22 @@ type Settings struct {
 	SpinnerTipsOverride        *SettingsSpinnerTipsOverride `json:"spinnerTipsOverride,omitempty"`
 	SyntaxHighlightingDisabled *bool                        `json:"syntaxHighlightingDisabled,omitempty"`
 	TerminalTitleFromRename    *bool                        `json:"terminalTitleFromRename,omitempty"`
-	AlwaysThinkingEnabled      *bool                        `json:"alwaysThinkingEnabled,omitempty"`
-	EffortLevel                EffortLevel                  `json:"effortLevel,omitempty"`
+	// PromptCacheTTL is the prompt-cache lifetime for the main conversation —
+	// interactive, -p and SDK turns, plus the helpers running inline with
+	// them. Empty means automatic: one hour on a Claude subscription within
+	// its usage limits, five minutes on an API key, Bedrock, Vertex or
+	// Foundry. A one-hour cache is billed at a higher write rate in exchange
+	// for staying warm across longer breaks. CLAUDE_CODE_PROMPT_CACHE_TTL
+	// takes precedence over this (sdk.d.ts v0.3.251 L7679).
+	PromptCacheTTL CacheTTL `json:"promptCacheTtl,omitempty"`
+	// SubagentPromptCacheTTL is the same for everything outside the main
+	// conversation: subagents, workflows, background and helper requests.
+	// Empty means automatic, which is five minutes unless
+	// ENABLE_PROMPT_CACHING_1H=1. CLAUDE_CODE_SUBAGENT_PROMPT_CACHE_TTL takes
+	// precedence (sdk.d.ts v0.3.251 L7683).
+	SubagentPromptCacheTTL CacheTTL    `json:"subagentPromptCacheTtl,omitempty"`
+	AlwaysThinkingEnabled  *bool       `json:"alwaysThinkingEnabled,omitempty"`
+	EffortLevel            EffortLevel `json:"effortLevel,omitempty"`
 	// ModelSettings holds per-model settings keyed by canonical model name —
 	// the per-model twin of EffortLevel above. Note the ceiling differs: a
 	// persisted per-model effort tops out at "xhigh", where the init message's
@@ -592,6 +626,25 @@ type Settings struct {
 	AllowAllClaudeAiMcps *bool `json:"allowAllClaudeAiMcps,omitempty"`
 	// ParentSettingsBehavior controls whether the SDK parent tier layers under the admin tier. Mirrors sdk.d.ts v0.3.150 L5019.
 	ParentSettingsBehavior string `json:"parentSettingsBehavior,omitempty"`
+	// ManagedSourcesBehavior controls how the managed settings sources
+	// compose. "first-wins" (the default) uses the highest-priority source
+	// present — server-managed, then MDM, then managed-settings.json — as the
+	// managed tier alone. "merge" deep-merges every present source at that
+	// fixed precedence: scalars take the highest source's value and arrays
+	// union.
+	//
+	// Three groups opt out of the union. The restriction allowlists
+	// (fallbackModel, allowedMcpServers, availableModels,
+	// strictKnownMarketplaces, allowedChannelPlugins) are owned whole by the
+	// highest source that sets one, and the auth pins (forceLoginOrgUUID,
+	// forceLoginMethod, forceLoginGatewayUrl) come from the highest source
+	// only — merging either would let a lower source widen a restriction.
+	//
+	// Honored only from the highest-priority source present. Enable it only
+	// when every lower source is admin-controlled, since under "merge" they
+	// start contributing entries such as permissions.allow. HKCU and
+	// --managed-settings never take part (sdk.d.ts v0.3.251 L7367).
+	ManagedSourcesBehavior string `json:"managedSourcesBehavior,omitempty"`
 	// IsolatePeerMachines requires approval before SendMessage can reach peer sessions on other machines. Mirrors sdk.d.ts v0.3.150 L5407.
 	IsolatePeerMachines *bool `json:"isolatePeerMachines,omitempty"`
 	// DaemonColdStart controls daemon behavior when no background service is running. Mirrors sdk.d.ts v0.3.150 L5411.
@@ -987,9 +1040,28 @@ type SettingsSpinnerVerbs struct {
 	Verbs []string `json:"verbs"`
 }
 
+// SettingsSpinnerTipsOverride adds an organization's own tips to the spinner
+// tip rotation.
 type SettingsSpinnerTipsOverride struct {
-	ExcludeDefault *bool    `json:"excludeDefault,omitempty"`
-	Tips           []string `json:"tips"`
+	// ExcludeDefault shows only these tips instead of mixing them into the
+	// built-in rotation. Defaults to false.
+	ExcludeDefault *bool `json:"excludeDefault,omitempty"`
+
+	// Tips are the tip strings. Upstream widened the element to also accept
+	// an object ({id, text, cooldownSessions?, priority?}); that form is not
+	// modeled here yet, since widening this field's type is a breaking
+	// change and Settings only flows outward from this SDK.
+	Tips []string `json:"tips,omitempty"`
+
+	// TipsFile is an absolute or ~/-relative path to a JSON file holding an
+	// array of tips in the same shapes as Tips. Honored from user, --settings
+	// and on-disk managed settings only, and read once per CLI process —
+	// edits need a restart (sdk.d.ts v0.3.251 L7640).
+	TipsFile string `json:"tipsFile,omitempty"`
+
+	// Label is the prefix shown before these tips in the spinner. Defaults to
+	// "Tip".
+	Label string `json:"label,omitempty"`
 }
 
 type SettingsSandbox struct {

--- a/options_test.go
+++ b/options_test.go
@@ -2189,3 +2189,84 @@ func TestSettingsMarketplaceSourceURLConstant(t *testing.T) {
 		SettingsMarketplaceSourceKind("url"),
 		SettingsMarketplaceSourceURL)
 }
+
+func TestSettingsParityV0_3_251(t *testing.T) {
+	desktopRetention := 14
+	syncPlugins := false
+	excludeDefault := true
+
+	settings := Settings{
+		DesktopSessionCleanupPeriodDays: &desktopRetention,
+		SyncClaudeAiPlugins:             &syncPlugins,
+		ManagedSourcesBehavior:          "merge",
+		PromptCacheTTL:                  CacheTTL1h,
+		SubagentPromptCacheTTL:          CacheTTL5m,
+		SpinnerTipsOverride: &SettingsSpinnerTipsOverride{
+			ExcludeDefault: &excludeDefault,
+			Tips:           []string{"run make lint before pushing"},
+			TipsFile:       "~/.claude/tips.json",
+			Label:          "Ops",
+		},
+	}
+
+	data, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.Equal(t, float64(14), got["desktopSessionCleanupPeriodDays"])
+	assert.Equal(t, false, got["syncClaudeAiPlugins"])
+	assert.Equal(t, "merge", got["managedSourcesBehavior"])
+	assert.Equal(t, "1h", got["promptCacheTtl"])
+	assert.Equal(t, "5m", got["subagentPromptCacheTtl"])
+
+	override, ok := got["spinnerTipsOverride"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "~/.claude/tips.json", override["tipsFile"])
+	assert.Equal(t, "Ops", override["label"])
+
+	var back Settings
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, settings, back)
+}
+
+func TestSettingsParityV0_3_251OmitEmpty(t *testing.T) {
+	data, err := json.Marshal(Settings{})
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	for _, key := range []string{
+		"desktopSessionCleanupPeriodDays",
+		"syncClaudeAiPlugins",
+		"managedSourcesBehavior",
+		"promptCacheTtl",
+		"subagentPromptCacheTtl",
+	} {
+		assert.NotContains(t, got, key)
+	}
+}
+
+// Zero is a meaningful value for the desktop ceiling — it means "no ceiling",
+// unlike cleanupPeriodDays where a zero would disable transcript writes. The
+// pointer is what keeps it distinguishable from unset.
+func TestSettingsDesktopCleanupZeroSurvives(t *testing.T) {
+	noCeiling := 0
+	data, err := json.Marshal(Settings{
+		DesktopSessionCleanupPeriodDays: &noCeiling,
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"desktopSessionCleanupPeriodDays": 0}`, string(data))
+}
+
+// tips went required to optional upstream. An override that only points at a
+// tipsFile must not emit an empty tips array the CLI would read as "no tips".
+func TestSettingsSpinnerTipsOverrideFileOnly(t *testing.T) {
+	data, err := json.Marshal(SettingsSpinnerTipsOverride{
+		TipsFile: "~/.claude/tips.json",
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"tipsFile": "~/.claude/tips.json"}`, string(data))
+}


### PR DESCRIPTION
Part of #217 (parity with TypeScript Agent SDK v0.3.251).

Five scalars plus one reshape:

| field | sdk.d.ts |
|---|---|
| `desktopSessionCleanupPeriodDays` | L5600 |
| `syncClaudeAiPlugins` | L5607 |
| `managedSourcesBehavior` | L7367 |
| `promptCacheTtl` | L7679 |
| `subagentPromptCacheTtl` | L7683 |
| `spinnerTipsOverride` reshape | L7633 |

## CacheTTL is reused, not redeclared

The two TTLs are the same `'5m' | '1h'` set as `cache_ttl` on the model-switch hook inputs from #218. That type is defined once and used in both places. Two independent declarations of the same closed set is how they drift.

## Zero means something here

`desktopSessionCleanupPeriodDays` is `*int`. Zero is the documented **default** and means "no ceiling" — and upstream is explicit that zero is allowed here precisely because it is not allowed on `cleanupPeriodDays`, where it would disable transcript writes. This setting only bounds an *exemption from deletion*; it never stops writes. Collapsing zero into unset would erase the default. `TestSettingsDesktopCleanupZeroSurvives` pins it.

`managedSourcesBehavior` gets the long comment because the merge rules have a security shape: under `"merge"` every present managed source contributes, but the restriction allowlists and the auth pins deliberately do *not* union — the highest source owns them whole. Without that, a lower source could widen a restriction an admin set. Upstream also warns to enable it only when every lower source is admin-controlled, since they start contributing `permissions.allow` entries.

## The spinnerTipsOverride reshape

```
- tips: string[]
+ tips?: (string | { [k: string]: unknown })[]
+ tipsFile?: string
+ label?: string
```

Taken non-breaking. `Tips` keeps `[]string` and gains `omitempty` — required to optional is not a breaking change for callers, and it fixes a real bug: an override that only points at a `tipsFile` was emitting `"tips": []`, which the CLI reads as "no tips". `TestSettingsSpinnerTipsOverrideFileOnly` covers that.

The union element is **not** modeled. Widening an exported field's type is breaking, and `Settings` only flows outward from this SDK, so no decode path can encounter the object form today. Deferred to #227, which also flags the question that should settle it: whether the resolved-settings transport can ever hand us a `Settings` to decode, since that would make it a correctness bug rather than a missing feature.

## Testing

Round-trip and omit-empty pairs matching the existing `TestSettingsParityV0_3_241*` shape, plus the two edge cases above.

The live test was written **after** probing the bare CLI directly:

```
claude --managed-settings '{"desktopSessionCleanupPeriodDays":14,...,"spinnerTipsOverride":{...}}' -p 'Say OK.'
```

That order matters here. An unrecognized member of a managed-settings union stalls the handshake rather than being ignored, which presents as a hang and costs the full timeout — so probing first is cheaper than debugging a stuck integration test. All six keys pass. `TestIntegrationSettingsParityV0_3_251` then pushes them through `WithManagedSettings` and completes a turn, which is the assertable form of "the CLI understood the shape".

`go test ./...`, `go vet ./...` (both build tags), `gofmt -l .`, and `golangci-lint run` are all clean.