### PR TITLE
options: settings parity with TypeScript SDK v0.3.263

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ stdin/stdout, giving you access to Claude's tool use, extended thinking,
 session management, and hook system.
 
 This repository tracks the official TypeScript Agent SDK surface through the
-v0.3.241 catchup work, using Go idioms where the API shape differs.
+v0.3.263 catchup work, using Go idioms where the API shape differs.
 
 ```mermaid
 flowchart TB
@@ -767,6 +767,96 @@ Deferred in v0.3.241:
   `SDKControlGetPlanRequest` / `SDKControlGetWorkspaceDiffRequest` were deleted
   outright (gone from `sdk.mjs` too). The Go SDK never modeled either surface, so
   both removals are no-ops here.
+
+The v0.3.251 catchup added:
+
+- `PreModelSwitch` / `PostModelSwitch` hooks — the first new hook pair since
+  `DirectoryAdded`, and the first hook input to carry prompt-cache economics.
+  Only `PreModelSwitch` is vetoable, which is why `source` differs between them:
+  the post phase adds `auto` and `resume`, switches the CLI initiates itself and
+  so never offers for approval.
+- Per-server `timeout` on SDK MCP servers, in milliseconds. Values under 1000ms
+  are ignored, and changing it on an already-registered server does nothing
+  until the server is removed and re-added.
+- `ModelUsage.CostBasis` (plus `CanonicalModel` and `Provider`, which predate it
+  and were never modeled) — which price table the most recent request was priced
+  at. Empty until this process has priced a request for the model, which a
+  `--resume` makes common; read that as list pricing.
+- `PerTaskStopAffordance` on the initialize request.
+- `UserMessageUUID` on every first reply frame, plus `QueuedTurnCount` on
+  results so a host draining a send queue can tell "this run is done" from "more
+  is inbound".
+- The `Ambient` marker on task frames, which covers every `SkipTranscript` task
+  and more.
+- `DefaultToNo` on permission asks.
+- SessionStart resume-cost fields, so a host can price a resume before
+  committing to it.
+- Settings: `PromptCacheTTL`, `SubagentPromptCacheTTL`,
+  `DesktopSessionCleanupPeriodDays`, `SyncClaudeAiPlugins`,
+  `ManagedSourcesBehavior`, `SpinnerTipsOverride`, plus the model picker and
+  contracted-rate pricing.
+
+PRs in this cycle (squash-merged): #218 model-switch hooks, #219 SDK MCP
+per-server timeout, #220 pricing provenance, #221 `perTaskStopAffordance`,
+#222 `user_message_uuid`, #223 queued-turn count, #224 ambient marker,
+#225 `default_to_no`, #226 SessionStart resume pricing, #228 Settings parity,
+#229 model picker and pricing.
+
+The v0.3.263 catchup added:
+
+- Plugin delivery over the initialize request. `pluginDelivery: 'initialize'`
+  moves the plugin list off the command line and into the initialize payload,
+  because Windows refuses a command line past 32,767 characters and one
+  `--plugin-dir` per plugin blows through it. `'argv'` remains the Go default:
+  `initialize` needs Claude Code 2.1.261+, and an older binary exits at startup
+  on the unknown `--await-initialize` option rather than degrading.
+- `PermissionPrompts` — lets a session declare it has no approval surface.
+- System prompt `snapshot`, a genuine tri-state: omitted records a bare preset,
+  `false` never records. Plus sending a preset system prompt's `append`.
+- `update_settings` and `reload_output_styles` control requests — the first new
+  control subtypes since `get_settings` — and options on `get_context_usage` and
+  `get_usage`.
+- `SDKMcpResourceLink` and `ResourceLinks` on task notifications. A backgrounded
+  MCP task's `tool_result` is placeholder text and its real result arrives as the
+  notification, so this is the only place a host learns which files the call
+  produced.
+- `UserMessageUUIDs` on reply, result and thinking frames. `UserMessageUUID`
+  alone turned out to be insufficient: when the host merges several
+  close-together sends into one turn it names only the last member, leaving
+  every other sender unable to recognize the reply. The result list can be
+  strictly longer than the reply list, because queued messages fold into a
+  running turn between tool rounds.
+- The first-frame result timings — `FirstContentFrameMs`, `FirstStreamPostMs`,
+  `FirstStreamPostAckMs`, `FirstStreamPostWallMs`. Success results only.
+- `NoResponse` on `api_retry`. Its presence, not its durations, is the point:
+  for a first-byte timeout `MaxRetries` is that cause's own cap — normally a
+  single retry — rather than the session's retry budget.
+- `ModelUsage.ThinkingTokens`, already counted inside `OutputTokens` so summing
+  the two double-counts. It tallies only turns run on a CLI recording the field,
+  which makes it partial for a session resumed across versions and unsafe as a
+  denominator.
+- Settings: `Permissions.BlockReadsOutsideWorkingDirectories` (nested in the
+  permissions block), `ManagedMCPServers`, `BashOutputMaxChars`,
+  `TaskOutputMaxChars`, `TimeFormat` and `TimeZone`. `TimeFormat` is an open
+  string type rather than an enum because upstream unions the four presets with
+  any strftime pattern containing `%`.
+
+PRs in this cycle (squash-merged): #231/#232 plugin delivery, #233
+`permissionPrompts`, #234/#235 system prompt append and snapshot, #236
+`update_settings`, #237 `reload_output_styles`, #238 control-request options,
+#239 `resource_links`, #240 `user_message_uuids`, #241 first-frame timings,
+#242 `no_response`, #243 `thinkingTokens`, #244 Settings parity, plus this docs
+refresh.
+
+Deferred in v0.3.251 and v0.3.263:
+
+- `bridge.d.ts` `onSetModel` (`notices` and a `Promise` return) — no Go bridge
+  transport exists. Deferred every cycle since v0.3.233.
+- `sdk-tools.d.ts` schema churn — the standing deferral since v0.3.207.
+- The `spinnerTipsOverride.tips` union element — breaking, outbound-only, and
+  with no decode consumer to justify it.
+- The prompt word-editing keys setting, which upstream now documents as having
+  no effect. The Go field stays: removing it is a breaking change for no gain.
 
 Some areas remain intentionally limited by the CLI or integration harness:
 desktop/IDE-only settings are not modeled exhaustively, several runtime control

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ stdin/stdout, giving you access to Claude's tool use, extended thinking,
 session management, and hook system.
 
 This repository tracks the official TypeScript Agent SDK surface through the
-v0.3.263 catchup work, using Go idioms where the API shape differs.
+v0.3.241 catchup work, using Go idioms where the API shape differs.
 
 ```mermaid
 flowchart TB
