### PR TITLE
client: add update_settings control request

### DIFF
--- a/client.go
+++ b/client.go
@@ -1196,6 +1196,40 @@ func (s *Stream) ApplyFlagSettings(
 	return err
 }
 
+// SettingsSource names the settings file Stream.UpdateSettings writes to. It
+// is a single-member type today; a named type keeps widening it additive.
+type SettingsSource string
+
+// SettingsSourceLocal is the project's local settings file — the only scope the
+// CLI accepts today, chosen so a host UI's writes land exactly where /config's
+// do.
+const SettingsSourceLocal SettingsSource = "localSettings"
+
+// UpdateSettings writes settings to a settings file on disk, the durable
+// counterpart to ApplyFlagSettings' in-memory flag layer. The CLI persists the
+// merge to the named file rather than holding it for the session.
+//
+// The CLI enforces a narrow contract: only outputStyle is writable today, its
+// value must be a string, and deletion is unsupported (a key cannot be cleared
+// this way). It refuses remote transports and any session whose
+// --setting-sources excludes source. Violations surface as an error response.
+//
+// Only available in streaming input mode.
+func (s *Stream) UpdateSettings(
+	ctx context.Context, source SettingsSource,
+	settings map[string]interface{},
+) error {
+	if settings == nil {
+		settings = map[string]interface{}{}
+	}
+	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype:        "update_settings",
+		SettingsSource: string(source),
+		Settings:       &settings,
+	})
+	return err
+}
+
 // StopTask asks the CLI to stop a running task.
 func (s *Stream) StopTask(ctx context.Context, taskID string) error {
 	_, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{

--- a/client_file_plugin_control_test.go
+++ b/client_file_plugin_control_test.go
@@ -471,6 +471,37 @@ func TestStreamApplyFlagSettingsNil(t *testing.T) {
 	)
 }
 
+func TestStreamUpdateSettingsWritesSourceAndSettings(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.UpdateSettings(ctx, SettingsSourceLocal,
+			map[string]interface{}{"outputStyle": "explanatory"})
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"update_settings","source":"localSettings","settings":{"outputStyle":"explanatory"}}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+// TestStreamUpdateSettingsNil sends an empty settings object rather than
+// omitting the key, matching ApplyFlagSettings; source is always present.
+func TestStreamUpdateSettingsNil(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		return stream.UpdateSettings(ctx, SettingsSourceLocal, nil)
+	})
+	require.NoError(t, err)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"update_settings","source":"localSettings","settings":{}}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
 // TestStreamApplyFlagSettingsNullValue asserts that a nil interface{} value for
 // a top-level key marshals to JSON null on the wire - the v0.3.150 contract
 // for clearing a key from the flag layer.

--- a/integration_test.go
+++ b/integration_test.go
@@ -1913,6 +1913,51 @@ func TestIntegrationStreamFileAndRuntime(t *testing.T) {
 		}))
 	})
 
+	t.Run("update_settings", func(t *testing.T) {
+		// The update_settings control subtype lands in Claude Code 2.1.261;
+		// older binaries reject it as an unsupported subtype.
+		skipIfCLIOlderThan(t, "2.1.261")
+
+		// Own cwd so the write target is known and readable. outputStyle is
+		// the only key the CLI writes today; assert it lands on disk rather
+		// than trusting a bare no-error, which would pass even if the write
+		// path silently drifted.
+		tempDir := t.TempDir()
+		opts := append(isolatedClientOptions(t),
+			WithCwd(tempDir),
+			WithSystemPrompt("You are a helpful assistant."),
+		)
+		client, err := NewClient(opts...)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		stream, err := client.Stream(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, stream.Close()) })
+
+		require.NoError(t, stream.UpdateSettings(ctx, SettingsSourceLocal,
+			map[string]interface{}{"outputStyle": "explanatory"}))
+
+		// The CLI writes local settings under the cwd's .claude dir. Find the
+		// file it touched and confirm our value is in it.
+		var wrote bool
+		_ = filepath.Walk(tempDir, func(p string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() || !strings.HasSuffix(p, ".json") {
+				return nil
+			}
+			if b, rerr := os.ReadFile(p); rerr == nil &&
+				strings.Contains(string(b), "explanatory") {
+				wrote = true
+			}
+			return nil
+		})
+		assert.True(t, wrote,
+			"update_settings did not persist outputStyle under %s", tempDir)
+	})
+
 	t.Run("submit_feedback", func(t *testing.T) {
 		stream, _ := newFileStream(t)
 

--- a/messages.go
+++ b/messages.go
@@ -705,7 +705,8 @@ type SDKControlRequestBody struct {
 	MaxBytes          *int                        `json:"max_bytes,omitempty"`           // For read_file
 	Encoding          string                      `json:"encoding,omitempty"`            // For read_file ("utf-8"|"base64")
 	MTime             *int64                      `json:"mtime,omitempty"`               // For seed_read_state
-	Settings          *map[string]interface{}     `json:"settings,omitempty"`            // For apply_flag_settings
+	Settings          *map[string]interface{}     `json:"settings,omitempty"`            // For apply_flag_settings/update_settings
+	SettingsSource    string                      `json:"source,omitempty"`              // For update_settings
 	Description       string                      `json:"description,omitempty"`         // For submit_feedback
 	Surface           string                      `json:"surface,omitempty"`             // For submit_feedback
 	TaskID            string                      `json:"task_id,omitempty"`             // For stop_task


### PR DESCRIPTION
PR-04 of the v0.3.263 catchup. Adds the `update_settings` control request (sdk.d.ts L4473, `updateSettings` client method L2708).

`ApplyFlagSettings` merges into the in-memory flag layer and vanishes when the session ends. A host application driving the SDK that wants a setting to survive needs it written to disk — where `/config`'s writes land. `update_settings` persists the merge to a named settings file.

## Shape

- `Stream.UpdateSettings(ctx, source, settings)`.
- Wire: `{subtype:"update_settings", source, settings}` on the control request (confirmed against `sdk.mjs`).
- `source` is a single-member union upstream (`'localSettings'`), modelled as a named `SettingsSource` type with `SettingsSourceLocal` so widening it stays additive.

## CLI contract (documented on the method)

Enforced CLI-side, surfaced as an error response: `outputStyle` is the only writable key today, values must be strings, deletion is unsupported, and it refuses remote transports and any session whose `--setting-sources` excludes the target.

## Tests

- Unit: source + settings wire shape, and the empty-map (nil) call sending `settings:{}` with `source` still present (`client_file_plugin_control_test.go`).
- Integration: `update_settings` subtest under `TestIntegrationStreamFileAndRuntime` writes `outputStyle` and reads it back off disk to prove the write landed. Guarded with `skipIfCLIOlderThan("2.1.261")` — the subtype lands in Claude Code 2.1.261 and the CI/local binary (2.1.222) rejects it as unsupported. Skips cleanly today; runs once the runner updates.