### PR TITLE
transport: actually pass configured plugins to the CLI

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -3429,3 +3429,95 @@ func TestIntegrationSettingsModelPickerPricing(t *testing.T) {
 	assert.True(t, gotResult,
 		"a stalled managed-settings handshake shows up as no result at all")
 }
+
+// writeProbePlugin lays down the smallest plugin directory the CLI will load
+// and returns its path.
+func writeProbePlugin(t *testing.T, name string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	manifestDir := filepath.Join(dir, ".claude-plugin")
+	require.NoError(t, os.MkdirAll(manifestDir, 0o755))
+
+	manifest := fmt.Sprintf(
+		`{"name":%q,"description":"integration probe","version":"0.0.1"}`,
+		name)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(manifestDir, "plugin.json"), []byte(manifest), 0o644))
+
+	return dir
+}
+
+// TestIntegrationPluginDirArgv asserts that a configured plugin actually
+// reaches the CLI. Options.Plugins was inert before this — the transport built
+// no --plugin-dir flag for it — so asserting the session merely starts would
+// pass just as well against the broken behavior. The init message's plugin
+// list is the evidence that the CLI loaded it.
+func TestIntegrationPluginDirArgv(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	const pluginName = "daedalus-probe"
+	pluginDir := writeProbePlugin(t, pluginName)
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithPlugins([]PluginConfig{{
+			Type: PluginTypeLocal,
+			Path: pluginDir,
+		}}),
+		WithMaxTurns(1),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var loaded []string
+	var gotResult bool
+	for msg := range client.Query(ctx, "Say OK.") {
+		switch m := msg.(type) {
+		case SystemMessage:
+			for _, p := range m.Plugins {
+				loaded = append(loaded, p.Name)
+			}
+		case ResultMessage:
+			assert.False(t, m.IsError, "session failed: %s", m.Result)
+			gotResult = true
+		}
+		if gotResult {
+			break
+		}
+	}
+
+	require.True(t, gotResult, "no result message")
+	assert.Contains(t, loaded, pluginName,
+		"the configured plugin never reached the CLI; init listed %v", loaded)
+}
+
+// A plugin the SDK cannot express as a flag must fail the connect outright
+// rather than starting a session that silently lacks it.
+func TestIntegrationPluginDirRejectsUnsupportedType(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	opts := append(isolatedClientOptions(t),
+		WithPlugins([]PluginConfig{{
+			Type: "remote",
+			Path: writeProbePlugin(t, "daedalus-probe"),
+		}}),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err = client.Connect(ctx)
+	require.Error(t, err, "the connect must fail rather than start a session "+
+		"that silently lacks the plugin")
+	assert.Contains(t, err.Error(), "unsupported plugin type")
+}

--- a/options.go
+++ b/options.go
@@ -1458,9 +1458,13 @@ type SandboxIgnoreViolations struct {
 	Network []string
 }
 
+// PluginTypeLocal is the only supported PluginConfig.Type: a plugin loaded
+// from a directory on this machine.
+const PluginTypeLocal = "local"
+
 // PluginConfig configures a plugin to load.
 type PluginConfig struct {
-	// Type must be "local" (only local plugins currently supported).
+	// Type must be PluginTypeLocal (only local plugins currently supported).
 	Type string `json:"type"`
 	// Path is the absolute or relative path to the plugin directory.
 	Path string `json:"path"`

--- a/transport.go
+++ b/transport.go
@@ -362,6 +362,25 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		args = append(args, "--add-dir", dir)
 	}
 
+	// Load each configured plugin. A plugin that skips MCP discovery selects a
+	// different flag rather than passing an argument, so the two cannot be
+	// merged. An unsupported type is refused rather than skipped: dropping a
+	// plugin the caller asked for, silently, is how this option came to do
+	// nothing at all.
+	for _, plugin := range t.options.Plugins {
+		if plugin.Type != PluginTypeLocal {
+			return fmt.Errorf(
+				"unsupported plugin type %q for path %q: only %q is supported",
+				plugin.Type, plugin.Path, PluginTypeLocal)
+		}
+
+		flag := "--plugin-dir"
+		if plugin.SkipMcpDiscovery {
+			flag = "--plugin-dir-no-mcp"
+		}
+		args = append(args, flag, plugin.Path)
+	}
+
 	// Add include-partial-messages flag for streaming deltas.
 	if t.options.IncludePartialMessages {
 		args = append(args, "--include-partial-messages")

--- a/transport_test.go
+++ b/transport_test.go
@@ -2203,3 +2203,112 @@ func TestSubprocessTransportPermissionModeArguments(t *testing.T) {
 		})
 	}
 }
