### PR TITLE
client: add options to get_context_usage and get_usage

### DIFF
--- a/client.go
+++ b/client.go
@@ -1432,12 +1432,37 @@ func (s *Stream) AccountInfo(ctx context.Context) (*AccountInfo, error) {
 	return &account, nil
 }
 
+// ContextUsageDetail selects how GetContextUsage computes its answer.
+type ContextUsageDetail string
+
+const (
+	// ContextUsageDetailFull counts each category with the token-count API.
+	// This is the CLI's default when the field is omitted.
+	ContextUsageDetailFull ContextUsageDetail = "full"
+
+	// ContextUsageDetailSummary answers from the last response's usage and
+	// local estimates, skipping the per-category token-count API calls.
+	ContextUsageDetailSummary ContextUsageDetail = "summary"
+)
+
+// GetContextUsageOptions configures Stream.GetContextUsage.
+type GetContextUsageOptions struct {
+	// Detail selects the accounting method. The empty value defers to the
+	// CLI's default (full).
+	Detail ContextUsageDetail
+}
+
 // GetContextUsage fetches the current context usage from the CLI.
 func (s *Stream) GetContextUsage(
-	ctx context.Context,
+	ctx context.Context, opts ...GetContextUsageOptions,
 ) (*SDKControlGetContextUsageResponse, error) {
+	var o GetContextUsageOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
 	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
 		Subtype: "get_context_usage",
+		Detail:  string(o.Detail),
 	})
 	if err != nil {
 		return nil, err
@@ -1453,6 +1478,15 @@ func (s *Stream) GetContextUsage(
 	return &out, nil
 }
 
+// GetUsageOptions configures Stream.GetUsageExperimental.
+type GetUsageOptions struct {
+	// SkipBehaviors drops the transcript scan that fills the response's
+	// Behaviors section, which comes back null. The scan reads every
+	// transcript touched in the last seven days, so a caller that needs only
+	// the plan rate limits (a usage meter, say) can set this to avoid it.
+	SkipBehaviors bool
+}
+
 // GetUsageExperimental fetches the structured data behind the `/usage`
 // command: session cost/usage totals plus claude.ai plan rate-limit
 // utilization windows (5-hour, 7-day, per-model) when available.
@@ -1462,11 +1496,19 @@ func (s *Stream) GetContextUsage(
 // EXPERIMENTAL: this control request is unstable upstream and may change or
 // be removed in any release without notice — do not rely on it yet. The
 // method name will change when the API stabilizes.
+//
+// Pass a GetUsageOptions with SkipBehaviors set to drop the transcript scan
+// when only the plan rate limits are needed.
 func (s *Stream) GetUsageExperimental(
-	ctx context.Context,
+	ctx context.Context, opts ...GetUsageOptions,
 ) (*SDKControlGetUsageResponse, error) {
+	var o GetUsageOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
 	resp, err := s.sendSDKControlRequest(ctx, SDKControlRequestBody{
-		Subtype: "get_usage",
+		Subtype:       "get_usage",
+		SkipBehaviors: o.SkipBehaviors,
 	})
 	if err != nil {
 		return nil, err

--- a/client_introspection_test.go
+++ b/client_introspection_test.go
@@ -575,3 +575,71 @@ func TestAccountInfoAPIProviderGatewayUnmarshal(t *testing.T) {
 	assert.Equal(t, APIProviderGateway, acct.APIProvider)
 	assert.Equal(t, "oauth", acct.APIKeySource)
 }
+
+func TestStreamGetContextUsageDetailWireShape(t *testing.T) {
+	t.Run("summary sends detail", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			_, err := stream.GetContextUsage(ctx, GetContextUsageOptions{
+				Detail: ContextUsageDetailSummary,
+			})
+			return err
+		})
+		require.NoError(t, err)
+
+		assert.JSONEq(t,
+			`{"type":"control_request","request_id":"req_1","request":{"subtype":"get_context_usage","detail":"summary"}}`,
+			rawWrittenSDKControlRequest(t, transport),
+		)
+	})
+
+	t.Run("no opts omits detail", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			_, err := stream.GetContextUsage(ctx)
+			return err
+		})
+		require.NoError(t, err)
+
+		assert.JSONEq(t,
+			`{"type":"control_request","request_id":"req_1","request":{"subtype":"get_context_usage"}}`,
+			rawWrittenSDKControlRequest(t, transport),
+		)
+	})
+}
+
+func TestStreamGetUsageSkipBehaviorsWireShape(t *testing.T) {
+	t.Run("skip_behaviors true is sent", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			_, err := stream.GetUsageExperimental(ctx, GetUsageOptions{
+				SkipBehaviors: true,
+			})
+			return err
+		})
+		require.NoError(t, err)
+
+		assert.JSONEq(t,
+			`{"type":"control_request","request_id":"req_1","request":{"subtype":"get_usage","skip_behaviors":true}}`,
+			rawWrittenSDKControlRequest(t, transport),
+		)
+	})
+
+	t.Run("false omits the key", func(t *testing.T) {
+		stream, transport, _ := newStreamControlTest(successSDKControlResponse)
+
+		err := callWithTimeout(t, func(ctx context.Context) error {
+			_, err := stream.GetUsageExperimental(ctx)
+			return err
+		})
+		require.NoError(t, err)
+
+		assert.JSONEq(t,
+			`{"type":"control_request","request_id":"req_1","request":{"subtype":"get_usage"}}`,
+			rawWrittenSDKControlRequest(t, transport),
+		)
+	})
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -2472,6 +2472,60 @@ func TestIntegrationGetUsageExperimental(t *testing.T) {
 	t.Skip("get_usage is EXPERIMENTAL upstream (unstable wire shape) and its response is account-dependent — rate_limits/behaviors are null for non-claude.ai-subscriber sessions and the installed CLI may not support the subtype; a live assertion would be brittle. Mirrors GetContextUsage, which ships without an integration test. Tracked in INTEGRATION-FOLLOWUPS.md")
 }
 
