### PR TITLE
protocol: send the preset system prompt's append

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -3747,3 +3747,58 @@ func TestIntegrationPermissionPromptsNone(t *testing.T) {
 		"a tool call that would have prompted must be denied outright, not "+
 			"silently allowed; result: %s", result.Result)
 }
+
+// TestIntegrationSystemPromptPresetAppend asserts that the preset form's
+// append actually reaches the model. WithSystemPromptPreset stored a config no
+// wire path read, so the append was silently dropped; a test that only checked
+// the session ran would have passed against that.
+//
+// The append carries a fact the model cannot otherwise know, and the prompt
+// asks for it. Recalling a fact is far more reliable than obeying a formatting
+// rule: an earlier version of this test appended "end every reply with X" and
+// asked for a three-word greeting, and the model split its compliance between
+// the two contradictory constraints about half the time.
+func TestIntegrationSystemPromptPresetAppend(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	const marker = "ZORBLAX7"
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPromptPreset("claude_code", fmt.Sprintf(
+			"The deployment codeword for this session is %s. "+
+				"When asked for the deployment codeword, reply with it.",
+			marker)),
+		WithMaxTurns(1),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var reply strings.Builder
+	var gotResult bool
+	for msg := range client.Query(ctx, "What is the deployment codeword?") {
+		switch m := msg.(type) {
+		case AssistantMessage:
+			for _, block := range m.Message.Content {
+				if block.Type == "text" {
+					reply.WriteString(block.Text)
+				}
+			}
+		case ResultMessage:
+			assert.False(t, m.IsError, "session failed: %s", m.Result)
+			gotResult = true
+		}
+		if gotResult {
+			break
+		}
+	}
+
+	require.True(t, gotResult, "no result message")
+	assert.Contains(t, reply.String(), marker,
+		"the preset append never reached the model; reply was %q",
+		reply.String())
+}