@@ -767,96 +767,6 @@ Deferred in v0.3.241:
   `SDKControlGetPlanRequest` / `SDKControlGetWorkspaceDiffRequest` were deleted
   outright (gone from `sdk.mjs` too). The Go SDK never modeled either surface, so
   both removals are no-ops here.
-
-The v0.3.251 catchup added:
-
-- `PreModelSwitch` / `PostModelSwitch` hooks — the first new hook pair since
-  `DirectoryAdded`, and the first hook input to carry prompt-cache economics.
-  Only `PreModelSwitch` is vetoable, which is why `source` differs between them:
-  the post phase adds `auto` and `resume`, switches the CLI initiates itself and
-  so never offers for approval.
-- Per-server `timeout` on SDK MCP servers, in milliseconds. Values under 1000ms
-  are ignored, and changing it on an already-registered server does nothing
-  until the server is removed and re-added.
-- `ModelUsage.CostBasis` (plus `CanonicalModel` and `Provider`, which predate it
-  and were never modeled) — which price table the most recent request was priced
-  at. Empty until this process has priced a request for the model, which a
-  `--resume` makes common; read that as list pricing.
-- `PerTaskStopAffordance` on the initialize request.
-- `UserMessageUUID` on every first reply frame, plus `QueuedTurnCount` on
-  results so a host draining a send queue can tell "this run is done" from "more
-  is inbound".
-- The `Ambient` marker on task frames, which covers every `SkipTranscript` task
-  and more.
-- `DefaultToNo` on permission asks.
-- SessionStart resume-cost fields, so a host can price a resume before
-  committing to it.
-- Settings: `PromptCacheTTL`, `SubagentPromptCacheTTL`,
-  `DesktopSessionCleanupPeriodDays`, `SyncClaudeAiPlugins`,
-  `ManagedSourcesBehavior`, `SpinnerTipsOverride`, plus the model picker and
-  contracted-rate pricing.
-
-PRs in this cycle (squash-merged): #218 model-switch hooks, #219 SDK MCP
-per-server timeout, #220 pricing provenance, #221 `perTaskStopAffordance`,
-#222 `user_message_uuid`, #223 queued-turn count, #224 ambient marker,
-#225 `default_to_no`, #226 SessionStart resume pricing, #228 Settings parity,
-#229 model picker and pricing.
-
-The v0.3.263 catchup added:
-
-- Plugin delivery over the initialize request. `pluginDelivery: 'initialize'`
-  moves the plugin list off the command line and into the initialize payload,
-  because Windows refuses a command line past 32,767 characters and one
-  `--plugin-dir` per plugin blows through it. `'argv'` remains the Go default:
-  `initialize` needs Claude Code 2.1.261+, and an older binary exits at startup
-  on the unknown `--await-initialize` option rather than degrading.
-- `PermissionPrompts` — lets a session declare it has no approval surface.
-- System prompt `snapshot`, a genuine tri-state: omitted records a bare preset,
-  `false` never records. Plus sending a preset system prompt's `append`.
-- `update_settings` and `reload_output_styles` control requests — the first new
-  control subtypes since `get_settings` — and options on `get_context_usage` and
-  `get_usage`.
-- `SDKMcpResourceLink` and `ResourceLinks` on task notifications. A backgrounded
-  MCP task's `tool_result` is placeholder text and its real result arrives as the
-  notification, so this is the only place a host learns which files the call
-  produced.
-- `UserMessageUUIDs` on reply, result and thinking frames. `UserMessageUUID`
-  alone turned out to be insufficient: when the host merges several
-  close-together sends into one turn it names only the last member, leaving
-  every other sender unable to recognize the reply. The result list can be
-  strictly longer than the reply list, because queued messages fold into a
-  running turn between tool rounds.
-- The first-frame result timings — `FirstContentFrameMs`, `FirstStreamPostMs`,
-  `FirstStreamPostAckMs`, `FirstStreamPostWallMs`. Success results only.
-- `NoResponse` on `api_retry`. Its presence, not its durations, is the point:
-  for a first-byte timeout `MaxRetries` is that cause's own cap — normally a
-  single retry — rather than the session's retry budget.
-- `ModelUsage.ThinkingTokens`, already counted inside `OutputTokens` so summing
-  the two double-counts. It tallies only turns run on a CLI recording the field,
-  which makes it partial for a session resumed across versions and unsafe as a
-  denominator.
-- Settings: `Permissions.BlockReadsOutsideWorkingDirectories` (nested in the
-  permissions block), `ManagedMCPServers`, `BashOutputMaxChars`,
-  `TaskOutputMaxChars`, `TimeFormat` and `TimeZone`. `TimeFormat` is an open
-  string type rather than an enum because upstream unions the four presets with
-  any strftime pattern containing `%`.
-
-PRs in this cycle (squash-merged): #231/#232 plugin delivery, #233
-`permissionPrompts`, #234/#235 system prompt append and snapshot, #236
-`update_settings`, #237 `reload_output_styles`, #238 control-request options,
-#239 `resource_links`, #240 `user_message_uuids`, #241 first-frame timings,
-#242 `no_response`, #243 `thinkingTokens`, #244 Settings parity, plus this docs
-refresh.
-
-Deferred in v0.3.251 and v0.3.263:
-
-- `bridge.d.ts` `onSetModel` (`notices` and a `Promise` return) — no Go bridge
-  transport exists. Deferred every cycle since v0.3.233.
-- `sdk-tools.d.ts` schema churn — the standing deferral since v0.3.207.
-- The `spinnerTipsOverride.tips` union element — breaking, outbound-only, and
-  with no decode consumer to justify it.
-- The prompt word-editing keys setting, which upstream now documents as having
-  no effect. The Go field stays: removing it is a breaking change for no gain.
 
 Some areas remain intentionally limited by the CLI or integration harness:
 desktop/IDE-only settings are not modeled exhaustively, several runtime control

