### PR TITLE
options: deliver plugins over the initialize request

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -3520,4 +3521,153 @@ func TestIntegrationPluginDirRejectsUnsupportedType(t *testing.T) {
 	require.Error(t, err, "the connect must fail rather than start a session "+
 		"that silently lacks the plugin")
 	assert.Contains(t, err.Error(), "unsupported plugin type")
+}
+
+// skipIfCLIOlderThan skips when the installed CLI predates the given version.
+// Written as a gate rather than an unconditional skip so the test starts
+// running on its own once the environment's CLI catches up.
+func skipIfCLIOlderThan(t *testing.T, minVersion string) {
+	t.Helper()
+
+	path, err := DiscoverCLIPath(&Options{})
+	if err != nil {
+		t.Skip("claude CLI not found in PATH")
+	}
+
+	out, err := exec.Command(path, "--version").Output()
+	if err != nil {
+		t.Skipf("could not read CLI version: %v", err)
+	}
+
+	// "2.1.222 (Claude Code)" — the version is the leading token.
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		t.Skipf("could not parse CLI version from %q", string(out))
+	}
+	got, want := fields[0], minVersion
+
+	if compareDottedVersions(got, want) < 0 {
+		t.Skipf("CLI %s predates %s", got, want)
+	}
+}
+
+// compareDottedVersions compares two dotted numeric versions, returning -1, 0
+// or 1. A non-numeric or missing component sorts as 0.
+func compareDottedVersions(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+
+	for i := 0; i < len(aParts) || i < len(bParts); i++ {
+		var av, bv int
+		if i < len(aParts) {
+			av, _ = strconv.Atoi(aParts[i])
+		}
+		if i < len(bParts) {
+			bv, _ = strconv.Atoi(bParts[i])
+		}
+		switch {
+		case av < bv:
+			return -1
+		case av > bv:
+			return 1
+		}
+	}
+	return 0
+}
+
+// awaitInitializeMinCLI is the first Claude Code release that understands
+// --await-initialize. An older binary exits at startup with an unknown-option
+// error (sdk.d.ts v0.3.263 L1885).
+const awaitInitializeMinCLI = "2.1.261"
+
+// TestIntegrationPluginDeliveryInitialize asserts that a plugin delivered over
+// the initialize request loads, and that the CLI confirms it via
+// plugins_applied. Both halves matter: the plugin list is the only thing
+// keeping the command line bounded, and plugins_applied is the only signal
+// that the CLI honored it rather than starting without them.
+func TestIntegrationPluginDeliveryInitialize(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfCLIOlderThan(t, awaitInitializeMinCLI)
+
+	const pluginName = "daedalus-probe"
+	pluginDir := writeProbePlugin(t, pluginName)
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithPlugins([]PluginConfig{{
+			Type: PluginTypeLocal,
+			Path: pluginDir,
+		}}),
+		WithPluginDelivery(PluginDeliveryInitialize),
+		WithMaxTurns(1),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	stream, err := client.Stream(ctx)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	// A re-sent initialize naming the launch set also reads true, so this is a
+	// legitimate way to read the verdict on the plugins delivered at startup.
+	resp, err := stream.Reinitialize(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.PluginsApplied,
+		"a request that listed plugins must get a verdict on them")
+	assert.True(t, *resp.PluginsApplied,
+		"the CLI did not load the plugins sent over initialize")
+
+	var loaded []string
+	var gotResult bool
+	for msg := range client.Query(ctx, "Say OK.") {
+		switch m := msg.(type) {
+		case SystemMessage:
+			for _, p := range m.Plugins {
+				loaded = append(loaded, p.Name)
+			}
+		case ResultMessage:
+			assert.False(t, m.IsError, "session failed: %s", m.Result)
+			gotResult = true
+		}
+		if gotResult {
+			break
+		}
+	}
+
+	require.True(t, gotResult, "no result message")
+	assert.Contains(t, loaded, pluginName,
+		"plugin never loaded; init listed %v", loaded)
+}
+
+// The version gate is the only thing standing between this suite and silently
+// never exercising initialize delivery again, so the comparison itself is
+// worth pinning.
+func TestCompareDottedVersions(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"2.1.222", "2.1.261", -1},
+		{"2.1.261", "2.1.261", 0},
+		{"2.1.262", "2.1.261", 1},
+		{"2.2.0", "2.1.261", 1},
+		{"3.0.0", "2.9.9", 1},
+		// Numeric, not lexicographic: "222" < "261" but "99" > "100" would be
+		// the wrong answer under a string compare.
+		{"2.1.99", "2.1.100", -1},
+		// A missing component reads as zero rather than as "unknown".
+		{"2.1", "2.1.0", 0},
+		{"2.1", "2.1.1", -1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.a+"_vs_"+tc.b, func(t *testing.T) {
+			assert.Equal(t, tc.want, compareDottedVersions(tc.a, tc.b))
+		})
+	}
 }

