### PR TITLE
options: let a session declare it has no approval surface

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3575,6 +3576,30 @@ func compareDottedVersions(a, b string) int {
 	return 0
 }
 
+// skipIfCLILacksFlag skips when the installed CLI does not recognize a flag.
+//
+// The probe passes a deliberately invalid value, which makes both outcomes
+// fail during option parsing — before any API call — and lets the error text
+// tell them apart: an unrecognized flag reports "unknown option", while a
+// recognized one complains about the argument. Cheaper and more precise than
+// letting the real test hang until its context expires.
+func skipIfCLILacksFlag(t *testing.T, flag string) {
+	t.Helper()
+
+	path, err := DiscoverCLIPath(&Options{})
+	if err != nil {
+		t.Skip("claude CLI not found in PATH")
+	}
+
+	cmd := exec.Command(path, flag, "__probe__", "-p", "x")
+	cmd.Stdin = strings.NewReader("")
+	out, _ := cmd.CombinedOutput()
+
+	if strings.Contains(string(out), "unknown option '"+flag+"'") {
+		t.Skipf("CLI does not support %s", flag)
+	}
+}
+
 // awaitInitializeMinCLI is the first Claude Code release that understands
 // --await-initialize. An older binary exits at startup with an unknown-option
 // error (sdk.d.ts v0.3.263 L1885).
@@ -3670,4 +3695,55 @@ func TestCompareDottedVersions(t *testing.T) {
 			assert.Equal(t, tc.want, compareDottedVersions(tc.a, tc.b))
 		})
 	}
+}
+
+// TestIntegrationPermissionPromptsNone asserts that a session declared to have
+// no approval surface denies a call that would otherwise prompt, without ever
+// invoking the callback.
+//
+// A tool that is not pre-approved is the only way to reach the prompt path, so
+// the test asks for a Bash command under the default permission mode and
+// expects a denial rather than a hang.
+func TestIntegrationPermissionPromptsNone(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfCLILacksFlag(t, "--permission-prompts")
+
+	var callbackInvocations atomic.Int32
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithAllowedTools([]string{"Bash"}),
+		WithPermissionPrompts(PermissionPromptsNone),
+		WithCanUseTool(func(
+			ctx context.Context, req ToolPermissionRequest,
+		) PermissionResult {
+			callbackInvocations.Add(1)
+			return PermissionAllow{}
+		}),
+		WithMaxTurns(2),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var result ResultMessage
+	var gotResult bool
+	for msg := range client.Query(ctx,
+		"Run the shell command `echo hello` using the Bash tool.") {
+		if m, ok := msg.(ResultMessage); ok {
+			result = m
+			gotResult = true
+			break
+		}
+	}
+
+	require.True(t, gotResult, "no result message")
+	assert.Zero(t, callbackInvocations.Load(),
+		"the callback must never run when the session has no approval surface")
+	assert.NotEmpty(t, result.PermissionDenials,
+		"a tool call that would have prompted must be denied outright, not "+
+			"silently allowed; result: %s", result.Result)
 }

--- a/options.go
+++ b/options.go
@@ -73,6 +73,21 @@ type Options struct {
 	// Return PermissionAllow to proceed or PermissionDeny to block.
 	CanUseTool CanUseToolFunc
 
+	// PermissionPrompts says who answers permission prompts. Empty means
+	// PermissionPromptsHost.
+	//
+	// PermissionPromptsNone does not loosen anything: the permission mode
+	// (including auto mode's classifier), the rules and the hooks all still
+	// decide as they would otherwise. It removes only the fallback — a call
+	// that would have prompted is denied at once, and Claude is told the
+	// session has no approval surface rather than being left to wait.
+	//
+	// It overrides CanUseTool rather than conflicting with it: the callback is
+	// never invoked under PermissionPromptsNone. Setting both is legitimate
+	// for a host that installs a callback globally and suppresses prompting
+	// for one unattended session (sdk.d.ts v0.3.263 L1836).
+	PermissionPrompts PermissionPrompts
+
 	// OnElicitation handles MCP server requests for user input.
 	OnElicitation OnElicitationFunc
 
@@ -1744,6 +1759,15 @@ func WithCanUseTool(fn CanUseToolFunc) Option {
 	}
 }
 