+// TestIntegrationGetContextUsageDetail exercises the detail option on the
+// get_context_usage control request. detail=summary answers from the last
+// response's usage and local estimates, skipping the per-category token-count
+// API calls. An older CLI that predates the option ignores the extra field and
+// still returns a usage payload, so the assertion only requires a non-empty
+// answer.
+func TestIntegrationGetContextUsageDetail(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithMaxTurns(1),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	stream, err := client.Stream(ctx)
+	require.NoError(t, err)
+	defer stream.Close()
+
+	// Prime the session so there is a prior response for summary to read from.
+	require.NoError(t, stream.Send(ctx, "Say hi."))
+	for msg := range stream.Messages() {
+		if _, ok := msg.(ResultMessage); ok {
+			break
+		}
+	}
+
+	usage, err := stream.GetContextUsage(ctx, GetContextUsageOptions{
+		Detail: ContextUsageDetailSummary,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Positive(t, usage.TotalTokens,
+		"summary detail should still report a token total")
+}
+
+// TestIntegrationGetUsageSkipBehaviors would exercise skip_behaviors on
+// get_usage, but the base request is EXPERIMENTAL upstream with an
+// account-dependent, brittle response (see TestIntegrationGetUsageExperimental),
+// and the installed CLI may not support the subtype. Skipped for the same
+// reason; the wire shape of the option is covered by the unit test.
+func TestIntegrationGetUsageSkipBehaviors(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+	t.Skip("get_usage is EXPERIMENTAL and account-dependent; skip_behaviors " +
+		"wire shape covered by unit test. Tracked in INTEGRATION-FOLLOWUPS.md")
+}
+
 // TestIntegrationSetMcpPermissionModeOverride exercises the
 // set_mcp_permission_mode_override control request against the live CLI. The
 // override targets an unknown server name, which a supporting CLI answers with

--- a/messages.go
+++ b/messages.go
@@ -716,6 +716,8 @@ type SDKControlRequestBody struct {
 	Enabled           *bool                       `json:"enabled,omitempty"`             // For mcp_toggle (pointer so explicit false serializes)
 	Servers           *map[string]MCPServerConfig `json:"servers,omitempty"`             // For mcp_set_servers (pointer so nil/empty round-trips as {})
 	Message           map[string]interface{}      `json:"message,omitempty"`             // For mcp_message (JSONRPC)
+	Detail            string                      `json:"detail,omitempty"`              // For get_context_usage ("summary"|"full")
+	SkipBehaviors     bool                        `json:"skip_behaviors,omitempty"`      // For get_usage
 }
 
 // SDKHookCallbackMatcher defines hook callback matching configuration.


### PR DESCRIPTION
PR-06 of the v0.3.263 catchup. Adds two independent options to existing control requests, grouped because the edit shape is identical (sdk.d.ts L3627 `detail`, get_usage `skip_behaviors`).

Both methods take an options struct via a variadic parameter, so existing no-arg callers keep compiling.

## get_context_usage — `detail`

`ContextUsageDetail` (`full`|`summary`). `summary` answers from the last response's usage and local estimates, skipping the per-category token-count API calls; `full` is the CLI default when the field is omitted. Empty value defers to the CLI.

## get_usage — `skip_behaviors`

`GetUsageOptions.SkipBehaviors` nulls the response's `behaviors` section. The scan that fills it reads every transcript touched in the last seven days, so a caller that needs only the plan rate limits (a usage meter) can drop it. Sent only when true (matches `sdk.mjs`, which spreads `skip_behaviors:!0` conditionally).

## Tests

- Unit: wire-shape assertions for both — `detail:"summary"` present / omitted when unset, `skip_behaviors:true` present / omitted when false (`client_introspection_test.go`).
- Integration: `TestIntegrationGetContextUsageDetail` runs `detail=summary` against the live CLI and asserts a token total comes back (passes, 3.9s; the 2.1.222 runner ignores the unknown field and still answers). `TestIntegrationGetUsageSkipBehaviors` is a documented skip — `get_usage` is EXPERIMENTAL and account-dependent (mirrors the existing `TestIntegrationGetUsageExperimental` skip); the option's wire shape is unit-covered.