### PR TITLE
options: curate the model picker and price it at contracted rates

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -3369,3 +3369,63 @@ func TestIntegrationSettingsParityV0_3_251(t *testing.T) {
 	assert.True(t, gotResult,
 		"a stalled managed-settings handshake shows up as no result at all")
 }
+
+// TestIntegrationSettingsModelPickerPricing pushes a curated picker and a
+// contracted price table through the managed tier and completes a turn. Both
+// blocks are nested objects, and an unrecognized member of a managed-settings
+// union stalls the handshake outright rather than being ignored, so a completed
+// turn is evidence the CLI understood the shapes — including behavesAs, which
+// v0.3.263 added inside the picker rows.
+func TestIntegrationSettingsModelPickerPricing(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	replace := false
+	multiplier := 0.85
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithManagedSettings(Settings{
+			ModelPicker: &SettingsModelPicker{
+				Options: []SettingsModelPickerOption{{
+					Model:       "opus",
+					Label:       "Deep work",
+					Description: "Architecture and hard bugs",
+					BehavesAs:   "claude-opus-4-8",
+				}},
+				ReplaceBuiltInOptions: &replace,
+			},
+			ModelPricing: &SettingsModelPricing{
+				Multiplier: &multiplier,
+				Overrides: map[string]SettingsModelPricingRates{
+					"claude-sonnet-4-6": {
+						Input:      3,
+						Output:     15,
+						CacheRead:  0.3,
+						CacheWrite: 3.75,
+					},
+				},
+			},
+		}),
+		WithMaxTurns(1),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var gotResult bool
+	for msg := range client.Query(ctx, "Say OK.") {
+		if m, ok := msg.(ResultMessage); ok {
+			assert.False(t, m.IsError,
+				"a curated picker and price table must not fail the session: %s",
+				m.Result)
+			gotResult = true
+			break
+		}
+	}
+	assert.True(t, gotResult,
+		"a stalled managed-settings handshake shows up as no result at all")
+}