--- a/options.go
+++ b/options.go
@@ -335,9 +335,17 @@ type Options struct {
 
 // SystemPromptConfig represents system prompt configuration.
 type SystemPromptConfig struct {
-	Type   string // "preset"
-	Preset string // "claude_code"
-	Append string // Additional instructions to append
+	Type string // "preset"
+
+	// Preset names the base prompt. "claude_code" is the only one, and it is
+	// not sent on the wire: an initialize request that carries an append but
+	// no systemPrompt is already unambiguous about wanting the built-in
+	// prompt. The field is kept because the upstream option has it.
+	Preset string
+
+	// Append holds instructions added to the preset prompt. This is the only
+	// part of the preset form that reaches the CLI.
+	Append string
 }
 
 // SettingSource represents a filesystem settings source.

--- a/protocol.go
+++ b/protocol.go
@@ -138,6 +138,22 @@ func (p *Protocol) doInitialize(ctx context.Context) error {
 		plugins = p.options.Plugins
 	}
 
+	// The preset form asks for Claude Code's own prompt plus an addition, so it
+	// sends only the addition: leaving systemPrompt unset is what selects the
+	// built-in prompt. Setting it to the append text instead would replace the
+	// preset with a fragment.
+	systemPrompt := p.options.SystemPrompt
+	appendSystemPrompt := ""
+	if preset := p.options.SystemPromptPreset; preset != nil {
+		if systemPrompt != "" {
+			return fmt.Errorf(
+				"SystemPrompt and SystemPromptPreset are mutually exclusive: " +
+					"a custom prompt replaces the preset, so setting both " +
+					"leaves it ambiguous which one the session should use")
+		}
+		appendSystemPrompt = preset.Append
+	}
+
 	var agents map[string]interface{}
 	if len(p.options.Agents) > 0 {
 		agents = make(map[string]interface{}, len(p.options.Agents))
@@ -157,7 +173,8 @@ func (p *Protocol) doInitialize(ctx context.Context) error {
 			SDKMCPServers:          sdkMcpServers,
 			SDKMCPServerConfigs:    sdkMcpServerConfigs,
 			MCPServers:             p.options.MCPServers,
-			SystemPrompt:           p.options.SystemPrompt,
+			SystemPrompt:           systemPrompt,
+			AppendSystemPrompt:     appendSystemPrompt,
 			PlanModeInstructions:   p.options.PlanModeInstructions,
 			ExcludeDynamicSections: excludeDynamicSections,
 			Agents:                 agents,

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -415,6 +415,37 @@ func TestProtocolInitializeOptions(t *testing.T) {
 			},
 			unexpected: []string{"sdkMcpServerConfigs"},
 		},
+		{
+			// systemPrompt stays unset: that absence is what selects Claude
+			// Code's built-in prompt for the append to extend.
+			name: "preset sends only the append",
+			configure: func(opts *Options) {
+				WithSystemPromptPreset(
+					"claude_code", "Always explain your reasoning.")(opts)
+			},
+			expected: map[string]interface{}{
+				"appendSystemPrompt": "Always explain your reasoning.",
+			},
+			unexpected: []string{"systemPrompt"},
+		},
+		{
+			name: "preset without an append sends neither",
+			configure: func(opts *Options) {
+				WithSystemPromptPreset("claude_code", "")(opts)
+			},
+			unexpected: []string{"systemPrompt", "appendSystemPrompt"},
+		},
+		{
+			// A custom prompt replaces the preset rather than extending it.
+			name: "custom prompt sends no append",
+			configure: func(opts *Options) {
+				WithSystemPrompt("You are a release bot.")(opts)
+			},
+			expected: map[string]interface{}{
+				"systemPrompt": "You are a release bot.",
+			},
+			unexpected: []string{"appendSystemPrompt"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -4819,4 +4850,27 @@ func TestSessionStartCacheContext(t *testing.T) {
 		assert.Nil(t, got.PromptCacheLikelyExpired)
 		assert.Nil(t, got.EstimatedCacheWriteUSD)
 	})
+}
+
+// The two system-prompt forms are alternatives: a custom prompt replaces the
+// preset rather than extending it, so asking for both leaves no defensible
+// interpretation. Refuse rather than silently picking one.
+func TestProtocolInitializeSystemPromptConflict(t *testing.T) {
+	runner := NewMockSubprocessRunner()
+	opts := NewOptions()
+	WithSystemPrompt("You are a release bot.")(opts)
+	WithSystemPromptPreset("claude_code", "Be brief.")(opts)
+
+	transport := NewSubprocessTransportWithRunner(runner, opts)
+	protocol := NewProtocol(transport, opts)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	require.NoError(t, transport.Connect(ctx))
+	defer transport.Close()
+
+	err := protocol.Initialize(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
 }


### PR DESCRIPTION
Prerequisite for the v0.3.263 `systemPrompt.snapshot` work (#230, PR-03). Splitting it out because it is a standalone bug fix, not parity work — same situation as #231.

`WithSystemPromptPreset` stored a `SystemPromptConfig` that no wire path read. `Options.SystemPromptPreset` was matched by nothing in `transport.go` or `protocol.go`, so a caller asking for Claude Code's prompt plus their own instructions got the prompt without the instructions, and no error.

**Changes:**
- Populate `appendSystemPrompt` on the initialize request from the preset, matching the TS derivation (`sdk.mjs`: for `type: 'preset'` it sets only `appendSystemPrompt`, `excludeDynamicSections` and `snapshot`).
- Leave `systemPrompt` unset for the preset form. That absence is what selects the built-in prompt; filling it with the append text would replace the whole preset with a fragment.
- Refuse the combination of a custom `SystemPrompt` and a `SystemPromptPreset`.
- Document that `SystemPromptConfig.Preset` is not sent — `claude_code` is the only value, and the shape of the request is already unambiguous. Upstream reads `s.append` / `s.excludeDynamicSections` / `s.snapshot` off the preset object and never `s.preset`.

**On refusing the conflict:** upstream models this as a union, so the case cannot arise there. As two Go fields it can, and the two are genuinely contradictory — a custom prompt *replaces* the preset rather than extending it, so there is no defensible way to honor both. Erroring beats picking one silently.

**Tests:** three cases added to the `TestProtocolInitializeOptions` table (preset sends only the append; preset with no append sends neither key; custom prompt sends no append) plus a conflict test.

**Integration:** `TestIntegrationSystemPromptPresetAppend` asserts the append actually reaches the model.

Worth flagging how that test got written, since it bears on trusting it: the first version appended *"end every reply with ZORBLAX"* and prompted *"say hello in exactly three words"*. Those two instructions contradict each other, and the model honored one or the other roughly half the time — it failed, passed on a re-run, then failed again. That is a test that would have landed and then flaked in CI for someone else to debug. The version here puts a codeword in the append and asks for it, so compliance is recall rather than obeying a formatting rule that fights the prompt. Ran it three times in a row clean, and it is faster (4-5s vs 7-9s).

I also verified the underlying mechanism independently before trusting either result — a hand-rolled `stream-json` session that sends `appendSystemPrompt` on the initialize request and nothing else confirms the CLI honors it from the control protocol, with no `--append-system-prompt` flag involved (upstream emits no such flag either).