--- a/messages.go
+++ b/messages.go
@@ -671,10 +671,16 @@ type SDKControlRequestBody struct {
 	ToolAliases            map[string]string                   `json:"toolAliases,omitempty"`            // For initialize
 	SupportedDialogKinds   []string                            `json:"supportedDialogKinds,omitempty"`   // For initialize
 	PerTaskStopAffordance  *bool                               `json:"perTaskStopAffordance,omitempty"`  // For initialize
-	ToolName               string                              `json:"tool_name,omitempty"`              // For can_use_tool/hook_callback
-	Input                  map[string]interface{}              `json:"input,omitempty"`                  // For can_use_tool/hook_callback
-	ToolUseID              string                              `json:"tool_use_id,omitempty"`            // For can_use_tool/hooks/background_tasks
-	AgentID                string                              `json:"agent_id,omitempty"`               // For can_use_tool
+	// Plugins carries the plugin list when Options.PluginDelivery is
+	// PluginDeliveryInitialize, keeping it off the command line. Read only by
+	// a CLI launched with --await-initialize, which consults this request
+	// during startup before any plugin work; without that flag, on a repeated
+	// initialize, or over a remote session transport it loads nothing.
+	Plugins   []PluginConfig         `json:"plugins,omitempty"`     // For initialize
+	ToolName  string                 `json:"tool_name,omitempty"`   // For can_use_tool/hook_callback
+	Input     map[string]interface{} `json:"input,omitempty"`       // For can_use_tool/hook_callback
+	ToolUseID string                 `json:"tool_use_id,omitempty"` // For can_use_tool/hooks/background_tasks
+	AgentID   string                 `json:"agent_id,omitempty"`    // For can_use_tool
 
 	// Inbound can_use_tool context. These describe how the ask reached the
 	// host and constrain how it may be rendered; see PermissionContext.

--- a/options.go
+++ b/options.go
@@ -200,6 +200,17 @@ type Options struct {
 	// Plugins loads custom plugins from local paths.
 	Plugins []PluginConfig
 
+	// PluginDelivery selects how Plugins reach the Claude Code process. Empty
+	// means PluginDeliveryArgv.
+	//
+	// This exists because the command line is a bounded resource:
+	// PluginDeliveryArgv spends one --plugin-dir flag per plugin, and Windows
+	// refuses to start a process whose command line exceeds 32,767 characters.
+	// PluginDeliveryInitialize moves the list to stdin instead, so the command
+	// line stops growing with the plugin count. Loading is otherwise identical
+	// (sdk.d.ts v0.3.263 L1889).
+	PluginDelivery PluginDelivery
+
 	// OutputFormat defines structured output format for agent results.
 	OutputFormat *OutputFormat
 
@@ -1461,6 +1472,35 @@ type SandboxIgnoreViolations struct {
 // PluginTypeLocal is the only supported PluginConfig.Type: a plugin loaded
 // from a directory on this machine.
 const PluginTypeLocal = "local"
+
+// PluginDelivery selects how Options.Plugins reach the Claude Code process.
+type PluginDelivery string
+
+const (
+	// PluginDeliveryArgv passes one --plugin-dir flag per plugin. It is the
+	// default and works with any Claude Code version, at the cost of a command
+	// line that grows with the plugin count.
+	PluginDeliveryArgv PluginDelivery = "argv"
+
+	// PluginDeliveryInitialize sends the list over stdin in the initialize
+	// request and launches Claude Code with --await-initialize.
+	//
+	// Requires Claude Code 2.1.261 or newer; an older binary does not
+	// recognize --await-initialize and exits at startup with an unknown-option
+	// error. That failure is why PluginDeliveryArgv remains the default.
+	// InitializeResult.PluginsApplied reports whether the listed plugins are
+	// in fact loaded.
+	PluginDeliveryInitialize PluginDelivery = "initialize"
+)
+
+// usesInitializePluginDelivery reports whether the plugin list travels in the
+// initialize request rather than on the command line. Both the launch flag and
+// the request field derive from this, so they cannot disagree: a CLI told to
+// wait for a plugin list must receive one, and a list sent to a CLI that was
+// not told to wait would load nothing.
+func (o *Options) usesInitializePluginDelivery() bool {
+	return o.PluginDelivery == PluginDeliveryInitialize && len(o.Plugins) > 0
+}
 
 // PluginConfig configures a plugin to load.
 type PluginConfig struct {
@@ -3654,6 +3694,15 @@ func WithExcludeDynamicSystemPromptSections(enable bool) Option {
 func WithPlugins(plugins []PluginConfig) Option {
 	return func(o *Options) {
 		o.Plugins = plugins
+	}
+}
+
+// WithPluginDelivery selects how Plugins reach the Claude Code process. See
+// Options.PluginDelivery; PluginDeliveryInitialize requires Claude Code
+// 2.1.261 or newer.
+func WithPluginDelivery(delivery PluginDelivery) Option {
+	return func(o *Options) {
+		o.PluginDelivery = delivery
 	}
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -129,6 +129,15 @@ func (p *Protocol) doInitialize(ctx context.Context) error {
 		excludeDynamicSections = &trueVal
 	}
 
+	// Only send the list when the CLI was launched to wait for it. A CLI
+	// started without --await-initialize ignores the field, so sending it
+	// anyway would suggest the plugins were delivered when argv already
+	// delivered them.
+	var plugins []PluginConfig
+	if p.options.usesInitializePluginDelivery() {
+		plugins = p.options.Plugins
+	}
+
 	var agents map[string]interface{}
 	if len(p.options.Agents) > 0 {
 		agents = make(map[string]interface{}, len(p.options.Agents))
@@ -160,6 +169,7 @@ func (p *Protocol) doInitialize(ctx context.Context) error {
 			ToolAliases:            p.options.ToolAliases,
 			SupportedDialogKinds:   p.options.SupportedDialogKinds,
 			PerTaskStopAffordance:  p.options.PerTaskStopAffordance,
+			Plugins:                plugins,
 		},
 	}
 

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -291,6 +291,52 @@ func TestProtocolInitializeOptions(t *testing.T) {
 			unexpected: []string{"excludeDynamicSections"},
 		},
 		{
+			name: "plugins wired through under initialize delivery",
+			configure: func(opts *Options) {
+				WithPluginDelivery(PluginDeliveryInitialize)(opts)
+				WithPlugins([]PluginConfig{
+					{Type: PluginTypeLocal, Path: "/plugins/lint"},
+					{
+						Type:             PluginTypeLocal,
+						Path:             "/plugins/deploy",
+						SkipMcpDiscovery: true,
+					},
+				})(opts)
+			},
+			expected: map[string]interface{}{
+				"plugins": []interface{}{
+					map[string]interface{}{
+						"type": "local",
+						"path": "/plugins/lint",
+					},
+					map[string]interface{}{
+						"type":             "local",
+						"path":             "/plugins/deploy",
+						"skipMcpDiscovery": true,
+					},
+				},
+			},
+		},
+		{
+			// Under argv delivery the flags already carried the plugins. Sending
+			// the list too would claim a delivery that did not happen — the CLI
+			// ignores the field without --await-initialize.
+			name: "plugins omitted under argv delivery",
+			configure: func(opts *Options) {
+				WithPlugins([]PluginConfig{
+					{Type: PluginTypeLocal, Path: "/plugins/lint"},
+				})(opts)
+			},
+			unexpected: []string{"plugins"},
+		},
+		{
+			name: "empty plugin list omitted under initialize delivery",
+			configure: func(opts *Options) {
+				WithPluginDelivery(PluginDeliveryInitialize)(opts)
+			},
+			unexpected: []string{"plugins"},
+		},
+		{
 			name: "agents wired through",
 			configure: func(opts *Options) {
 				WithAgents(map[string]AgentDefinition{

--- a/query_types.go
+++ b/query_types.go
@@ -64,6 +64,21 @@ type SDKControlInitializeResponse struct {
 	// registered, and its own callbacks will never fire (sdk.d.ts v0.3.241
 	// L3752).
 	HooksApplied *bool `json:"hooks_applied,omitempty"`
+	// PluginsApplied reports whether every plugin this initialize listed is
+	// loaded in the process: true when each one is among the plugins loaded at
+	// launch, whether they arrived through PluginDeliveryInitialize under
+	// --await-initialize or as --plugin-dir flags. A re-sent initialize naming
+	// the launch set therefore also reads true.
+	//
+	// The request's plugin list never loads anything after launch, so a false
+	// here is not a transient state that a later initialize can repair — it
+	// means the running process does not have those plugins and will not get
+	// them. The usual cause is a CLI older than 2.1.261, which ignores
+	// --await-initialize's contract entirely.
+	//
+	// Nil when the request listed no plugins, and on CLIs that predate the
+	// field (sdk.d.ts v0.3.263 L4033).
+	PluginsApplied *bool `json:"plugins_applied,omitempty"`
 }
 
 // McpServerStatus reports the connection status of an MCP server.

--- a/transport.go
+++ b/transport.go
@@ -362,23 +362,49 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		args = append(args, "--add-dir", dir)
 	}
 
-	// Load each configured plugin. A plugin that skips MCP discovery selects a
-	// different flag rather than passing an argument, so the two cannot be
-	// merged. An unsupported type is refused rather than skipped: dropping a
-	// plugin the caller asked for, silently, is how this option came to do
-	// nothing at all.
+	// Validate every plugin regardless of how the list is delivered. An
+	// unsupported type is refused rather than skipped: dropping a plugin the
+	// caller asked for, silently, is how this option came to do nothing at
+	// all.
 	for _, plugin := range t.options.Plugins {
 		if plugin.Type != PluginTypeLocal {
 			return fmt.Errorf(
 				"unsupported plugin type %q for path %q: only %q is supported",
 				plugin.Type, plugin.Path, PluginTypeLocal)
 		}
+	}
 
-		flag := "--plugin-dir"
-		if plugin.SkipMcpDiscovery {
-			flag = "--plugin-dir-no-mcp"
+	switch t.options.PluginDelivery {
+	case "", PluginDeliveryArgv:
+	case PluginDeliveryInitialize:
+	default:
+		return fmt.Errorf(
+			"invalid plugin delivery %q: expected %q or %q",
+			t.options.PluginDelivery, PluginDeliveryArgv,
+			PluginDeliveryInitialize)
+	}
+
+	// The two deliveries are exclusive. --await-initialize makes the CLI wait
+	// for the initialize request before doing any plugin work, so the flags
+	// are not merely redundant alongside it — they would load the plugins a
+	// second time, at a point the request was meant to own.
+	//
+	// An empty list stays on the argv path even under
+	// PluginDeliveryInitialize: there is nothing to keep off the command line,
+	// and --await-initialize would otherwise impose a version floor for no
+	// benefit.
+	if t.options.usesInitializePluginDelivery() {
+		args = append(args, "--await-initialize")
+	} else {
+		// A plugin that skips MCP discovery selects a different flag rather
+		// than passing an argument, so the two cannot be merged.
+		for _, plugin := range t.options.Plugins {
+			flag := "--plugin-dir"
+			if plugin.SkipMcpDiscovery {
+				flag = "--plugin-dir-no-mcp"
+			}
+			args = append(args, flag, plugin.Path)
 		}
-		args = append(args, flag, plugin.Path)
 	}
 
 	// Add include-partial-messages flag for streaming deltas.

--- a/transport_test.go
+++ b/transport_test.go
@@ -2312,3 +2312,97 @@ func TestSubprocessTransportPluginsEmpty(t *testing.T) {
 		assert.NotEqual(t, "--plugin-dir-no-mcp", arg)
 	}
 }
+
+// TestSubprocessTransportPluginDeliveryInitialize tests that initialize
+// delivery replaces the per-plugin flags with --await-initialize. The two are
+// exclusive: --await-initialize makes the CLI wait for the initialize request
+// before doing plugin work, so leaving the flags in would load each plugin a
+// second time at a point the request was meant to own.
+func TestSubprocessTransportPluginDeliveryInitialize(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	opts := &Options{
+		PluginDelivery: PluginDeliveryInitialize,
+		Plugins: []PluginConfig{
+			{Type: PluginTypeLocal, Path: "/plugins/lint"},
+			{
+				Type:             PluginTypeLocal,
+				Path:             "/plugins/deploy",
+				SkipMcpDiscovery: true,
+			},
+		},
+	}
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	require.NoError(t, transport.Connect(context.Background()))
+	defer transport.Close()
+
+	assert.Contains(t, runner.StartArgs, "--await-initialize")
+	for _, arg := range runner.StartArgs {
+		assert.NotEqual(t, "--plugin-dir", arg,
+			"argv delivery leaked alongside --await-initialize: %v",
+			runner.StartArgs)
+		assert.NotEqual(t, "--plugin-dir-no-mcp", arg)
+	}
+}
+
+// Argv delivery is the default, so an unset PluginDelivery must not put a
+// version floor on the CLI by emitting --await-initialize.
+func TestSubprocessTransportPluginDeliveryDefaultsToArgv(t *testing.T) {
+	for _, delivery := range []PluginDelivery{"", PluginDeliveryArgv} {
+		t.Run(string(delivery), func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+
+			opts := &Options{
+				PluginDelivery: delivery,
+				Plugins: []PluginConfig{
+					{Type: PluginTypeLocal, Path: "/plugins/lint"},
+				},
+			}
+
+			transport := NewSubprocessTransportWithRunner(runner, opts)
+
+			require.NoError(t, transport.Connect(context.Background()))
+			defer transport.Close()
+
+			assert.NotContains(t, runner.StartArgs, "--await-initialize")
+			assert.Subset(t, runner.StartArgs,
+				[]string{"--plugin-dir", "/plugins/lint"})
+		})
+	}
+}
+
+// With nothing to keep off the command line there is no reason to impose
+// --await-initialize's version floor, so an empty list stays on the argv path
+// even when initialize delivery was asked for.
+func TestSubprocessTransportPluginDeliveryInitializeNoPlugins(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	opts := &Options{PluginDelivery: PluginDeliveryInitialize}
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	require.NoError(t, transport.Connect(context.Background()))
+	defer transport.Close()
+
+	assert.NotContains(t, runner.StartArgs, "--await-initialize")
+}
+
+func TestSubprocessTransportPluginDeliveryRejectsInvalid(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	opts := &Options{
+		PluginDelivery: PluginDelivery("stdin"),
+		Plugins: []PluginConfig{
+			{Type: PluginTypeLocal, Path: "/plugins/lint"},
+		},
+	}
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+
+	err := transport.Connect(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid plugin delivery")
+	assert.False(t, runner.started)
+}


### PR DESCRIPTION
Parity with TypeScript Agent SDK v0.3.263 — see #230, PR-01. Builds on #231, which made `Options.Plugins` reach the CLI at all.

Adds `Options.PluginDelivery` (`sdk.d.ts` L1889), the `--await-initialize` flag, `plugins` on the initialize request (L4028), and `plugins_applied` on the initialize response (L4033).

**Why it exists:** argv delivery spends one `--plugin-dir` flag per plugin, and Windows refuses to start a process whose command line exceeds 32,767 characters. `PluginDeliveryInitialize` moves the list to stdin so the launch command stops growing with the plugin count. Loading is otherwise identical.

**The exclusivity is the load-bearing part.** `--await-initialize` makes the CLI wait for the initialize request before doing any plugin work, so the flags are not merely redundant next to it — they would load each plugin a second time at a point the request was meant to own. One predicate (`Options.usesInitializePluginDelivery`) drives both the flag and the request field so they cannot disagree in either direction: a CLI told to wait must receive a list, and a list sent to a CLI not told to wait loads nothing.

**Two deliberate edge cases:**
- An empty plugin list stays on the argv path even under initialize delivery. Nothing needs keeping off the command line, and `--await-initialize` would otherwise impose the 2.1.261 version floor for free. This matches the TS gate (`pluginDelivery === 'initialize' && plugins?.length > 0`).
- `plugins` is omitted from the request under argv delivery. The CLI ignores the field without `--await-initialize`, so sending it would claim a delivery that did not happen.

`PluginsApplied` is documented as terminal rather than advisory: the request's list never loads anything after launch, so a `false` means the running process does not have those plugins and will not get them.

**Tests:** transport coverage for flag/no-flag across delivery modes, the empty-list case, invalid-delivery rejection, and no argv leakage under `--await-initialize`; three new cases in the `TestProtocolInitializeOptions` table for the request field's gate.

**Integration:** `TestIntegrationPluginDeliveryInitialize` asserts both that the plugin loads and that `plugins_applied` is true. It is **version-gated, not skipped** — this environment ships CLI 2.1.222, below the 2.1.261 floor (confirmed: `--await-initialize` exits 1 with `unknown option`), so it skips here and starts running on its own once the CLI catches up. `TestCompareDottedVersions` pins the gate's comparator, since a bug there would silently disable the test forever rather than failing.