--- a/integration_test.go
+++ b/integration_test.go
@@ -2393,6 +2393,106 @@ exec "$real_cli" "$@"
 		assert.Equal(t, "gateway", got.ForceLoginMethod)
 		assert.Equal(t, want.ForceLoginGatewayURL, got.ForceLoginGatewayURL)
 	})
+
+	// The v0.3.263 adds. These are consumed inside the CLI rather than echoed
+	// back to the SDK, so what is assertable is that they survive the managed
+	// tier intact — including the nesting of the permissions-block member,
+	// which is the placement easy to get wrong.
+	t.Run("v0_3_263_settings", func(t *testing.T) {
+		blockOutsideReads := true
+		bashChars := 64000
+		taskChars := 8000
+
+		want := Settings{
+			Permissions: &SettingsPermissions{
+				BlockReadsOutsideWorkingDirectories: &blockOutsideReads,
+			},
+			BashOutputMaxChars: &bashChars,
+			TaskOutputMaxChars: &taskChars,
+			TimeFormat:         SettingsTimeFormat24HourUTC,
+			TimeZone:           "Europe/Dublin",
+			ManagedMCPServers: map[string]map[string]interface{}{
+				"corp-docs": {
+					"type": "http",
+					"url":  "https://mcp.example.com/docs",
+				},
+			},
+		}
+
+		argv := runWithArgvCapture(t, WithManagedSettings(want))
+		var got Settings
+		require.NoError(t, json.Unmarshal([]byte(argValue(t, argv, "--managed-settings")), &got))
+
+		require.NotNil(t, got.Permissions)
+		require.NotNil(t, got.Permissions.BlockReadsOutsideWorkingDirectories)
+		assert.True(t, *got.Permissions.BlockReadsOutsideWorkingDirectories)
+
+		require.NotNil(t, got.BashOutputMaxChars)
+		assert.Equal(t, bashChars, *got.BashOutputMaxChars)
+		require.NotNil(t, got.TaskOutputMaxChars)
+		assert.Equal(t, taskChars, *got.TaskOutputMaxChars)
+
+		assert.Equal(t, SettingsTimeFormat24HourUTC, got.TimeFormat)
+		assert.Equal(t, "Europe/Dublin", got.TimeZone)
+
+		require.Contains(t, got.ManagedMCPServers, "corp-docs")
+		assert.Equal(t, "http", got.ManagedMCPServers["corp-docs"]["type"])
+	})
+
+	// A strftime pattern is why TimeFormat is an open string type rather than
+	// an enum, so the pattern has to survive the same path the presets do.
+	t.Run("v0_3_263_time_format_pattern", func(t *testing.T) {
+		want := Settings{TimeFormat: SettingsTimeFormat("%Y-%m-%d %H:%M")}
+
+		argv := runWithArgvCapture(t, WithManagedSettings(want))
+		var got Settings
+		require.NoError(t, json.Unmarshal([]byte(argValue(t, argv, "--managed-settings")), &got))
+
+		assert.Equal(t, want.TimeFormat, got.TimeFormat)
+	})
+}
+
+// TestIntegrationSettingsV0_3_263RealCLI checks the bare CLI actually starts on
+// the v0.3.263 settings rather than stalling the managed-settings handshake,
+// which is how an unrecognized nested member fails — it looks like a hang and
+// costs the full timeout rather than erroring.
+func TestIntegrationSettingsV0_3_263RealCLI(t *testing.T) {
+	skipIfNoToken(t)
+	skipIfNoCLI(t)
+
+	blockOutsideReads := true
+	bashChars := 64000
+	taskChars := 8000
+
+	opts := append(isolatedClientOptions(t),
+		WithSystemPrompt("You are a helpful assistant. Be very brief."),
+		WithMaxTurns(1),
+		WithManagedSettings(Settings{
+			Permissions: &SettingsPermissions{
+				BlockReadsOutsideWorkingDirectories: &blockOutsideReads,
+			},
+			BashOutputMaxChars: &bashChars,
+			TaskOutputMaxChars: &taskChars,
+			TimeFormat:         SettingsTimeFormat24HourUTC,
+			TimeZone:           "Europe/Dublin",
+		}),
+	)
+	client, err := NewClient(opts...)
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	var result *ResultMessage
+	for msg := range client.Query(ctx, "Say OK.") {
+		if m, ok := msg.(ResultMessage); ok {
+			result = &m
+			break
+		}
+	}
+	require.NotNil(t, result, "the CLI must start and complete a turn on these settings")
+	assert.False(t, result.IsError, "settings must not fault the run")
 }
 
 func TestIntegrationSettingsManagedOrgFields(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -477,6 +477,21 @@ type Settings struct {
 	DisableAllHooks            *bool                            `json:"disableAllHooks,omitempty"`
 	DisableSkillShellExecution *bool                            `json:"disableSkillShellExecution,omitempty"`
 	DefaultShell               string                           `json:"defaultShell,omitempty"`
+	// BashOutputMaxChars caps how many characters of a successful Bash or
+	// PowerShell command's output Claude receives inline (default 30000,
+	// clamped to 4000-128000). Output past the cap is written to a file and
+	// Claude receives a short preview plus the path. Setting this also
+	// replaces BASH_MAX_OUTPUT_LENGTH, which on its own only sizes the
+	// read-back window (sdk.d.ts v0.3.263 L6298).
+	BashOutputMaxChars *int `json:"bashOutputMaxChars,omitempty"`
+	// TaskOutputMaxChars caps how many characters of a background task's
+	// output the TaskOutput tool hands Claude inline (default 32000, same
+	// 4000-128000 clamp). Longer output is cut to its most recent
+	// characters plus the path of the full output file — except for a shell
+	// command still running, which returns its first characters instead.
+	// Setting this also replaces TASK_MAX_OUTPUT_LENGTH (sdk.d.ts v0.3.263
+	// L6302).
+	TaskOutputMaxChars *int `json:"taskOutputMaxChars,omitempty"`
 	// RespondToBashCommands controls whether Claude responds after an
 	// input-box ! bash command runs. Set to false to add the command output to
 	// context without a response. Default true. Mirrors sdk.d.ts v0.3.195 L5032.
@@ -620,20 +635,32 @@ type Settings struct {
 	// RequiredMinimumVersion prevents startup below the managed minimum version. Honored only from managed (policy) settings. Mirrors sdk.d.ts v0.3.168 L5488.
 	RequiredMinimumVersion string `json:"requiredMinimumVersion,omitempty"`
 	// RequiredMaximumVersion prevents startup above the managed maximum version. Honored only from managed (policy) settings. Mirrors sdk.d.ts v0.3.168 L5492.
-	RequiredMaximumVersion            string                  `json:"requiredMaximumVersion,omitempty"`
-	PlansDirectory                    string                  `json:"plansDirectory,omitempty"`
-	TUI                               string                  `json:"tui,omitempty"`
-	Voice                             *SettingsVoice          `json:"voice,omitempty"`
-	ChannelsEnabled                   *bool                   `json:"channelsEnabled,omitempty"`
-	AllowedChannelPlugins             []SettingsChannelPlugin `json:"allowedChannelPlugins,omitempty"`
-	PrefersReducedMotion              *bool                   `json:"prefersReducedMotion,omitempty"`
-	AutoMemoryEnabled                 *bool                   `json:"autoMemoryEnabled,omitempty"`
-	AutoMemoryDirectory               string                  `json:"autoMemoryDirectory,omitempty"`
-	AutoDreamEnabled                  *bool                   `json:"autoDreamEnabled,omitempty"`
-	ShowThinkingSummaries             *bool                   `json:"showThinkingSummaries,omitempty"`
-	SkipDangerousModePermissionPrompt *bool                   `json:"skipDangerousModePermissionPrompt,omitempty"`
-	DisableAutoMode                   string                  `json:"disableAutoMode,omitempty"`
-	SSHConfigs                        []SettingsSSHConfig     `json:"sshConfigs,omitempty"`
+	RequiredMaximumVersion string                  `json:"requiredMaximumVersion,omitempty"`
+	PlansDirectory         string                  `json:"plansDirectory,omitempty"`
+	TUI                    string                  `json:"tui,omitempty"`
+	Voice                  *SettingsVoice          `json:"voice,omitempty"`
+	ChannelsEnabled        *bool                   `json:"channelsEnabled,omitempty"`
+	AllowedChannelPlugins  []SettingsChannelPlugin `json:"allowedChannelPlugins,omitempty"`
+	PrefersReducedMotion   *bool                   `json:"prefersReducedMotion,omitempty"`
+	// TimeFormat is the clock format for times shown in the UI. It is a
+	// preset or a strftime pattern, not a closed enum: any value containing
+	// "%" is taken as a pattern (other unrecognized values read as
+	// TimeFormatAuto), so modelling it as an enum would make patterns
+	// unrepresentable. A pattern replaces the time everywhere and message
+	// timestamps then show only the pattern, so include %Y-%m-%d if the date
+	// matters (sdk.d.ts v0.3.263 L8076).
+	TimeFormat SettingsTimeFormat `json:"timeFormat,omitempty"`
+	// TimeZone is the IANA time zone for times shown in the UI, e.g. "UTC"
+	// or "Europe/Dublin". Defaults to the system time zone, which an
+	// unknown name also falls back to (sdk.d.ts v0.3.263 L8080).
+	TimeZone                          string              `json:"timeZone,omitempty"`
+	AutoMemoryEnabled                 *bool               `json:"autoMemoryEnabled,omitempty"`
+	AutoMemoryDirectory               string              `json:"autoMemoryDirectory,omitempty"`
+	AutoDreamEnabled                  *bool               `json:"autoDreamEnabled,omitempty"`
+	ShowThinkingSummaries             *bool               `json:"showThinkingSummaries,omitempty"`
+	SkipDangerousModePermissionPrompt *bool               `json:"skipDangerousModePermissionPrompt,omitempty"`
+	DisableAutoMode                   string              `json:"disableAutoMode,omitempty"`
+	SSHConfigs                        []SettingsSSHConfig `json:"sshConfigs,omitempty"`
 	// ClaudeMD is CLAUDE.md-style instructions injected as organization-managed memory. Honored only from managed / policy settings. Mirrors sdk.d.ts v0.3.150 L5343.
 	ClaudeMD           string   `json:"claudeMd,omitempty"`
 	ClaudeMDExcludes   []string `json:"claudeMdExcludes,omitempty"`
@@ -701,6 +728,20 @@ type Settings struct {
 	WorkflowKeywordTriggerEnabled *bool `json:"workflowKeywordTriggerEnabled,omitempty"`
 	// AllowAllClaudeAiMcps lets claude.ai cloud MCP connectors load alongside managed-mcp.json. Mirrors sdk.d.ts v0.3.150 L4411.
 	AllowAllClaudeAiMcps *bool `json:"allowAllClaudeAiMcps,omitempty"`
+	// ManagedMCPServers are MCP servers the organization provides to every
+	// user, keyed by server name, each value carrying the .mcp.json entry
+	// shape. Only "http" and "sse" servers are accepted: nothing that names
+	// a program to run, and no ${VAR} references. Honored from managed
+	// settings only — users cannot remove them, and unlike servers users add
+	// they need no AllowedMCPServers entry, though DeniedMCPServers still
+	// applies. Not read in Claude Desktop's Code tab on a third-party
+	// deployment or in Cowork sessions, where Claude Desktop supplies and
+	// locks the session's MCP servers itself.
+	//
+	// The value stays an untyped object because upstream types it that way;
+	// narrowing it here would reject entry shapes the CLI accepts
+	// (sdk.d.ts v0.3.263 L5991).
+	ManagedMCPServers map[string]map[string]interface{} `json:"managedMcpServers,omitempty"`
 	// ParentSettingsBehavior controls whether the SDK parent tier layers under the admin tier. Mirrors sdk.d.ts v0.3.150 L5019.
 	ParentSettingsBehavior string `json:"parentSettingsBehavior,omitempty"`
 	// ManagedSourcesBehavior controls how the managed settings sources
@@ -710,12 +751,15 @@ type Settings struct {
 	// fixed precedence: scalars take the highest source's value and arrays
 	// union.
 	//
-	// Three groups opt out of the union. The restriction allowlists
+	// Several groups opt out of the union. The restriction allowlists
 	// (fallbackModel, allowedMcpServers, availableModels,
 	// strictKnownMarketplaces, allowedChannelPlugins) are owned whole by the
-	// highest source that sets one, and the auth pins (forceLoginOrgUUID,
-	// forceLoginMethod, forceLoginGatewayUrl) come from the highest source
-	// only — merging either would let a lower source widen a restriction.
+	// highest source that sets one, as are sandbox.credentials.awsPairs and
+	// sandbox.ripgrep; the auth pins (forceLoginOrgUUID, forceLoginMethod,
+	// forceLoginGatewayUrl) come from the highest source only — merging any
+	// of these would let a lower source widen a restriction.
+	// ManagedMCPServers unions by server name, but a name set by two sources
+	// takes the higher source's entry whole rather than merging the two.
 	//
 	// Honored only from the highest-priority source present. Enable it only
 	// when every lower source is admin-controlled, since under "merge" they
@@ -806,13 +850,19 @@ type SettingsAttribution struct {
 }
 
 type SettingsPermissions struct {
-	Allow                        []string               `json:"allow,omitempty"`
-	Deny                         []string               `json:"deny,omitempty"`
-	Ask                          []string               `json:"ask,omitempty"`
-	DefaultMode                  PermissionMode         `json:"defaultMode,omitempty"`
-	DisableBypassPermissionsMode string                 `json:"disableBypassPermissionsMode,omitempty"`
-	AdditionalDirectories        []string               `json:"additionalDirectories,omitempty"`
-	Extra                        map[string]interface{} `json:"-"`
+	Allow                        []string       `json:"allow,omitempty"`
+	Deny                         []string       `json:"deny,omitempty"`
+	Ask                          []string       `json:"ask,omitempty"`
+	DefaultMode                  PermissionMode `json:"defaultMode,omitempty"`
+	DisableBypassPermissionsMode string         `json:"disableBypassPermissionsMode,omitempty"`
+	AdditionalDirectories        []string       `json:"additionalDirectories,omitempty"`
+	// BlockReadsOutsideWorkingDirectories refuses file-tool reads (Read,
+	// Grep, Glob, LSP) outside the working directories in every permission
+	// mode. True in any settings source wins, so a lower source cannot
+	// relax it. Also set when the user answers "block" to the one-time
+	// auto-mode prompt for such a read (sdk.d.ts v0.3.263 L5889).
+	BlockReadsOutsideWorkingDirectories *bool                  `json:"blockReadsOutsideWorkingDirectories,omitempty"`
+	Extra                               map[string]interface{} `json:"-"`
 }
 
 func (p SettingsPermissions) MarshalJSON() ([]byte, error) {
@@ -833,6 +883,19 @@ func (p SettingsPermissions) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(obj)
 }
+
+// SettingsTimeFormat is the clock format for UI times. Upstream types it as
+// the four presets unioned with plain string, so it is deliberately an open
+// string type: the constants below name the presets, but any strftime pattern
+// containing "%" is equally valid and a closed enum could not express one.
+type SettingsTimeFormat string
+
+const (
+	SettingsTimeFormatAuto      SettingsTimeFormat = "auto"
+	SettingsTimeFormat12Hour    SettingsTimeFormat = "12-hour"
+	SettingsTimeFormat24Hour    SettingsTimeFormat = "24-hour"
+	SettingsTimeFormat24HourUTC SettingsTimeFormat = "24-hour-utc"
+)
 
 type SettingsSkillOverride string
 

--- a/options.go
+++ b/options.go
@@ -645,7 +645,7 @@ type Settings struct {
 	// TimeFormat is the clock format for times shown in the UI. It is a
 	// preset or a strftime pattern, not a closed enum: any value containing
 	// "%" is taken as a pattern (other unrecognized values read as
-	// TimeFormatAuto), so modelling it as an enum would make patterns
+	// TimeFormatAuto), so modeling it as an enum would make patterns
 	// unrepresentable. A pattern replaces the time everywhere and message
 	// timestamps then show only the pattern, so include %Y-%m-%d if the date
 	// matters (sdk.d.ts v0.3.263 L8076).

--- a/options_test.go
+++ b/options_test.go
@@ -2392,3 +2392,85 @@ func TestSettingsModelPickerPricingOmitEmpty(t *testing.T) {
 	assert.NotContains(t, got, "modelPicker")
 	assert.NotContains(t, got, "modelPricing")
 }
+
+func TestSettingsParityV0_3_263(t *testing.T) {
+	blockOutsideReads := true
+	bashChars := 64000
+	taskChars := 8000
+
+	settings := Settings{
+		Permissions: &SettingsPermissions{
+			BlockReadsOutsideWorkingDirectories: &blockOutsideReads,
+		},
+		BashOutputMaxChars: &bashChars,
+		TaskOutputMaxChars: &taskChars,
+		TimeFormat:         SettingsTimeFormat24HourUTC,
+		TimeZone:           "Europe/Dublin",
+		ManagedMCPServers: map[string]map[string]interface{}{
+			"corp-docs": {
+				"type": "http",
+				"url":  "https://mcp.example.com/docs",
+			},
+		},
+	}
+
+	data, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	perms, ok := got["permissions"].(map[string]interface{})
+	require.True(t, ok)
+	// Nested in the permissions block, not top-level — the one placement
+	// this field is easy to get wrong.
+	assert.Equal(t, true, perms["blockReadsOutsideWorkingDirectories"])
+	assert.NotContains(t, got, "blockReadsOutsideWorkingDirectories")
+
+	assert.Equal(t, float64(64000), got["bashOutputMaxChars"])
+	assert.Equal(t, float64(8000), got["taskOutputMaxChars"])
+	assert.Equal(t, "24-hour-utc", got["timeFormat"])
+	assert.Equal(t, "Europe/Dublin", got["timeZone"])
+
+	servers, ok := got["managedMcpServers"].(map[string]interface{})
+	require.True(t, ok)
+	entry, ok := servers["corp-docs"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "http", entry["type"])
+
+	var back Settings
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, settings, back)
+}
+
+// TimeFormat is a union of four presets with plain string, so a strftime
+// pattern has to survive the round trip. A closed enum could not carry one.
+func TestSettingsTimeFormatAcceptsStrftimePattern(t *testing.T) {
+	data, err := json.Marshal(Settings{
+		TimeFormat: SettingsTimeFormat("%Y-%m-%d %H:%M"),
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"timeFormat": "%Y-%m-%d %H:%M"}`, string(data))
+
+	var back Settings
+	require.NoError(t, json.Unmarshal(data, &back))
+	assert.Equal(t, SettingsTimeFormat("%Y-%m-%d %H:%M"), back.TimeFormat)
+}
+
+func TestSettingsParityV0_3_263OmitEmpty(t *testing.T) {
+	data, err := json.Marshal(Settings{})
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	for _, key := range []string{
+		"bashOutputMaxChars",
+		"taskOutputMaxChars",
+		"timeFormat",
+		"timeZone",
+		"managedMcpServers",
+	} {
+		assert.NotContains(t, got, key)
+	}
+}


### PR DESCRIPTION
Six `Settings` adds from TS SDK v0.3.263. Most are ordinary scalars; three carry a trap worth commenting.

## The traps

**`blockReadsOutsideWorkingDirectories` nests in the permissions block** (sdk.d.ts L5889), not at the top level. Filed wrong it would decode silently into nothing and the test would still pass, so the unit test asserts both directions: present under `permissions`, absent at top level.

**`timeFormat` is a union, not an enum** (L8076): the four presets *or* any string containing `%`, read as a strftime pattern. Modelling it as a closed enum would make every pattern unrepresentable. It is a named open string type — `SettingsTimeFormat` — with the presets as constants, and both the unit test and the integration test round-trip an actual pattern rather than only the presets.

**`managedMcpServers` keeps an untyped object value** (L5991). Upstream types the entry as `Record<string, unknown>`; narrowing it to a Go struct here would reject entry shapes the CLI accepts, and this is an admin-controlled surface where being wrong is expensive.

The remaining three are straightforward: `bashOutputMaxChars` (L6298, default 30000), `taskOutputMaxChars` (L6302, default 32000), both clamped 4000–128000 by the CLI, and `timeZone` (L8080).

## Comment-only change

`managedSourcesBehavior`'s opt-out list grew upstream. `sandbox.credentials.awsPairs` and `sandbox.ripgrep` join the settings owned whole by the highest source, and `managedMcpServers` unions by server name — but a name set by two sources takes the higher source's entry whole rather than merging the two. Updated the comment on the field #228 added.

## Testing

Probed the bare CLI with all six through `--managed-settings` before writing any live assertion. This matters: an unrecognized nested member stalls the handshake rather than erroring, which presents as a hang and costs the full timeout. It started clean.

Both integration tests **pass rather than skip** — unusual for a settings PR:

- `TestIntegrationSettingsOptions/v0_3_263_settings` and `/v0_3_263_time_format_pattern` assert the values survive the managed tier intact through real argv capture.
- `TestIntegrationSettingsV0_3_263RealCLI` starts the actual CLI on these settings and drives a turn to completion, which is the assertion that would have caught a handshake stall.

Verified locally: `TestIntegrationSettingsOptions` 10.58s, `TestIntegrationSettingsV0_3_263RealCLI` 3.50s, both PASS.

Part of the v0.3.263 parity work (#230).