### PR TITLE
client: add reload_output_styles control request

### DIFF
--- a/client.go
+++ b/client.go
@@ -1171,6 +1171,32 @@ func (s *Stream) ReloadSkills(
 	return &out, nil
 }
 
+// ReloadOutputStyles asks the running CLI to rescan its output-style
+// directories and returns the refreshed names, built-in and custom.
+//
+// The reload also drops the shared markdown-file scan cache, so agents, skills
+// and routines re-read their directories on next use — a wider effect than the
+// name suggests. Only available in streaming input mode.
+func (s *Stream) ReloadOutputStyles(
+	ctx context.Context,
+) (*SDKControlReloadOutputStylesResponse, error) {
+	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
+		Subtype: "reload_output_styles",
+	})
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := json.Marshal(resp.Response.Response)
+	if err != nil {
+		return nil, fmt.Errorf("reload_output_styles: marshal: %w", err)
+	}
+	var out SDKControlReloadOutputStylesResponse
+	if err := json.Unmarshal(bytes, &out); err != nil {
+		return nil, fmt.Errorf("reload_output_styles: unmarshal: %w", err)
+	}
+	return &out, nil
+}
+
 // ApplyFlagSettings merges the provided settings into the flag settings layer,
 // updating the active configuration. Top-level keys are shallow-merged by the
 // CLI across successive calls and fall back to lower-precedence sources when

--- a/client_file_plugin_control_test.go
+++ b/client_file_plugin_control_test.go
@@ -440,6 +440,44 @@ func TestStreamReloadSkillsCancelledContext(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+func TestStreamReloadOutputStylesRoundTrip(t *testing.T) {
+	stream, transport, _ := newStreamControlTest(
+		successSDKControlResponseWithPayload(map[string]interface{}{
+			"available_output_styles": []interface{}{
+				"default", "explanatory", "learning", "my-custom",
+			},
+		}),
+	)
+
+	var got *SDKControlReloadOutputStylesResponse
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		var err error
+		got, err = stream.ReloadOutputStyles(ctx)
+		return err
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t,
+		[]string{"default", "explanatory", "learning", "my-custom"},
+		got.AvailableOutputStyles)
+
+	assert.JSONEq(t,
+		`{"type":"control_request","request_id":"req_1","request":{"subtype":"reload_output_styles"}}`,
+		rawWrittenSDKControlRequest(t, transport),
+	)
+}
+
+func TestStreamReloadOutputStylesErrorResponse(t *testing.T) {
+	stream, _, _ := newStreamControlTest(controlErrorResponse("reload output styles failed"))
+
+	err := callWithTimeout(t, func(ctx context.Context) error {
+		_, err := stream.ReloadOutputStyles(ctx)
+		return err
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reload output styles failed")
+}
+
 func TestStreamApplyFlagSettingsNonEmpty(t *testing.T) {
 	stream, transport, _ := newStreamControlTest(successSDKControlResponse)
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -1913,6 +1913,24 @@ func TestIntegrationStreamFileAndRuntime(t *testing.T) {
 		}))
 	})
 
+	t.Run("reload_output_styles", func(t *testing.T) {
+		// The reload_output_styles control subtype lands in Claude Code
+		// 2.1.261; older binaries reject it as an unsupported subtype.
+		skipIfCLIOlderThan(t, "2.1.261")
+
+		stream, _ := newFileStream(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		resp, err := stream.ReloadOutputStyles(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		// Built-ins are always present, so the refreshed list is never empty.
+		assert.NotEmpty(t, resp.AvailableOutputStyles,
+			"reload must return at least the built-in output styles")
+	})
+
 	t.Run("submit_feedback", func(t *testing.T) {
 		stream, _ := newFileStream(t)
 

--- a/query_types.go
+++ b/query_types.go
@@ -170,6 +170,12 @@ type SDKControlReloadSkillsResponse struct {
 	Skills []SlashCommand `json:"skills"`
 }
 
+// SDKControlReloadOutputStylesResponse reports the output style names after a
+// reload — built-in and custom, in the order the initialize response lists them.
+type SDKControlReloadOutputStylesResponse struct {
+	AvailableOutputStyles []string `json:"available_output_styles"`
+}
+
 // PluginInfo describes a plugin loaded by the CLI.
 type PluginInfo struct {
 	Name string `json:"name"`


### PR DESCRIPTION
PR-05 of the v0.3.263 catchup. Adds the `reload_output_styles` control request (sdk.d.ts L4287, response L4294; `reloadOutputStyles` client method L2835).

A host application that edits output-style files on disk had no way to make the running CLI pick them up. `reload_output_styles` rescans the directories and returns the refreshed names — built-in and custom, in the order the initialize response lists them.

## Shape

- `Stream.ReloadOutputStyles(ctx) (*SDKControlReloadOutputStylesResponse, error)`, mirroring `ReloadSkills`.
- Request `{subtype:"reload_output_styles"}`; response `{available_output_styles: string[]}` (confirmed against `sdk.mjs`).

## Note

The reload also drops the shared markdown-file scan cache, so agents, skills and routines re-read their directories on next use — a wider effect than the name suggests. Documented on the method.

## Tests

- Unit: round-trip parsing of `available_output_styles` and the exact request wire shape, plus an error-response path (`client_file_plugin_control_test.go`).
- Integration: `reload_output_styles` subtest under `TestIntegrationStreamFileAndRuntime` asserts the refreshed list is non-empty (built-ins always present). Guarded with `skipIfCLIOlderThan("2.1.261")` — the subtype lands in Claude Code 2.1.261; the current runner (2.1.222) rejects it. Skips cleanly today.