+
+// TestSubprocessTransportPlugins tests that each configured plugin reaches the
+// CLI, and that skipping MCP discovery selects the no-mcp flag rather than
+// passing an argument.
+func TestSubprocessTransportPlugins(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	opts := &Options{
+		Plugins: []PluginConfig{
+			{Type: PluginTypeLocal, Path: "/plugins/lint"},
+			{
+				Type:             PluginTypeLocal,
+				Path:             "/plugins/deploy",
+				SkipMcpDiscovery: true,
+			},
+		},
+	}
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	ctx := context.Background()
+	err := transport.Connect(ctx)
+	require.NoError(t, err)
+	defer transport.Close()
+
+	assert.True(t, runner.started)
+	assert.Subset(t, runner.StartArgs,
+		[]string{"--plugin-dir", "/plugins/lint"})
+	assert.Subset(t, runner.StartArgs,
+		[]string{"--plugin-dir-no-mcp", "/plugins/deploy"})
+
+	// The two flags are alternatives; a no-mcp plugin must not also produce a
+	// plain --plugin-dir for the same path.
+	for i, arg := range runner.StartArgs {
+		if arg == "--plugin-dir" && i+1 < len(runner.StartArgs) {
+			assert.NotEqual(t, "/plugins/deploy", runner.StartArgs[i+1],
+				"no-mcp plugin leaked a plain --plugin-dir: %v",
+				runner.StartArgs)
+		}
+	}
+}
+
+// Plugin order is meaningful — a later plugin can shadow an earlier one — so
+// the flags must come out in the order they were configured.
+func TestSubprocessTransportPluginsPreserveOrder(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	opts := &Options{
+		Plugins: []PluginConfig{
+			{Type: PluginTypeLocal, Path: "/plugins/a"},
+			{Type: PluginTypeLocal, Path: "/plugins/b"},
+			{Type: PluginTypeLocal, Path: "/plugins/c"},
+		},
+	}
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	ctx := context.Background()
+	require.NoError(t, transport.Connect(ctx))
+	defer transport.Close()
+
+	var paths []string
+	for i, arg := range runner.StartArgs {
+		if arg == "--plugin-dir" && i+1 < len(runner.StartArgs) {
+			paths = append(paths, runner.StartArgs[i+1])
+		}
+	}
+	assert.Equal(t, []string{"/plugins/a", "/plugins/b", "/plugins/c"}, paths)
+}
+
+// An unsupported type fails the connect rather than loading nothing quietly.
+func TestSubprocessTransportPluginsRejectUnsupportedType(t *testing.T) {
+	for _, pluginType := range []string{"", "remote", "url"} {
+		t.Run(pluginType, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+
+			opts := &Options{
+				Plugins: []PluginConfig{
+					{Type: pluginType, Path: "/plugins/x"},
+				},
+			}
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+
+			err := transport.Connect(context.Background())
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unsupported plugin type")
+			assert.False(t, runner.started,
+				"the CLI must not start with a plugin it cannot load")
+		})
+	}
+}
+
+// TestSubprocessTransportPluginsEmpty tests that no plugin flag is present when
+// none are configured.
+func TestSubprocessTransportPluginsEmpty(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	transport := NewSubprocessTransportWithRunner(runner, &Options{})
+
+	ctx := context.Background()
+	require.NoError(t, transport.Connect(ctx))
+	defer transport.Close()
+
+	for _, arg := range runner.StartArgs {
+		assert.NotEqual(t, "--plugin-dir", arg)
+		assert.NotEqual(t, "--plugin-dir-no-mcp", arg)
+	}
+}


### PR DESCRIPTION
Prerequisite for the v0.3.263 `pluginDelivery` work (#230, PR-01). Splitting it out because it is a standalone bug fix, not parity work.

`Options.Plugins` has never done anything. `WithPlugins` stored the slice and nothing read it — the transport built no `--plugin-dir` flag, and the initialize request carried no plugin list. Configure a plugin, get a session without it, no error.

This came up while modelling v0.3.263's `pluginDelivery` option, which chooses between argv delivery and delivery over the initialize request. The `'argv'` branch is the default and it did not exist.

**Changes:**
- Emit the flag pair the TS SDK emits (`sdk.mjs` argv builder): `--plugin-dir`, or `--plugin-dir-no-mcp` when `SkipMcpDiscovery` is set. These are alternative flags, not a flag plus an argument, so they cannot be collapsed.
- Preserve configuration order — a later plugin can shadow an earlier one.
- Reject an unsupported `Type` at `Connect` rather than skipping it. The TS SDK throws on the same input. Quietly dropping a plugin the caller asked for is the bug being fixed, so ignoring a type we cannot express would reintroduce it in a narrower form.
- Add `PluginTypeLocal` so callers stop writing the bare string.

**On the strictness:** an empty `Type` now errors too. That is technically a behavior change for code that compiled before, but no such code can have been working — the field was inert, so there is no caller whose plugins were loading and now stop. A clear error at `Connect` beats the previous silence.

**Tests:** flag mapping for both variants, order preservation, no-flag-when-unconfigured, and a table over rejected types asserting the CLI never starts. `TestIntegrationPluginDirArgv` writes a minimal plugin directory and asserts the plugin name appears in the init message's plugin list — asserting only that the session starts would have passed against the broken behavior just as well. Both integration tests verified passing locally (5.3s).