+// WithPermissionPrompts sets who answers permission prompts.
+// PermissionPromptsNone denies anything that would prompt and never invokes
+// Options.CanUseTool. See Options.PermissionPrompts.
+func WithPermissionPrompts(prompts PermissionPrompts) Option {
+	return func(o *Options) {
+		o.PermissionPrompts = prompts
+	}
+}
+
 // WithOnElicitation registers a callback that handles MCP elicitation requests.
 //
 // If unset, the SDK auto-declines all elicitation requests.
@@ -1964,6 +1988,28 @@ const (
 
 	// PermissionModeDontAsk runs without asking for permission prompts.
 	PermissionModeDontAsk PermissionMode = "dontAsk"
+)
+
+// PermissionPrompts says who answers permission prompts for a session.
+//
+// This is orthogonal to PermissionMode, which is easy to miss because
+// PermissionModeDontAsk sounds like the same thing. The mode participates in
+// the decision — dontAsk denies whatever is not pre-approved. PermissionPrompts
+// instead describes whether an approval surface exists at all, and applies
+// whichever mode is in force.
+type PermissionPrompts string
+
+const (
+	// PermissionPromptsHost answers prompts in this process, through
+	// Options.CanUseTool or a named permission prompt tool. It is the default.
+	PermissionPromptsHost PermissionPrompts = "host"
+
+	// PermissionPromptsNone leaves nobody to ask. Modes, rules and hooks still
+	// decide; only the prompt fallback is gone, so a call that would have
+	// prompted is denied immediately and Claude is told the session has no
+	// approval surface rather than being left waiting on an answer that cannot
+	// come.
+	PermissionPromptsNone PermissionPrompts = "none"
 )
 
 // CanUseToolFunc is a callback invoked before tool execution.

--- a/transport.go
+++ b/transport.go
@@ -241,6 +241,22 @@ func (t *SubprocessTransport) Connect(ctx context.Context) error {
 		args = append(args, "--permission-prompt-tool", "stdio")
 	}
 
+	// Declare who answers prompts. Sent even alongside --permission-prompt-tool:
+	// "none" is what tells the CLI to stop short of the tool, so suppressing
+	// the flag here would leave the callback wired up and the session waiting.
+	if t.options.PermissionPrompts != "" {
+		switch t.options.PermissionPrompts {
+		case PermissionPromptsHost, PermissionPromptsNone:
+			args = append(args, "--permission-prompts",
+				string(t.options.PermissionPrompts))
+		default:
+			return fmt.Errorf(
+				"invalid permission prompts %q: expected %q or %q",
+				t.options.PermissionPrompts, PermissionPromptsHost,
+				PermissionPromptsNone)
+		}
+	}
+
 	// Note: --verbose is already added above (required for stream-json).
 
 	// Add settings sources for Skills

--- a/transport_test.go
+++ b/transport_test.go
@@ -2406,3 +2406,86 @@ func TestSubprocessTransportPluginDeliveryRejectsInvalid(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid plugin delivery")
 	assert.False(t, runner.started)
 }
