### PR TITLE
options: opt in to system prompt snapshotting

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -3802,3 +3802,56 @@ func TestIntegrationSystemPromptPresetAppend(t *testing.T) {
 		"the preset append never reached the model; reply was %q",
 		reply.String())
 }
+
+// TestIntegrationSystemPromptSnapshot asserts the CLI accepts a snapshotted
+// system prompt in the initialize handshake and still runs the turn. The
+// snapshot's real effect — a prompt cached once and replayed verbatim across
+// requests — is not observable from a single query, so this guards the wire
+// contract instead: an unknown field in the initialize request stalls the
+// handshake for the full timeout, and pairing snapshot with a preset append
+// confirms the append still lands while snapshotting is on.
+func TestIntegrationSystemPromptSnapshot(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	const marker = "QUASAR3"
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPromptPreset("claude_code", fmt.Sprintf(
+			"The deployment codeword for this session is %s. "+
+				"When asked for the deployment codeword, reply with it.",
+			marker)),
+		WithSystemPromptSnapshot(true),
+		WithMaxTurns(1),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var reply strings.Builder
+	var gotResult bool
+	for msg := range client.Query(ctx, "What is the deployment codeword?") {
+		switch m := msg.(type) {
+		case AssistantMessage:
+			for _, block := range m.Message.Content {
+				if block.Type == "text" {
+					reply.WriteString(block.Text)
+				}
+			}
+		case ResultMessage:
+			assert.False(t, m.IsError, "session failed: %s", m.Result)
+			gotResult = true
+		}
+		if gotResult {
+			break
+		}
+	}
+
+	require.True(t, gotResult, "no result message")
+	assert.Contains(t, reply.String(), marker,
+		"snapshotting broke the preset append or stalled the handshake; "+
+			"reply was %q", reply.String())
+}

--- a/messages.go
+++ b/messages.go
@@ -660,6 +660,7 @@ type SDKControlRequestBody struct {
 	JSONSchema             map[string]interface{}              `json:"jsonSchema,omitempty"`             // For initialize
 	SystemPrompt           string                              `json:"systemPrompt,omitempty"`           // For initialize
 	AppendSystemPrompt     string                              `json:"appendSystemPrompt,omitempty"`     // For initialize
+	SystemPromptSnapshot   *bool                               `json:"systemPromptSnapshot,omitempty"`   // For initialize
 	PlanModeInstructions   string                              `json:"planModeInstructions,omitempty"`   // For initialize
 	ExcludeDynamicSections *bool                               `json:"excludeDynamicSections,omitempty"` // For initialize
 	Agents                 map[string]interface{}              `json:"agents,omitempty"`                 // For initialize

--- a/options.go
+++ b/options.go
@@ -19,6 +19,30 @@ type Options struct {
 	// Use "claude_code" to get Claude Code's default system prompt.
 	SystemPromptPreset *SystemPromptConfig
 
+	// SystemPromptSnapshot records the conversation's system prompt once and
+	// reuses it verbatim on every later request and resume. Recommended: true.
+	//
+	// It is worth setting because a system prompt that changes mid-conversation
+	// invalidates the API prompt-cache prefix and, with extended thinking,
+	// discards the model's earlier reasoning. A CLI upgrade between launches, a
+	// flipped flag, or a different append is enough to cause that. A recorded
+	// prompt cannot change until the conversation is compacted.
+	//
+	// The three states are distinct, which is why this is a pointer:
+	//   - nil: only a bare preset is recorded. Setting a custom prompt or an
+	//     append turns recording off, so that text is applied fresh on every
+	//     launch. This is the historical behavior.
+	//   - true: an existing record is sent as-is, and a later launch's
+	//     different prompt or append is ignored until compaction or a new
+	//     session. With no record yet, the prompt is rendered with the append
+	//     included, sent, and recorded for the rest of the conversation.
+	//   - false: never record; render fresh every request.
+	//
+	// Safe to set before the feature reaches an account: where recording is
+	// not yet enabled, and on Bedrock, Vertex and Foundry today, the field is
+	// accepted and does nothing (sdk.d.ts v0.3.263 L3990).
+	SystemPromptSnapshot *bool
+
 	// Model specifies which Claude model to use.
 	// Default: "claude-sonnet-4-5-20250929"
 	Model string
@@ -3630,6 +3654,17 @@ func WithSystemPromptPreset(preset string, append string) Option {
 			Preset: preset,
 			Append: append,
 		}
+	}
+}
+
+// WithSystemPromptSnapshot records the conversation's system prompt once and
+// reuses it verbatim on every later request and resume. Recommended: true.
+//
+// Omitting this is not the same as passing false — see
+// Options.SystemPromptSnapshot for the three states.
+func WithSystemPromptSnapshot(snapshot bool) Option {
+	return func(o *Options) {
+		o.SystemPromptSnapshot = &snapshot
 	}
 }
 