--- a/options.go
+++ b/options.go
@@ -376,19 +376,38 @@ type Settings struct {
 	// plugins load like ones installed locally, except that a locally
 	// installed plugin of the same name wins, and they re-sync at each launch
 	// rather than on a timer (sdk.d.ts v0.3.251 L5607).
-	SyncClaudeAiPlugins        *bool                            `json:"syncClaudeAiPlugins,omitempty"`
-	SkillListingMaxDescChars   *int                             `json:"skillListingMaxDescChars,omitempty"`
-	SkillListingBudgetFraction *float64                         `json:"skillListingBudgetFraction,omitempty"`
-	WSLInheritsWindowsSettings *bool                            `json:"wslInheritsWindowsSettings,omitempty"`
-	Env                        map[string]string                `json:"env,omitempty"`
-	Attribution                *SettingsAttribution             `json:"attribution,omitempty"`
-	IncludeCoAuthoredBy        *bool                            `json:"includeCoAuthoredBy,omitempty"`
-	IncludeGitInstructions     *bool                            `json:"includeGitInstructions,omitempty"`
-	Permissions                *SettingsPermissions             `json:"permissions,omitempty"`
-	Model                      string                           `json:"model,omitempty"`
-	FallbackModel              []string                         `json:"fallbackModel,omitempty"`
-	AvailableModels            []string                         `json:"availableModels,omitempty"`
-	ModelOverrides             map[string]string                `json:"modelOverrides,omitempty"`
+	SyncClaudeAiPlugins        *bool                `json:"syncClaudeAiPlugins,omitempty"`
+	SkillListingMaxDescChars   *int                 `json:"skillListingMaxDescChars,omitempty"`
+	SkillListingBudgetFraction *float64             `json:"skillListingBudgetFraction,omitempty"`
+	WSLInheritsWindowsSettings *bool                `json:"wslInheritsWindowsSettings,omitempty"`
+	Env                        map[string]string    `json:"env,omitempty"`
+	Attribution                *SettingsAttribution `json:"attribution,omitempty"`
+	IncludeCoAuthoredBy        *bool                `json:"includeCoAuthoredBy,omitempty"`
+	IncludeGitInstructions     *bool                `json:"includeGitInstructions,omitempty"`
+	Permissions                *SettingsPermissions `json:"permissions,omitempty"`
+	Model                      string               `json:"model,omitempty"`
+	FallbackModel              []string             `json:"fallbackModel,omitempty"`
+	AvailableModels            []string             `json:"availableModels,omitempty"`
+	ModelOverrides             map[string]string    `json:"modelOverrides,omitempty"`
+	// ModelPicker curates the /model picker with an ordered list of rows,
+	// independent of the built-in lineup and of Claude Code releases.
+	// AvailableModels still filters these rows. Honored from managed,
+	// --settings/SDK and user settings only — never from a project checkout —
+	// and the highest-precedence source that defines it wins outright, with no
+	// merging across sources (sdk.d.ts v0.3.263 L5921).
+	ModelPicker *SettingsModelPicker `json:"modelPicker,omitempty"`
+	// ModelPricing prices usage at the organization's contracted rates rather
+	// than list price, moving every spend figure Claude Code reports — /cost,
+	// the status line, ResultMessage.TotalCostUSD, --max-budget-usd and the
+	// OpenTelemetry cost metric. They stay USD estimates, not an invoice, and
+	// the per-Mtok labels in /model stay at list price.
+	//
+	// This is what drives ModelUsage.CostBasis to ModelCostBasisManaged, and
+	// the model-switch hooks' pricing field to "configured". Honored only from
+	// managed settings, or — when no managed source sets it — from a host
+	// application that manages the model provider; ignored in user, project,
+	// local and --settings sources (sdk.d.ts v0.3.263 L5951).
+	ModelPricing               *SettingsModelPricing            `json:"modelPricing,omitempty"`
 	EnableAllProjectMCPServers *bool                            `json:"enableAllProjectMcpServers,omitempty"`
 	EnabledMCPJSONServers      []string                         `json:"enabledMcpjsonServers,omitempty"`
 	DisabledMCPJSONServers     []string                         `json:"disabledMcpjsonServers,omitempty"`
@@ -875,6 +894,72 @@ type SettingsModel struct {
 	// EffortLevel is the persisted effort level for this model. Unlike the
 	// init message's applied effort, "max" is not a member here.
 	EffortLevel EffortLevel `json:"effortLevel,omitempty"`
+}
+
+// SettingsModelPicker curates the rows shown in the /model picker.
+type SettingsModelPicker struct {
+	// Options are the picker rows, in the order they are shown.
+	Options []SettingsModelPickerOption `json:"options"`
+
+	// ReplaceBuiltInOptions shows only the Default row and Options, hiding the
+	// built-in lineup, gateway-discovered models and
+	// ANTHROPIC_CUSTOM_MODEL_OPTION. When false or unset, Options are appended
+	// after the built-in lineup.
+	ReplaceBuiltInOptions *bool `json:"replaceBuiltInOptions,omitempty"`
+}
+
+// SettingsModelPickerOption is one row of a curated /model picker.
+type SettingsModelPickerOption struct {
+	// Model is the model to select, taken verbatim — an alias ("opus"), an
+	// Anthropic model ID, or a provider-format ID for Vertex, Bedrock or a
+	// gateway. Accepts the same values as --model.
+	Model string `json:"model"`
+
+	// Label is the row title. Defaults to the model name.
+	Label string `json:"label,omitempty"`
+
+	// Description is the row subtitle. Defaults to a generic description.
+	Description string `json:"description,omitempty"`
+
+	// BehavesAs names a model this Claude Code version does know (e.g.
+	// "claude-opus-4-8") whose client-side handling — prompt profile,
+	// capability and effort defaults — should apply to a model it does not.
+	// It changes neither the row's label nor the model ID sent. Without it a
+	// row for an unknown model is not offered at all until Claude Code is
+	// updated, which is what makes this the difference between a new model
+	// being selectable today and only after a release (sdk.d.ts v0.3.263
+	// L5941).
+	BehavesAs string `json:"behavesAs,omitempty"`
+}
+
+// SettingsModelPricing prices usage at an organization's contracted rates.
+type SettingsModelPricing struct {
+	// Multiplier scales every computed cost, overridden or not — 0.85 charges
+	// 85% of the price. Must fall in (0, 1].
+	Multiplier *float64 `json:"multiplier,omitempty"`
+
+	// Overrides maps a model ID to its rates. A key Claude Code itself uses
+	// for a built-in model — the plain ID such as "claude-sonnet-4-6", or its
+	// first-party, Bedrock, Vertex or Foundry ID — covers every dated and
+	// provider form of that model. Any other key matches that one model ID
+	// case-insensitively, and such an exact match beats a built-in row. An
+	// invalid row is reported and skipped without disturbing the rest.
+	Overrides map[string]SettingsModelPricingRates `json:"overrides,omitempty"`
+}
+
+// SettingsModelPricingRates is one model's USD-per-million-token rates.
+//
+// All four are required within a row and each must fall in [0, 10000], so they
+// are plain values rather than pointers: a partially filled row is invalid
+// upstream and would be skipped whole.
+type SettingsModelPricingRates struct {
+	Input     float64 `json:"input"`
+	Output    float64 `json:"output"`
+	CacheRead float64 `json:"cacheRead"`
+
+	// CacheWrite prices both 5-minute and 1-hour cache writes, so a Settings
+	// author cannot price Settings.PromptCacheTTL's two tiers apart.
+	CacheWrite float64 `json:"cacheWrite"`
 }
 
 // SettingsSpellcheck configures prompt-input spell checking. It does nothing

--- a/options_test.go
+++ b/options_test.go
@@ -2270,3 +2270,125 @@ func TestSettingsSpinnerTipsOverrideFileOnly(t *testing.T) {
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"tipsFile": "~/.claude/tips.json"}`, string(data))
 }
+
+func TestSettingsModelPickerRoundTrip(t *testing.T) {
+	replace := true
+
+	settings := Settings{
+		ModelPicker: &SettingsModelPicker{
+			Options: []SettingsModelPickerOption{
+				{
+					Model:       "opus",
+					Label:       "Deep work",
+					Description: "Architecture and hard bugs",
+				},
+				{
+					Model:     "vendor/some-unreleased-model",
+					Label:     "Preview",
+					BehavesAs: "claude-opus-4-8",
+				},
+			},
+			ReplaceBuiltInOptions: &replace,
+		},
+	}
+
+	data, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	picker, ok := got["modelPicker"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, picker["replaceBuiltInOptions"])
+
+	rows, ok := picker["options"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, rows, 2)
+
+	// The first row carries no behavesAs, so it must not appear at all: an
+	// empty string there would name a model the CLI cannot resolve.
+	first, ok := rows[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.NotContains(t, first, "behavesAs")
+
+	second, ok := rows[1].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "claude-opus-4-8", second["behavesAs"])
+	assert.NotContains(t, second, "description")
+
+	var back Settings
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, settings, back)
+}
+
+// options is required upstream, so a picker with no rows still has to emit the
+// key rather than dropping it and reading as "no picker configured".
+func TestSettingsModelPickerEmptyOptionsEmitted(t *testing.T) {
+	data, err := json.Marshal(SettingsModelPicker{})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"options": null}`, string(data))
+}
+
+func TestSettingsModelPricingRoundTrip(t *testing.T) {
+	multiplier := 0.85
+
+	settings := Settings{
+		ModelPricing: &SettingsModelPricing{
+			Multiplier: &multiplier,
+			Overrides: map[string]SettingsModelPricingRates{
+				"claude-sonnet-4-6": {
+					Input:      3,
+					Output:     15,
+					CacheRead:  0.3,
+					CacheWrite: 3.75,
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	pricing, ok := got["modelPricing"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, 0.85, pricing["multiplier"])
+
+	overrides, ok := pricing["overrides"].(map[string]interface{})
+	require.True(t, ok)
+	row, ok := overrides["claude-sonnet-4-6"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, float64(3), row["input"])
+	assert.Equal(t, float64(15), row["output"])
+	assert.Equal(t, 0.3, row["cacheRead"])
+	assert.Equal(t, 3.75, row["cacheWrite"])
+
+	var back Settings
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, settings, back)
+}
+
+// A free model prices at zero across the board. Because the four rates are
+// required upstream, they must survive the round trip rather than being elided
+// as Go zero values and leaving the CLI to read the row as incomplete.
+func TestSettingsModelPricingZeroRatesSurvive(t *testing.T) {
+	data, err := json.Marshal(SettingsModelPricingRates{})
+	require.NoError(t, err)
+	assert.JSONEq(t,
+		`{"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0}`,
+		string(data))
+}
+
+func TestSettingsModelPickerPricingOmitEmpty(t *testing.T) {
+	data, err := json.Marshal(Settings{})
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	assert.NotContains(t, got, "modelPicker")
+	assert.NotContains(t, got, "modelPricing")
+}


### PR DESCRIPTION
Closes the last open surface from the v0.3.251 catchup. See `memory/catchup-v0.3.251/PLAN.md` §"PR-11".

Two nested `Settings` blocks that were split out of the scalar parity PR (#228) because they need their own named structs and their own tests.

- **`modelPicker`** (`sdk.d.ts` v0.3.263 L5921) — an ordered list of `/model` rows an administrator writes, independent of the built-in lineup. `availableModels` still filters the rows, and the highest-precedence source that defines the block wins outright with no merging.
- **`behavesAs`** (L5941) — new in v0.3.263, so the picker rows carry it from the start rather than needing a follow-up. It lends a known model's prompt profile, capability and effort defaults to a model this CLI version does not know. Without it such a row is not offered at all until Claude Code is updated, which makes this the difference between a new model being selectable today and only after a release.
- **`modelPricing`** (L5951) — contracted rates and/or a multiplier, moving every spend figure the CLI reports. This is the setting that makes `ModelUsage.CostBasis` reach `ModelCostBasisManaged` (#220) and the model-switch hooks' `pricing` field reach `configured` (#218); both landed with comments pointing here, and neither value was reachable until now.

**Shape notes:**
- `SettingsModelPricingRates` uses plain `float64`, not pointers. All four rates are required within a row upstream and an invalid row is skipped whole, so eliding a zero would turn a legitimately free model into an incomplete row. `TestSettingsModelPricingZeroRatesSurvive` pins that.
- `SettingsModelPicker.Options` has no `omitempty` for the same reason — `options` is required upstream, and dropping the key would read as "no picker configured" rather than "a picker with no rows".
- `Multiplier` and `ReplaceBuiltInOptions` are pointers: both have meaningful zero values (`0` is an out-of-range multiplier worth sending so the CLI reports it; `false` is the documented default worth stating explicitly).

**Tests:** round-trip and `omitempty` coverage for both blocks, plus the two zero-value pins above. `TestIntegrationSettingsModelPickerPricing` pushes both through the managed tier against the live CLI — an unrecognized member of a managed-settings union stalls the handshake outright rather than being ignored, so a completed turn is real evidence the CLI parsed the nested shapes. Verified passing locally (5.7s).