+
+func TestSubprocessTransportPermissionPrompts(t *testing.T) {
+	tests := []struct {
+		name     string
+		prompts  PermissionPrompts
+		expected []string
+		absent   bool
+	}{
+		{
+			name:     "none",
+			prompts:  PermissionPromptsNone,
+			expected: []string{"--permission-prompts", "none"},
+		},
+		{
+			name:     "host",
+			prompts:  PermissionPromptsHost,
+			expected: []string{"--permission-prompts", "host"},
+		},
+		{
+			// Host is the CLI's own default, so an unset option must not
+			// start pinning it.
+			name:    "unset omits the flag",
+			prompts: "",
+			absent:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := NewMockSubprocessRunner()
+
+			transport := NewSubprocessTransportWithRunner(runner, &Options{
+				PermissionPrompts: tc.prompts,
+			})
+
+			require.NoError(t, transport.Connect(context.Background()))
+			defer transport.Close()
+
+			if tc.absent {
+				assert.NotContains(t, runner.StartArgs, "--permission-prompts")
+				return
+			}
+			assert.Subset(t, runner.StartArgs, tc.expected)
+		})
+	}
+}
+
+// "none" is precisely what tells the CLI to stop short of the prompt tool, so
+// it must still be sent when a callback is registered. Dropping it would leave
+// the callback wired up and the session waiting on an answer nobody will give.
+func TestSubprocessTransportPermissionPromptsNoneWithCallback(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	transport := NewSubprocessTransportWithRunner(runner, &Options{
+		PermissionPrompts: PermissionPromptsNone,
+		CanUseTool: func(
+			ctx context.Context, req ToolPermissionRequest,
+		) PermissionResult {
+			return PermissionAllow{}
+		},
+	})
+
+	require.NoError(t, transport.Connect(context.Background()))
+	defer transport.Close()
+
+	assert.Subset(t, runner.StartArgs,
+		[]string{"--permission-prompts", "none"})
+	assert.Subset(t, runner.StartArgs,
+		[]string{"--permission-prompt-tool", "stdio"})
+}
+
+func TestSubprocessTransportPermissionPromptsRejectsInvalid(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+
+	transport := NewSubprocessTransportWithRunner(runner, &Options{
+		PermissionPrompts: PermissionPrompts("sometimes"),
+	})
+
+	err := transport.Connect(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid permission prompts")
+	assert.False(t, runner.started)
+}


### PR DESCRIPTION
Parity with TypeScript Agent SDK v0.3.263 — see #230, PR-02.

Adds `Options.PermissionPrompts` (`sdk.d.ts` L1836) and the `--permission-prompts` CLI flag.

**The gap it closes:** an unattended session has nobody to ask. Before this the SDK could only let a call that would prompt sit waiting for an answer that never arrives, or pre-approve tools it did not actually want to pre-approve. `PermissionPromptsNone` gives a third option — deny immediately and tell Claude the session has no approval surface, so it can adapt instead of stalling.

**It does not loosen anything.** The permission mode (auto mode's classifier included), the rules and the hooks all still decide exactly as before. Only the fallback changes.

**Three things worth reviewing:**
- **The flag is sent even when `CanUseTool` is registered.** `none` is precisely what tells the CLI to stop short of the prompt tool, so suppressing it in that case would leave the callback wired up and reintroduce the hang this is meant to remove. Upstream is the same shape — it pushes `--permission-prompt-tool stdio` and `--permission-prompts` independently. Setting both is a legitimate pattern: a host installs a callback globally and suppresses prompting for one session.
- **Documented apart from `PermissionMode`.** `PermissionModeDontAsk` sounds like the same feature. It is not: the mode participates in the decision (deny what is not pre-approved), while this says whether an approval surface exists at all, under whichever mode is in force. The type comment spells that out because the names invite the confusion.
- **Invalid values are rejected at `Connect`** rather than passed through to the CLI.

**Tests:** flag mapping for both values, no flag when unset (host is the CLI's own default — the SDK should not start pinning it), the none-plus-callback case, and invalid-value rejection.

**Integration:** `TestIntegrationPermissionPromptsNone` asks for an un-pre-approved Bash call and asserts the callback never fires *and* that `result.permission_denials` is non-empty — a denial actually booked, not merely a session that did not hang.

**On the skip helper:** this environment's CLI (2.1.222) does not know `--permission-prompts`, so the test skips. My first version detected that by waiting for the context to expire, which cost 90 seconds per CI run. `skipIfCLILacksFlag` instead probes with a deliberately invalid value: both outcomes fail during option parsing before any API call, and the error text discriminates (`unknown option` vs an argument complaint). Same skip in 0.19s, and it self-backfills when the CLI updates. The helper is reusable for future catchups, where a flag routinely lands upstream before the bundled CLI catches up.