--- a/protocol.go
+++ b/protocol.go
@@ -175,6 +175,7 @@ func (p *Protocol) doInitialize(ctx context.Context) error {
 			MCPServers:             p.options.MCPServers,
 			SystemPrompt:           systemPrompt,
 			AppendSystemPrompt:     appendSystemPrompt,
+			SystemPromptSnapshot:   p.options.SystemPromptSnapshot,
 			PlanModeInstructions:   p.options.PlanModeInstructions,
 			ExcludeDynamicSections: excludeDynamicSections,
 			Agents:                 agents,

--- a/protocol_test.go
+++ b/protocol_test.go
@@ -436,6 +436,46 @@ func TestProtocolInitializeOptions(t *testing.T) {
 			unexpected: []string{"systemPrompt", "appendSystemPrompt"},
 		},
 		{
+			name: "snapshot true wired through",
+			configure: func(opts *Options) {
+				WithSystemPromptSnapshot(true)(opts)
+			},
+			expected: map[string]interface{}{
+				"systemPromptSnapshot": true,
+			},
+		},
+		{
+			// False is not the default — it means "never record", where
+			// omitting means "record only a bare preset". So it has to survive
+			// as an explicit false rather than being elided.
+			name: "snapshot false is explicit",
+			configure: func(opts *Options) {
+				WithSystemPromptSnapshot(false)(opts)
+			},
+			expected: map[string]interface{}{
+				"systemPromptSnapshot": false,
+			},
+		},
+		{
+			name:       "unset snapshot omits the key",
+			configure:  func(opts *Options) {},
+			unexpected: []string{"systemPromptSnapshot"},
+		},
+		{
+			// The recommended pairing: extend the preset and record the result
+			// so the append does not re-render on every launch.
+			name: "snapshot rides alongside a preset append",
+			configure: func(opts *Options) {
+				WithSystemPromptPreset("claude_code", "Be brief.")(opts)
+				WithSystemPromptSnapshot(true)(opts)
+			},
+			expected: map[string]interface{}{
+				"appendSystemPrompt":   "Be brief.",
+				"systemPromptSnapshot": true,
+			},
+			unexpected: []string{"systemPrompt"},
+		},
+		{
 			// A custom prompt replaces the preset rather than extending it.
 			name: "custom prompt sends no append",
 			configure: func(opts *Options) {


### PR DESCRIPTION
Second half of the v0.3.263 system-prompt work (PR-03; #234 landed the preset append).

`snapshot` on the TS SDK's system-prompt config records the conversation's system prompt once and replays it verbatim on every later request and resume. A prompt that shifts mid-conversation invalidates the API prompt-cache prefix and, under extended thinking, discards the model's earlier reasoning — a CLI upgrade between launches, a flipped flag, or a different append is enough to cause it.

## Shape

- `Options.SystemPromptSnapshot *bool` + `WithSystemPromptSnapshot(bool)`.
- Wired to `systemPromptSnapshot` on the initialize control request (top-level, matching how the SDK already flattens `systemPrompt`/`appendSystemPrompt`).

The field is a pointer because the three states are genuinely distinct — omitted is not `false`:

| state | behavior |
|-------|----------|
| `nil` | record only a bare preset; a custom prompt or append renders fresh each launch (historical behavior) |
| `true` | reuse an existing record; a later launch's divergent prompt/append is ignored until compaction |
| `false` | never record; render fresh every request |

## Tests

- Unit: snapshot true/false/unset wiring into the initialize request, plus snapshot riding alongside a preset append (`protocol_test.go`).
- Integration: `TestIntegrationSystemPromptSnapshot` round-trips snapshot=true against the live CLI, asserting the init handshake accepts the field and a paired preset append still reaches the model (passes, 3.6s).

Safe to set before the feature reaches an account: where recording is not yet enabled, and on Bedrock/Vertex/Foundry today, the field is accepted and does nothing (sdk.d.ts v0.3.263 L2219).